### PR TITLE
Fix(NetworkConnection::send)

### DIFF
--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -44,11 +44,16 @@ where
 
     /// Send the data from `buffer` via TCP connection.
     pub async fn send(&mut self, buffer: &[u8]) -> Result<(), ReasonCode> {
-        let _ = self
-            .io
-            .write(buffer)
+        self.io
+            .write_all(buffer)
             .await
             .map_err(|_| ReasonCode::NetworkError)?;
+
+        self.io
+            .flush()
+            .await
+            .map_err(|_| ReasonCode::NetworkError)?;
+
         Ok(())
     }
 


### PR DESCRIPTION
`NetworkConnection::send` was trying to send the bytes using `write`, which - depending on the implementation - might not write the whole buffer to the tcp connection. `NetworkConnection::send` now uses `write_all` and `flush` to make sure, that all the bytes are `written` to the tcp buffer and `flushed`. 

## Issue
#41

## Test
- Esp32-C3
- Private `mosquitto server` 
- With `TLS` using `embedded-tls v0.17.0` 
- Without `TLS`

## Notes
- Cargo feature `tls` was not needed