### PR TITLE
chore: update dependencies, switch to stable Rust, and update readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ embedded-io-async = "0.6"
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 embedded-io = "0.6"
-embedded-io-adapters ={ version = "0.6", features = ["tokio-1"]}
+embedded-io-adapters = { version = "0.6", features = ["tokio-1"] }
 embedded-io-async = { version = "0.6" }
-tokio-test = { version = "0.4.2"}
-env_logger = "0.9.0"
+tokio-test = { version = "0.4.2" }
+env_logger = "0.10.1"
 futures = { version = "0.3.21" }
-log = { version = "0.4.14"}
-serial_test = "0.6.0"
+log = { version = "0.4.14" }
+serial_test = "3.0.0"
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ cargo test integration
 cargo test load
 ```
 
+## Minimum supported Rust version (MSRV)
+Rust-mqtt is guaranteed to compile on stable Rust 1.75 and up.
+It might compile with older versions but that may change in any new patch release.
+
 ## Acknowledgment
 This project could not be in state in which currently is without Ulf Lilleengen and rest of the community
 from [Drogue IoT](https://github.com/drogue-iot).

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,11 @@
 [toolchain]
-channel = "nightly-2023-11-01"
-components = [ "rust-src", "rustfmt" ]
-targets = [ "thumbv7em-none-eabi", "thumbv7m-none-eabi", "thumbv6m-none-eabi", "thumbv7em-none-eabihf", "thumbv8m.main-none-eabihf", "wasm32-unknown-unknown" ]
+channel = "1.75"
+components = ["rust-src", "rustfmt"]
+targets = [
+  "thumbv7em-none-eabi",
+  "thumbv7m-none-eabi",
+  "thumbv6m-none-eabi",
+  "thumbv7em-none-eabihf",
+  "thumbv8m.main-none-eabihf",
+  "wasm32-unknown-unknown",
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@
 #![macro_use]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
-#![feature(type_alias_impl_trait)]
 pub(crate) mod fmt;
 
 pub mod client;


### PR DESCRIPTION
- Switch to stable Rust 1.75.
- Add MSRV section in README.md, documenting compatibility with stable Rust 1.75+.
- Update Cargo.toml dependencies: `embedded-io-adapters`, `env_logger`, `serial_test`.

The crate builds and all tests (unit, integration and load) pass.

Is there anything else I can do to help with the release?