### PR TITLE
Updated to work with the latest embadded-io-async from embassy 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rand_core = "0.6.0"
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
 embedded-io = { version = "0.4.0", features = ["async"]}
-embedded-io-async = { version = "0.5.0", features = ["defmt-03"]}
+embedded-io-async = { version = "0.6.0", features = ["defmt-03"]}
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rand_core = "0.6.0"
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
 embedded-io = { version = "0.4.0", features = ["async"]}
+embedded-io-async = { version = "0.5.0", features = ["defmt-03"]}
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -22,7 +22,8 @@
  * SOFTWARE.
  */
 
-use embedded_io::asynch::{Read, Write};
+//use embedded_io::asynch::{Read, Write};
+use embedded_io_async::{Read, Write};
 use heapless::Vec;
 use rand_core::RngCore;
 

--- a/src/client/raw_client.rs
+++ b/src/client/raw_client.rs
@@ -1,4 +1,5 @@
-use embedded_io::asynch::{Read, Write};
+//use embedded_io::asynch::{Read, Write};
+use embedded_io_async::{Read, Write};
 use heapless::Vec;
 use rand_core::RngCore;
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -23,7 +23,8 @@
  */
 
 use crate::packet::v5::reason_codes::ReasonCode;
-use embedded_io::asynch::{Read, Write};
+//use embedded_io::asynch::{Read, Write};
+use embedded_io_async::{Read, Write};
 
 pub struct NetworkConnection<T>
 where


### PR DESCRIPTION
Hi,

Embassy-rs updated from using embadded-io::asynch to embedded-io-async, so using rust-mqtt with it would now fail. 
@shulltronics updated his fork to use the new(er?) embedded-io-async ( thanks! ), I just updated it to use 0.6.0.

It compiles for me hope nothing else broke tested with my code here:
https://github.com/TinHead/embassy-playground/tree/main/wifi-gw

Cheers,
TH
