### PR TITLE
Small improvements

### DIFF
--- a/src/client/raw_client.rs
+++ b/src/client/raw_client.rs
@@ -214,13 +214,8 @@ where
         let len = {
             let mut subs = SubscriptionPacket::<'b, TOPICS, MAX_PROPERTIES>::new();
             subs.packet_identifier = identifier;
-            let mut i = 0;
-            loop {
-                if i == TOPICS {
-                    break;
-                }
-                subs.add_new_filter(topic_names.get(i).unwrap(), self.config.max_subscribe_qos);
-                i += 1;
+            for topic_name in topic_names.iter() {
+                subs.add_new_filter(topic_name, self.config.max_subscribe_qos);
             }
             subs.encode(self.buffer, self.buffer_len)
         };

--- a/src/client/raw_client.rs
+++ b/src/client/raw_client.rs
@@ -387,18 +387,13 @@ where
                     return Err(ReasonCode::BuffError);
                 }
                 let (packet_identifier, reasons) = reason.unwrap();
-                let mut i = 0;
-                loop {
-                    if i == reasons.len() {
-                        break;
-                    }
-                    if *reasons.get(i).unwrap()
+                for reason_code in &reasons {
+                    if *reason_code
                         != (<QualityOfService as Into<u8>>::into(self.config.max_subscribe_qos)
                             >> 1)
                     {
-                        return Err(ReasonCode::from(*reasons.get(i).unwrap()));
+                        return Err(ReasonCode::from(*reason_code));
                     }
-                    i += 1;
                 }
                 Ok(Event::Suback(packet_identifier))
             }

--- a/src/packet/v5/mqtt_packet.rs
+++ b/src/packet/v5/mqtt_packet.rs
@@ -52,18 +52,11 @@ pub trait Packet<'a> {
         &mut self,
         properties: &Vec<Property<'a>, MAX_PROPERTIES>,
     ) -> u32 {
-        let mut i = 0;
-        let max = properties.len();
         let mut res: u32 = 0;
-        loop {
-            let prop = properties.get(i).unwrap();
+        for prop in properties.iter() {
             if self.property_allowed(prop) {
                 self.push_to_properties((*prop).clone());
                 res = res + prop.encoded_len() as u32 + 1;
-            }
-            i += 1;
-            if i == max {
-                break;
             }
         }
         res

--- a/src/packet/v5/mqtt_packet.rs
+++ b/src/packet/v5/mqtt_packet.rs
@@ -77,7 +77,7 @@ pub trait Packet<'a> {
     /// Method is decoding Byte array pointing to properties into heapless Vec
     /// in packet. If decoding goes wrong method is returning Error
     fn decode_properties(&mut self, buff_reader: &mut BuffReader<'a>) -> Result<(), BufferError> {
-        self.set_property_len(buff_reader.read_variable_byte_int().unwrap());
+        self.set_property_len(buff_reader.read_variable_byte_int()?);
         let mut x: u32 = 0;
         let mut prop: Property;
         if self.get_property_len() != 0 {

--- a/src/tests/unit/packet/v5/connack_packet_unit.rs
+++ b/src/tests/unit/packet/v5/connack_packet_unit.rs
@@ -68,7 +68,7 @@ fn test_decode() {
         0x15,
     ];
     let mut connack_res = ConnackPacket::<2>::new();
-    let res = connack_res.decode(&mut BuffReader::new(&mut buffer, 8));
+    let res = connack_res.decode(&mut BuffReader::new(&buffer, 8));
 
     assert!(res.is_ok());
     assert_eq!(connack_res.property_len, 3);

--- a/src/utils/buffer_writer.rs
+++ b/src/utils/buffer_writer.rs
@@ -85,22 +85,13 @@ impl<'a> BuffWriter<'a> {
         }
     }
 
-    /// Writes an array to the buffer.
+    /// Writes (part of) an array to the buffer.
     pub fn insert_ref(&mut self, len: usize, array: &[u8]) -> Result<(), BufferError> {
-        let mut x: usize = 0;
         if self.position + len > self.len {
             return Err(BufferError::InsufficientBufferSize);
         }
-        if len != 0 {
-            loop {
-                self.buffer[self.position] = array[x];
-                self.increment_position(1);
-                x += 1;
-                if x == len {
-                    break;
-                }
-            }
-        }
+        self.buffer[self.position..self.position+len].copy_from_slice(&array[0..len]);
+        self.increment_position(len);
         Ok(())
     }
 

--- a/src/utils/buffer_writer.rs
+++ b/src/utils/buffer_writer.rs
@@ -167,17 +167,8 @@ impl<'a> BuffWriter<'a> {
         &mut self,
         properties: &Vec<Property<'a>, LEN>,
     ) -> Result<(), BufferError> {
-        let mut i = 0;
-        let len = properties.len();
-        if len != 0 {
-            loop {
-                let prop: &Property = properties.get(i).unwrap_or(&Property::Reserved());
-                self.write_property(prop)?;
-                i += 1;
-                if i == len {
-                    break;
-                }
-            }
+        for prop in properties.iter() {
+            self.write_property(prop)?;
         }
         Ok(())
     }
@@ -204,14 +195,8 @@ impl<'a> BuffWriter<'a> {
         len: usize,
         filters: &Vec<TopicFilter<'a>, MAX>,
     ) -> Result<(), BufferError> {
-        let mut i = 0;
-        loop {
-            let topic_filter: &TopicFilter<'a> = filters.get(i).unwrap();
-            self.write_topic_filter_ref(sub, topic_filter)?;
-            i += 1;
-            if i == len {
-                break;
-            }
+        for filter in filters {
+            self.write_topic_filter_ref(sub, filter)?;
         }
         Ok(())
     }

--- a/tests/integration_test_single.rs
+++ b/tests/integration_test_single.rs
@@ -66,7 +66,7 @@ async fn publish_core<'b>(
     qos: QualityOfService,
     topic: &str,
     message: &str,
-    err: bool,
+    should_err: bool,
 ) -> Result<(), ReasonCode> {
     info!(
         "[Publisher] Connection to broker with username {} and password {}",
@@ -85,7 +85,7 @@ async fn publish_core<'b>(
         .send_message(topic, message.as_bytes(), qos, false)
         .await;
     info!("[PUBLISHER] sent");
-    if err == true {
+    if should_err {
         assert_err!(result);
     } else {
         assert_ok!(result);

--- a/tests/load_test.rs
+++ b/tests/load_test.rs
@@ -83,7 +83,7 @@ async fn publish_core<'b>(
             .await;
         info!("[PUBLISHER] sent {}", count);
         assert_ok!(result);
-        count = count + 1;
+        count += 1;
         if count == amount {
             break;
         }
@@ -150,7 +150,7 @@ async fn receive_core<'b>(
         let act_message = String::from_utf8_lossy(msg?.1);
         info!("[Receiver] Got new {}. message: {}", count, act_message);
         assert_eq!(act_message, MSG);
-        count = count + 1;
+        count += 1;
         if count == amount {
             break;
         }


### PR DESCRIPTION
I made some small improvements and simplifications which avoid a while bunch of panic branches.
Now there are a couple of functions that simply not use a `len` parameter (for which an invalid value would have led to a panic) but I do not know the API surface so I did not change it.
(`cargo build` will emit a warning)
I would advise reviewing all such length function parameters because they may be unnecessary and be provided by the data slices/vectors themselves.