### PR TITLE
updated embedded-io to v0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,13 @@ heapless = "0.7.10"
 rand_core = "0.6.0"
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
-embedded-io = { version = "0.4.0", features = ["async"]}
+embedded-io = { version = "0.6.1", features = ["async"]}
+embedded-io-async = { version = "0.6.0" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
-embedded-io = { version = "0.4.0", features = ["tokio"]}
+embedded-io = { version = "0.6.1", features = ["tokio"]}
+embedded-io-async = { version = "0.6.0" }
 tokio-test = { version = "0.4.2"}
 env_logger = "0.9.0"
 futures = { version = "0.3.21" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ embedded-io-async = { version = "0.6.0" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
-embedded-io = { version = "0.6.1", features = ["tokio"]}
+embedded-io = "0.6.1"
+embedded-io-adapters ={ version = "0.6.0", features = ["tokio-1"]}
 embedded-io-async = { version = "0.6.0" }
 tokio-test = { version = "0.4.2"}
 env_logger = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ heapless = "0.7.10"
 rand_core = "0.6.0"
 defmt = { version = "0.3", optional = true }
 log = { version = "0.4.14", optional = true }
-embedded-io = { version = "0.6.1", features = ["async"]}
+embedded-io = "0.6.1"
 embedded-io-async = { version = "0.6.0" }
 
 [dev-dependencies]

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -3,7 +3,7 @@ use std::{
     time::Duration,
 };
 
-use embedded_io::adapters::FromTokio;
+use embedded_io_adapters::tokio_1::FromTokio;
 use rust_mqtt::{
     client::{client::MqttClient, client_config::ClientConfig},
     packet::v5::reason_codes::ReasonCode,

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-use embedded_io::asynch::{Read, Write};
+use embedded_io_async::{Read, Write};
 use heapless::Vec;
 use rand_core::RngCore;
 

--- a/src/client/raw_client.rs
+++ b/src/client/raw_client.rs
@@ -1,4 +1,4 @@
-use embedded_io::asynch::{Read, Write};
+use embedded_io_async::{Read, Write};
 use heapless::Vec;
 use rand_core::RngCore;
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -23,7 +23,7 @@
  */
 
 use crate::packet::v5::reason_codes::ReasonCode;
-use embedded_io::asynch::{Read, Write};
+use embedded_io_async::{Read, Write};
 
 pub struct NetworkConnection<T>
 where

--- a/tests/integration_test_single.rs
+++ b/tests/integration_test_single.rs
@@ -35,7 +35,7 @@ use tokio::time::sleep;
 use tokio::{net::TcpStream, task};
 use tokio_test::{assert_err, assert_ok};
 
-use embedded_io::adapters::FromTokio;
+use embedded_io_adapters::tokio_1::FromTokio;
 use rust_mqtt::client::client::MqttClient;
 use rust_mqtt::client::client_config::ClientConfig;
 use rust_mqtt::client::client_config::MqttVersion::MQTTv5;

--- a/tests/load_test.rs
+++ b/tests/load_test.rs
@@ -43,7 +43,7 @@ use rust_mqtt::packet::v5::reason_codes::ReasonCode;
 use rust_mqtt::utils::rng_generator::CountingRng;
 use tokio::net::TcpStream;
 
-use embedded_io::adapters::FromTokio;
+use embedded_io_adapters::tokio_1::FromTokio;
 pub type TokioNetwork = FromTokio<TcpStream>;
 
 static IP: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);


### PR DESCRIPTION
* embedded-io was recently moved to https://github.com/rust-embedded/embedded-hal and updated

I just changed some imports and removed async feature as there is embedded-io-async now. 