### PR TITLE
Fix packet decoding for cases of dropped connection and decoding of ping responses

### DIFF
--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -558,6 +558,10 @@ async fn receive_packet<'c, T: Read + Write>(
             .receive(&mut recv_buffer[writer.position..(writer.position + 1)])
             .await?;
         trace!("    Received data!");
+        if len == 0 {
+            trace!("Zero byte len packet received, dropping connection.");
+            return Err(NetworkError);
+        }
         i = i + len;
         if let Err(_e) = writer.insert_ref(len, &recv_buffer[writer.position..i]) {
             error!("Error occurred during write to buffer!");

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -590,6 +590,10 @@ async fn receive_packet<'c, T: Read + Write>(
     }
 
     loop {
+        if writer.position == target_len + rem_len_len {
+            trace!("Received packet with len: {}", (target_len + rem_len_len));
+            return Ok(target_len + rem_len_len);
+        }
         let len: usize = conn
             .receive(&mut recv_buffer[writer.position..writer.position + (target_len - i)])
             .await?;
@@ -599,10 +603,6 @@ async fn receive_packet<'c, T: Read + Write>(
         {
             error!("Error occurred during write to buffer!");
             return Err(BuffError);
-        }
-        if writer.position == target_len + rem_len_len {
-            trace!("Received packet with len: {}", (target_len + rem_len_len));
-            return Ok(target_len + rem_len_len);
         }
     }
 }


### PR DESCRIPTION
When the connection returned that it read zero bytes, the reading loop would stuck in an infinite loop as the TCP connection is dropped.

When I was receiving ping response packet, the reception of the payload would get stuck as it was expecting data that would never be sent.

Not sure if solution like this is the correct one, please let me know if it needs any modification!