### PR TITLE
Add support for user property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add user property support across CONNECT, CONNACK, PUBLISH, SUBSCRIBE, SUBACK, UNSUBSCRIBE, UNSUBACK, DISCONNECT, plus incoming PUBACK, PUBREC, PUBREL, and PUBCOMP packets
 - Add `UnsubscriptionOptions`
+- Change `Client::subscribe` to take `SubscriptionOptions` by reference instead of by value
 - Add slices of user property `MqttStringPair`'s to `ConnectOptions`, `WillOptions`, `DisconnectOptions`, `PublicationOptions`, `SubscriptionOptions`, `UnsubscriptionOptions`, as well as `Vec`'s of user property `MqttStringPair`'s to `ConnectInfo` and the `Suback`, `Publish`, `Puback` or `Pubrej` event contents
 - Add the `MAX_USER_PROPERTIES` const generic parameter to the client as an upper limit to the amount of user properties the client can process
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add user property support across CONNECT, CONNACK, PUBLISH, SUBSCRIBE, SUBACK, UNSUBSCRIBE, UNSUBACK, DISCONNECT, plus incoming PUBACK, PUBREC, PUBREL, and PUBCOMP packets
+- Add `UnsubscriptionOptions`
+- Add slices of user property `MqttStringPair`'s to `ConnectOptions`, `WillOptions`, `DisconnectOptions`, `PublicationOptions`, `SubscriptionOptions`, `UnsubscriptionOptions`, as well as `Vec`'s of user property `MqttStringPair`'s to `ConnectInfo` and the `Suback`, `Publish`, `Puback` or `Pubrej` event contents
+- Add the `MAX_USER_PROPERTIES` const generic parameter to the client as an upper limit to the amount of user properties the client can process
+
 ## 0.5.1 - 2026-04-10
 
 - Fix swapped const generic parameter usage in `Session`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `Client::subscribe` to take `SubscriptionOptions` by reference instead of by value
 - Add slices of user property `MqttStringPair`'s to `ConnectOptions`, `WillOptions`, `DisconnectOptions`, `PublicationOptions`, `SubscriptionOptions`, `UnsubscriptionOptions`, as well as `Vec`'s of user property `MqttStringPair`'s to `ConnectInfo` and the `Suback`, `Publish`, `Puback` or `Pubrej` event contents
 - Add the `MAX_USER_PROPERTIES` const generic parameter to the client as an upper limit to the amount of user properties the client can process
+- Fix reason string being allowed more than once in incoming SUBACK and UNSUBACK packets
 
 ## 0.5.1 - 2026-04-10
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@ The design goal is a strict yet flexible and explicit API that leverages Rust's 
 - Topic alias
 - Request/Response
 - Reason String in CONNACK & DISCONNECT packets
+- User Property in CONNECT, CONNACK, PUBLISH, SUBSCRIBE, SUBACK, UNSUBSCRIBE, UNSUBACK and DISCONNECT packets as well as incoming PUBACK, PUBREC, PUBREL and PUBCOMP packets
 
 ### Currently unsupported MQTT features & limitations
 
 - AUTH packet
-- Properties: Authentication Method, Authentication Data, Request Problem Information, Reason String (PUBACK, PUBREC, PUBREL, PUBCOMP, SUBACK, UNSUBACK), User Property
+- Properties: Authentication Method, Authentication Data, Request Problem Information, Reason String (PUBACK, PUBREC, PUBREL, PUBCOMP, SUBACK, UNSUBACK), User Property (outgoing PUBACK, PUBREC, PUBREL and PUBCOMP)
 - Subscribing to multiple topics in a single packet
 
 ### Extension plans (more or less by priority)

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -103,8 +103,11 @@ async fn main() {
     match client.poll().await {
         Ok(Event::Suback(Suback {
             packet_identifier: _,
+            user_properties: _,
             reason_code,
-        })) => info!("Subscribed with reason code {reason_code:?}"),
+        })) => {
+            info!("Subscribed with reason code {reason_code:?}")
+        }
         Ok(e) => {
             error!("Expected Suback but received event {e:?}");
             return;
@@ -204,8 +207,11 @@ async fn main() {
     match client.poll().await {
         Ok(Event::Unsuback(Suback {
             packet_identifier: _,
+            user_properties: _,
             reason_code,
-        })) => info!("Unsubscribed with reason code {reason_code:?}"),
+        })) => {
+            info!("Unsubscribed with reason code {reason_code:?}")
+        }
         Ok(e) => {
             info!("Expected Unsuback but received event {e:?}");
             return;

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -33,7 +33,7 @@ async fn main() {
     #[cfg(feature = "bump")]
     let mut buffer = BumpBuffer::new(&mut buffer);
 
-    let mut client = Client::<'_, _, _, 1, 1, 1, 1>::new(&mut buffer);
+    let mut client = Client::<'_, _, _, 1, 1, 1, 1, 16>::new(&mut buffer);
 
     let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1883);
     let connection = TcpStream::connect(addr).await.unwrap();
@@ -249,7 +249,7 @@ async fn main() {
     let mut buffer = BumpBuffer::new(&mut buffer);
 
     // Continue the previous session
-    let mut client = Client::<'_, _, _, 1, 1, 1, 1>::with_session(session, &mut buffer);
+    let mut client = Client::<'_, _, _, 1, 1, 1, 1, 16>::with_session(session, &mut buffer);
 
     let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1883);
     let connection = TcpStream::connect(addr).await.unwrap();

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -310,6 +310,7 @@ async fn main() {
             Ok(Event::PublishComplete(Puback {
                 packet_identifier,
                 reason_code: _,
+                user_properties: _,
             })) if packet_identifier == incomplete_publish_packet_identifier => {
                 info!("Completed republish of packet identifier {packet_identifier}");
                 break;

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -14,7 +14,7 @@ use rust_mqtt::{
         event::{Event, Puback, Suback},
         options::{
             ConnectOptions, DisconnectOptions, PublicationOptions, RetainHandling,
-            SubscriptionOptions, TopicReference, WillOptions,
+            SubscriptionOptions, TopicReference, UnsubscriptionOptions, WillOptions,
         },
     },
     config::{KeepAlive, SessionExpiryInterval},
@@ -190,7 +190,10 @@ async fn main() {
         }
     }
 
-    match client.unsubscribe(topic.clone().into()).await {
+    match client
+        .unsubscribe(topic.clone().into(), &UnsubscriptionOptions::new())
+        .await
+    {
         Ok(_) => info!("Sent Unsubscribe"),
         Err(e) => {
             error!("Failed to unsubscribe: {e:?}");

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -92,7 +92,7 @@ async fn main() {
 
     let topic = TopicName::new(MqttString::from_str("rust-mqtt/is/great").unwrap()).unwrap();
 
-    match client.subscribe(topic.clone().into(), sub_options).await {
+    match client.subscribe(topic.clone().into(), &sub_options).await {
         Ok(_) => info!("Sent Subscribe"),
         Err(e) => {
             error!("Failed to subscribe: {e:?}");

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -107,11 +107,5 @@ async fn main() {
 
     sleep(Duration::from_secs(5)).await;
 
-    client
-        .disconnect(&DisconnectOptions {
-            publish_will: false,
-            session_expiry_interval: None,
-        })
-        .await
-        .unwrap();
+    client.disconnect(&DisconnectOptions::new()).await.unwrap();
 }

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -67,7 +67,7 @@ async fn main() {
     #[cfg(feature = "bump")]
     let mut buffer = BumpBuffer::new(&mut buffer);
 
-    let mut client = Client::<'_, _, _, 1, 1, 1, 0>::new(&mut buffer);
+    let mut client = Client::<'_, _, _, 1, 1, 1, 0, 0>::new(&mut buffer);
 
     let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8883);
     let connection = TcpStream::connect(addr).await.unwrap();

--- a/src/client/err.rs
+++ b/src/client/err.rs
@@ -1,8 +1,10 @@
+use heapless::Vec;
+
 use crate::{
     client::raw::RawError,
     eio::ErrorKind,
     header::Reserved,
-    types::{MqttString, ReasonCode, TooLargeToEncode},
+    types::{MqttString, MqttStringPair, ReasonCode, TooLargeToEncode},
 };
 
 /// The main error returned by [`crate::client::Client`].
@@ -18,7 +20,7 @@ use crate::{
 /// - For recoverable errors, follow the error-specific behaviour.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum Error<'e> {
+pub enum Error<'e, const MAX_USER_PROPERTIES: usize> {
     /// An underlying Read/Write method returned an error.
     ///
     /// Unrecoverable error. [`crate::client::Client::abort`] should be called.
@@ -53,6 +55,10 @@ pub enum Error<'e> {
         /// The reason string property of the causing CONNACK or DISCONNECT packet if the server included
         /// a reason string.
         reason_string: Option<MqttString<'e>>,
+
+        /// The user property entries in the causing CONNACK or DISCONNECT packet. If the vector is full,
+        /// this list might not be exhaustive.
+        user_properties: Vec<MqttStringPair<'e>, MAX_USER_PROPERTIES>,
 
         /// The server reference property of the causing CONNACK or DISCONNCET packet if the server included
         /// a server reference. Identifies another server which can be used.
@@ -132,7 +138,7 @@ pub enum Error<'e> {
     IllegalDisconnectSessionExpiryInterval,
 }
 
-impl Error<'_> {
+impl<const MAX_USER_PROPERTIES: usize> Error<'_, MAX_USER_PROPERTIES> {
     /// Returns whether the client can recover from this error without closing the network connection.
     #[must_use]
     pub fn is_recoverable(&self) -> bool {
@@ -150,14 +156,53 @@ impl Error<'_> {
         )
     }
 }
+impl<'e> Error<'e, 0> {
+    /// Converts an [`Error<0>`] into an [`Error<N>`] with any N.
+    ///
+    /// This cannot be a [`From`] implementation because `From<Error<0>> for Error<N>` would
+    /// collide with the blanket implementation `From<T> for T`. The reason this function is
+    /// only implemented for `MAX_USER_PROPERTIES` = 0 is to prevent potentially surprisng
+    /// panics when converting from more user properties to less.
+    pub fn inflate<const MAX_USER_PROPERTIES: usize>(self) -> Error<'e, MAX_USER_PROPERTIES> {
+        match self {
+            Self::Network(error_kind) => Error::Network(error_kind),
+            Self::Server => Error::Server,
+            Self::Alloc => Error::Alloc,
+            Self::AuthPacketReceived => Error::AuthPacketReceived,
+            Self::Disconnect {
+                reason,
+                reason_string,
+                user_properties,
+                server_reference,
+            } => Error::Disconnect {
+                reason,
+                reason_string,
+                user_properties: user_properties.into_iter().collect(),
+                server_reference,
+            },
+            Self::RecoveryRequired => Error::RecoveryRequired,
+            Self::PacketIdentifierNotInFlight => Error::PacketIdentifierNotInFlight,
+            Self::RepublishQoSNotMatching => Error::RepublishQoSNotMatching,
+            Self::PacketIdentifierAwaitingPubcomp => Error::PacketIdentifierAwaitingPubcomp,
+            Self::PacketMaximumLengthExceeded => Error::PacketMaximumLengthExceeded,
+            Self::ServerMaximumPacketSizeExceeded => Error::ServerMaximumPacketSizeExceeded,
+            Self::InvalidTopicAlias => Error::InvalidTopicAlias,
+            Self::SessionBuffer => Error::SessionBuffer,
+            Self::SendQuotaExceeded => Error::SendQuotaExceeded,
+            Self::IllegalDisconnectSessionExpiryInterval => {
+                Error::IllegalDisconnectSessionExpiryInterval
+            }
+        }
+    }
+}
 
-impl From<Reserved> for Error<'_> {
+impl<const MAX_USER_PROPERTIES: usize> From<Reserved> for Error<'_, MAX_USER_PROPERTIES> {
     fn from(_: Reserved) -> Self {
         Self::Server
     }
 }
 
-impl<B> From<RawError<B>> for Error<'_> {
+impl<B, const MAX_USER_PROPERTIES: usize> From<RawError<B>> for Error<'_, MAX_USER_PROPERTIES> {
     fn from(e: RawError<B>) -> Self {
         match e {
             RawError::Disconnected => Self::RecoveryRequired,
@@ -168,7 +213,7 @@ impl<B> From<RawError<B>> for Error<'_> {
     }
 }
 
-impl From<TooLargeToEncode> for Error<'_> {
+impl<const MAX_USER_PROPERTIES: usize> From<TooLargeToEncode> for Error<'_, MAX_USER_PROPERTIES> {
     fn from(_: TooLargeToEncode) -> Self {
         Self::PacketMaximumLengthExceeded
     }

--- a/src/client/event.rs
+++ b/src/client/event.rs
@@ -9,7 +9,7 @@ use crate::{
     types::{
         IdentifiedQoS, MqttBinary, MqttString, MqttStringPair, PacketIdentifier, ReasonCode,
         TopicName, VarByteInt,
-    },
+    }, v5::{packet::GenericPubackPacket, property::Property},
 };
 
 /// Events emitted by the client when receiving an MQTT packet.
@@ -45,7 +45,7 @@ pub enum Event<'e, const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER_PRO
     /// The included reason code is always erroneous.
     ///
     /// The publication process is aborted.
-    PublishRejected(Pubrej),
+    PublishRejected(Pubrej<'e, MAX_USER_PROPERTIES>),
 
     /// The server sent a PUBACK packet matching a [`QoS`] 1 PUBLISH packet
     /// confirming that the PUBLISH has been received.
@@ -54,7 +54,7 @@ pub enum Event<'e, const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER_PRO
     ///
     /// The [`QoS`] 1 publication process is complete,
     /// the PUBLISH packet won't have to be resent.
-    PublishAcknowledged(Puback),
+    PublishAcknowledged(Puback<'e, MAX_USER_PROPERTIES>),
 
     /// The server sent a PUBREC packet matching a [`QoS`] 2 PUBLISH packet
     /// confirming that the PUBLISH has been received.
@@ -65,7 +65,7 @@ pub enum Event<'e, const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER_PRO
     ///
     /// The first handshake of the [`QoS`] 2 publication process is complete,
     /// the PUBLISH packet won't have to be resent.
-    PublishReceived(Puback),
+    PublishReceived(Puback<'e, MAX_USER_PROPERTIES>),
 
     /// The server sent a PUBREL packet matching a [`QoS`] 2 PUBREC packet
     /// confirming that the PUBREC has been received.
@@ -76,7 +76,7 @@ pub enum Event<'e, const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER_PRO
     ///
     /// The [`QoS`] 2 publication process is complete,
     /// the PUBREC packet won't have to be resent.
-    PublishReleased(Puback),
+    PublishReleased(Puback<'e, MAX_USER_PROPERTIES>),
 
     /// The server sent a PUBCOMP packet matching a [`QoS`] 2 PUBREL packet
     /// confirming that the PUBREL has been received.
@@ -85,7 +85,7 @@ pub enum Event<'e, const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER_PRO
     ///
     /// The [`QoS`] 2 publication process is complete,
     /// the PUBREL packet won't have to be resent.
-    PublishComplete(Puback),
+    PublishComplete(Puback<'e, MAX_USER_PROPERTIES>),
 
     /// The server sent a SUBACK, PUBACK, PUBREC, PUBREL or PUBCOMP
     /// packet with a packet identifier that is not in flight (anymore).
@@ -180,11 +180,32 @@ pub struct Publish<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER
 /// The reason code is always successful.
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Puback {
+pub struct Puback<'p, const MAX_USER_PROPERTIES: usize> {
     /// Packet identifier of the acknowledged PUBLISH packet.
     pub packet_identifier: PacketIdentifier,
     /// Reason code of this state in the publication process
     pub reason_code: ReasonCode,
+    /// The user property entries in the PUBACK/PUBREC/PUBREL/PUBCOMP packet.
+    /// If the vector is full, this list might not be exhaustive.
+    pub user_properties: Vec<MqttStringPair<'p>, MAX_USER_PROPERTIES>,
+}
+
+impl<'p, T, const MAX_USER_PROPERTIES: usize> From<GenericPubackPacket<'p, T, MAX_USER_PROPERTIES>>
+    for Puback<'p, MAX_USER_PROPERTIES>
+{
+    fn from(packet: GenericPubackPacket<'p, T, MAX_USER_PROPERTIES>) -> Self {
+        debug_assert!(packet.reason_code.is_success());
+
+        Self {
+            packet_identifier: packet.packet_identifier,
+            reason_code: packet.reason_code,
+            user_properties: packet
+                .user_properties
+                .into_iter()
+                .map(Property::into_inner)
+                .collect(),
+        }
+    }
 }
 
 /// Content of [`Event::PublishRejected`].
@@ -192,9 +213,30 @@ pub struct Puback {
 /// The reason code is always erroneous.
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Pubrej {
+pub struct Pubrej<'p, const MAX_USER_PROPERTIES: usize> {
     /// Packet identifier of the rejected PUBLISH packet.
     pub packet_identifier: PacketIdentifier,
     /// Reason code of the rejection.
     pub reason_code: ReasonCode,
+    /// The user property entries in the PUBACK/PUBREC/PUBREL/PUBCOMP packet.
+    /// If the vector is full, this list might not be exhaustive.
+    pub user_properties: Vec<MqttStringPair<'p>, MAX_USER_PROPERTIES>,
+}
+
+impl<'p, T, const MAX_USER_PROPERTIES: usize> From<GenericPubackPacket<'p, T, MAX_USER_PROPERTIES>>
+    for Pubrej<'p, MAX_USER_PROPERTIES>
+{
+    fn from(packet: GenericPubackPacket<'p, T, MAX_USER_PROPERTIES>) -> Self {
+        debug_assert!(packet.reason_code.is_erroneous());
+
+        Self {
+            packet_identifier: packet.packet_identifier,
+            reason_code: packet.reason_code,
+            user_properties: packet
+                .user_properties
+                .into_iter()
+                .map(Property::into_inner)
+                .collect(),
+        }
+    }
 }

--- a/src/client/event.rs
+++ b/src/client/event.rs
@@ -2,20 +2,20 @@
 
 use heapless::Vec;
 
+#[allow(unused_imports)]
+use crate::types::QoS;
 use crate::{
     bytes::Bytes,
     types::{
-        IdentifiedQoS, MqttBinary, MqttString, PacketIdentifier, ReasonCode, TopicName, VarByteInt,
+        IdentifiedQoS, MqttBinary, MqttString, MqttStringPair, PacketIdentifier, ReasonCode,
+        TopicName, VarByteInt,
     },
 };
-
-#[allow(unused_imports)]
-use crate::types::QoS;
 
 /// Events emitted by the client when receiving an MQTT packet.
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum Event<'e, const MAX_SUBSCRIPTION_IDENTIFIERS: usize> {
+pub enum Event<'e, const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER_PROPERTIES: usize> {
     /// The server sent a PINGRESP packet.
     Pingresp,
 
@@ -31,13 +31,13 @@ pub enum Event<'e, const MAX_SUBSCRIPTION_IDENTIFIERS: usize> {
     ///
     /// The subscription process is complete and was successful if the reason code indicates success.
     /// The SUBSCRIBE packet won't have to be resent.
-    Suback(Suback),
+    Suback(Suback<'e, MAX_USER_PROPERTIES>),
 
     /// The server sent an UNSUBACK packet matching an UNSUBSCRIBE packet.
     ///
     /// The unsubscription process is complete and was successful if the reason code indicates success.
     /// The UNSUBSCRIBE packet won't have to be resent.
-    Unsuback(Suback),
+    Unsuback(Suback<'e, MAX_USER_PROPERTIES>),
 
     /// The server sent a PUBACK or PUBREC with an erroneous reason code,
     /// therefore rejecting the publication.
@@ -103,9 +103,14 @@ pub enum Event<'e, const MAX_SUBSCRIPTION_IDENTIFIERS: usize> {
 /// Content of [`Event::Suback`].
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Suback {
+pub struct Suback<'s, const MAX_USER_PROPERTIES: usize> {
     /// Packet identifier of the acknowledged SUBSCRIBE packet.
     pub packet_identifier: PacketIdentifier,
+
+    /// The user property entries in the SUBACK/UNSUBACK packet.
+    /// If the vector is full, this list might not be exhaustive.
+    pub user_properties: Vec<MqttStringPair<'s>, MAX_USER_PROPERTIES>,
+
     /// Reason code returned for the subscription.
     pub reason_code: ReasonCode,
 }

--- a/src/client/event.rs
+++ b/src/client/event.rs
@@ -9,7 +9,8 @@ use crate::{
     types::{
         IdentifiedQoS, MqttBinary, MqttString, MqttStringPair, PacketIdentifier, ReasonCode,
         TopicName, VarByteInt,
-    }, v5::{packet::GenericPubackPacket, property::Property},
+    },
+    v5::{packet::GenericPubackPacket, property::Property},
 };
 
 /// Events emitted by the client when receiving an MQTT packet.

--- a/src/client/event.rs
+++ b/src/client/event.rs
@@ -25,7 +25,7 @@ pub enum Event<'e, const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER_PRO
     /// - [`QoS`] 0: No action
     /// - [`QoS`] 1: A PUBACK packet has been sent to the server.
     /// - [`QoS`] 2: A PUBREC packet has been sent to the server and the packet identifier is tracked as in flight
-    Publish(Publish<'e, MAX_SUBSCRIPTION_IDENTIFIERS>),
+    Publish(Publish<'e, MAX_SUBSCRIPTION_IDENTIFIERS, MAX_USER_PROPERTIES>),
 
     /// The server sent a SUBACK packet matching a SUBSCRIBE packet.
     ///
@@ -118,7 +118,8 @@ pub struct Suback<'s, const MAX_USER_PROPERTIES: usize> {
 /// Content of [`Event::Publish`].
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Publish<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize> {
+pub struct Publish<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER_PROPERTIES: usize>
+{
     /// The DUP flag in the PUBLISH packet. If set to false, it indicates that this is the first occasion
     /// the server has attempted to send this publication.
     pub dup: bool,
@@ -157,6 +158,10 @@ pub struct Publish<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize> {
     /// associating either the following response with this specific request or in case of a response,
     /// link back to the original request.
     pub correlation_data: Option<MqttBinary<'p>>,
+
+    /// The user property entries in the PUBLISH packet. If the vector is full, this list might not be
+    /// exhaustive.
+    pub user_properties: Vec<MqttStringPair<'p>, MAX_USER_PROPERTIES>,
 
     /// The subscription identifiers in the PUBLISH packet. If the vector is full, this list might not
     /// be exhaustive.

--- a/src/client/info/connect.rs
+++ b/src/client/info/connect.rs
@@ -1,4 +1,6 @@
-use crate::types::MqttString;
+use heapless::Vec;
+
+use crate::types::{MqttString, MqttStringPair};
 
 /// Information taken from a connection handshake the client does not have to store
 /// for correct operational behaviour and does not store for optimization purposes.
@@ -7,7 +9,7 @@ use crate::types::MqttString;
 /// if this is returned.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Info<'i> {
+pub struct Info<'i, const MAX_USER_PROPERTIES: usize> {
     /// If set to true, a previous session is continued by the server for this connection.
     pub session_present: bool,
 
@@ -15,6 +17,10 @@ pub struct Info<'i> {
     /// or must assign a client identifier if none was included in the CONNECT packet.
     /// This is the final client identifier value used for this session.
     pub client_identifier: MqttString<'i>,
+
+    /// The user property entries in the CONNACK packet. If the vector is full, this list might
+    /// not be exhaustive.
+    pub user_properties: Vec<MqttStringPair<'i>, MAX_USER_PROPERTIES>,
 
     /// Response information used to create response topics.
     pub response_information: Option<MqttString<'i>>,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     packet::{Packet, TxPacket},
     session::{CPublishFlightState, SPublishFlightState, Session},
     types::{
-        IdentifiedQoS, MqttBinary, MqttString, PacketIdentifier, QoS, ReasonCode,
+        IdentifiedQoS, MqttBinary, MqttString, MqttStringPair, PacketIdentifier, QoS, ReasonCode,
         SubscriptionFilter, TopicFilter, TopicName, VarByteInt,
     },
     v5::{
@@ -55,6 +55,8 @@ pub use err::Error as MqttError;
 ///   can further limit this with its receive maximum. The client will use the minimum of this value and [`Self::server_config`].
 /// - `MAX_SUBSCRIPTION_IDENTIFIERS`: The maximum amount of subscription identifier properties the client can receive within a
 ///   single PUBLISH packet. If a packet with more subscription identifiers is received, the later identifers will be discarded.
+/// - `MAX_USER_PROPERTIES`: The maximum amount of user properties that the client can send and receive in one packet. Must not
+///   be greater than 1021. This limitation currently exists to easily rule out any variable byte integer overflows.
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Client<
@@ -65,6 +67,7 @@ pub struct Client<
     const RECEIVE_MAXIMUM: usize,
     const SEND_MAXIMUM: usize,
     const MAX_SUBSCRIPTION_IDENTIFIERS: usize,
+    const MAX_USER_PROPERTIES: usize,
 > {
     client_config: ClientConfig,
     shared_config: SharedConfig,
@@ -89,7 +92,18 @@ impl<
     const RECEIVE_MAXIMUM: usize,
     const SEND_MAXIMUM: usize,
     const MAX_SUBSCRIPTION_IDENTIFIERS: usize,
-> Client<'c, N, B, MAX_SUBSCRIBES, RECEIVE_MAXIMUM, SEND_MAXIMUM, MAX_SUBSCRIPTION_IDENTIFIERS>
+    const MAX_USER_PROPERTIES: usize,
+>
+    Client<
+        'c,
+        N,
+        B,
+        MAX_SUBSCRIBES,
+        RECEIVE_MAXIMUM,
+        SEND_MAXIMUM,
+        MAX_SUBSCRIPTION_IDENTIFIERS,
+        MAX_USER_PROPERTIES,
+    >
 {
     /// Creates a new, disconnected MQTT client using a buffer provider to store
     /// dynamically sized fields of received packets.
@@ -103,6 +117,10 @@ impl<
         assert!(
             RECEIVE_MAXIMUM > 0,
             "RECEIVE_MAXIMUM must be greater than 0"
+        );
+        assert!(
+            MAX_USER_PROPERTIES <= 1021,
+            "MAX_USER_PROPERTIES must be less than or equal to 1021"
         );
 
         Self {
@@ -241,6 +259,12 @@ impl<
     /// * [`MqttError::Disconnect`] if the CONNACK packet's reason code is not successful (>= 0x80)
     /// * [`MqttError::Network`] if the underlying [`Transport`] returned an error
     /// * [`MqttError::Alloc`] if the underlying [`BufferProvider`] returned an error
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the length of the `user_properties` slice in the [`ConnectOptions`]
+    /// or the length of the `user_properties` slice in the will in [`ConnectOptions`] is greater
+    /// than `MAX_USER_PROPERTIES`.
     pub async fn connect<'d>(
         &mut self,
         net: N,
@@ -250,6 +274,21 @@ impl<
     where
         'c: 'd,
     {
+        assert!(
+            options.user_properties.len() <= MAX_USER_PROPERTIES,
+            "Attempted to send CONNECT with {} > {} (MAX_USER_PROPERTIES) properties",
+            options.user_properties.len(),
+            MAX_USER_PROPERTIES
+        );
+        if let Some(ref will) = options.will {
+            assert!(
+                will.user_properties.len() <= MAX_USER_PROPERTIES,
+                "Attempted to send Will with {} > {} (MAX_USER_PROPERTIES) properties",
+                will.user_properties.len(),
+                MAX_USER_PROPERTIES
+            );
+        }
+
         if options.clean_start {
             self.session.clear();
         }
@@ -299,7 +338,7 @@ impl<
                 .map(MqttString::as_borrowed)
                 .unwrap_or_default();
 
-            let mut packet = ConnectPacket::new(
+            let mut packet = ConnectPacket::<MAX_USER_PROPERTIES>::new(
                 packet_client_identifier,
                 options.clean_start,
                 options.keep_alive,
@@ -309,6 +348,12 @@ impl<
                 // code is only reached when `RECEIVE_MAXIMUM` is greater than 0.
                 unsafe { NonZero::new_unchecked(RECEIVE_MAXIMUM as u16) },
                 options.request_response_information,
+                options
+                    .user_properties
+                    .iter()
+                    .map(MqttStringPair::as_borrowed)
+                    .map(Into::into)
+                    .collect(),
             );
 
             if let Some(ref user_name) = options.user_name {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -110,18 +110,20 @@ impl<
     /// The session state is initialised as a new session. If you want to start the
     /// client with an existing session, use [`Self::with_session`].
     pub fn new(buffer: &'c mut B) -> Self {
-        assert!(
-            RECEIVE_MAXIMUM <= 65535,
-            "RECEIVE_MAXIMUM must be less than or equal to 65535"
-        );
-        assert!(
-            RECEIVE_MAXIMUM > 0,
-            "RECEIVE_MAXIMUM must be greater than 0"
-        );
-        assert!(
-            MAX_USER_PROPERTIES <= 1021,
-            "MAX_USER_PROPERTIES must be less than or equal to 1021"
-        );
+        const {
+            assert!(
+                RECEIVE_MAXIMUM <= 65535,
+                "RECEIVE_MAXIMUM must be less than or equal to 65535"
+            );
+            assert!(
+                RECEIVE_MAXIMUM > 0,
+                "RECEIVE_MAXIMUM must be greater than 0"
+            );
+            assert!(
+                MAX_USER_PROPERTIES <= 1021,
+                "MAX_USER_PROPERTIES must be less than or equal to 1021"
+            );
+        }
 
         Self {
             client_config: ClientConfig::default(),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         raw::Raw,
     },
     config::{ClientConfig, MaximumPacketSize, ServerConfig, SessionExpiryInterval, SharedConfig},
-    fmt::{assert, debug, error, info, panic, trace, unreachable, warn},
+    fmt::{assert, const_assert, debug, error, info, panic, trace, unreachable, warn},
     header::{FixedHeader, PacketType},
     io::Transport,
     packet::{Packet, TxPacket},
@@ -111,15 +111,15 @@ impl<
     /// client with an existing session, use [`Self::with_session`].
     pub fn new(buffer: &'c mut B) -> Self {
         const {
-            assert!(
+            const_assert!(
                 RECEIVE_MAXIMUM <= 65535,
                 "RECEIVE_MAXIMUM must be less than or equal to 65535"
             );
-            assert!(
+            const_assert!(
                 RECEIVE_MAXIMUM > 0,
                 "RECEIVE_MAXIMUM must be greater than 0"
             );
-            assert!(
+            const_assert!(
                 MAX_USER_PROPERTIES <= 1021,
                 "MAX_USER_PROPERTIES must be less than or equal to 1021"
             );

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -12,7 +12,7 @@ use crate::{
         info::ConnectInfo,
         options::{
             ConnectOptions, DisconnectOptions, PublicationOptions, SubscriptionOptions,
-            TopicReference,
+            TopicReference, UnsubscriptionOptions,
         },
         raw::Raw,
     },
@@ -601,10 +601,23 @@ impl<
     /// * [`MqttError::SessionBuffer`] if the buffer for outgoing UNSUBSCRIBE packet identifiers is full
     /// * [`MqttError::ServerMaximumPacketSizeExceeded`] if the server's maximum packet size would be
     ///   exceeded by sending this UNSUBSCRIBE packet
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the length of the `user_properties` slice in the [`UnsubscriptionOptions`]
+    /// is greater than `MAX_USER_PROPERTIES`.
     pub async fn unsubscribe(
         &mut self,
         topic_filter: TopicFilter<'_>,
+        options: &UnsubscriptionOptions<'_>,
     ) -> Result<PacketIdentifier, MqttError<'c, 0>> {
+        assert!(
+            options.user_properties.len() <= MAX_USER_PROPERTIES,
+            "Attempted to send UNSUBSCRIBE with {} > {} (MAX_USER_PROPERTIES) properties",
+            options.user_properties.len(),
+            MAX_USER_PROPERTIES
+        );
+
         if self.pending_unsuback.len() == MAX_SUBSCRIBES {
             info!("maximum concurrent unsubscriptions reached");
             return Err(MqttError::SessionBuffer);
@@ -613,8 +626,17 @@ impl<
         let pid = self.packet_identifier();
         let mut topic_filters = Vec::<_, 1>::new();
         let _ = topic_filters.push(topic_filter);
-        let packet = UnsubscribePacket::new(pid, topic_filters)
-            .expect("UNSUBSCRIBE with a single topic cannot exceed VarByteInt::MAX_ENCODABLE");
+        let packet = UnsubscribePacket::<1, MAX_USER_PROPERTIES>::new(
+            pid,
+            options
+                .user_properties
+                .iter()
+                .map(MqttStringPair::as_borrowed)
+                .map(Into::into)
+                .collect(),
+            topic_filters,
+        )
+        .expect("UNSUBSCRIBE with a single topic cannot exceed VarByteInt::MAX_ENCODABLE");
 
         if self.server_config.maximum_packet_size.as_u32() < packet.encoded_len() as u32 {
             return Err(MqttError::ServerMaximumPacketSizeExceeded);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -551,7 +551,7 @@ impl<
             MAX_USER_PROPERTIES
         );
 
-        if self.pending_suback.len() == MAX_SUBSCRIBES {
+        if self.pending_suback.is_full() {
             info!("maximum concurrent subscriptions reached");
             return Err(MqttError::SessionBuffer);
         }
@@ -581,6 +581,8 @@ impl<
 
         self.raw.send(&packet).await?;
         self.raw.flush().await?;
+
+        // `!self.pending_suback.is_full` guarantees there is space
         self.pending_suback.push(pid).unwrap();
 
         Ok(pid)
@@ -619,7 +621,7 @@ impl<
             MAX_USER_PROPERTIES
         );
 
-        if self.pending_unsuback.len() == MAX_SUBSCRIBES {
+        if self.pending_unsuback.is_full() {
             info!("maximum concurrent unsubscriptions reached");
             return Err(MqttError::SessionBuffer);
         }
@@ -646,6 +648,8 @@ impl<
 
         self.raw.send(&packet).await?;
         self.raw.flush().await?;
+
+        // `!self.pending_unsuback.is_full` guarantees there is space
         self.pending_unsuback.push(pid).unwrap();
 
         Ok(pid)

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -532,23 +532,45 @@ impl<
     /// * [`MqttError::SessionBuffer`] if the buffer for outgoing SUBSCRIBE packet identifiers is full
     /// * [`MqttError::ServerMaximumPacketSizeExceeded`] if the server's maximum packet size would be
     ///   exceeded by sending this SUBSCRIBE packet
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the length of the `user_properties` slice in the [`SubscriptionOptions`]
+    /// is greater than `MAX_USER_PROPERTIES`.
     pub async fn subscribe(
         &mut self,
         topic_filter: TopicFilter<'_>,
-        options: SubscriptionOptions,
+        options: &SubscriptionOptions<'_>,
     ) -> Result<PacketIdentifier, MqttError<'c, 0>> {
+        assert!(
+            options.user_properties.len() <= MAX_USER_PROPERTIES,
+            "Attempted to send SUBSCRIBE with {} > {} (MAX_USER_PROPERTIES) properties",
+            options.user_properties.len(),
+            MAX_USER_PROPERTIES
+        );
+
         if self.pending_suback.len() == MAX_SUBSCRIBES {
             info!("maximum concurrent subscriptions reached");
             return Err(MqttError::SessionBuffer);
         }
 
-        let subscribe_filter = SubscriptionFilter::new(topic_filter, &options);
+        let subscribe_filter = SubscriptionFilter::new(topic_filter, options);
 
         let pid = self.packet_identifier();
         let mut subscribe_filters = Vec::<_, 1>::new();
         let _ = subscribe_filters.push(subscribe_filter);
-        let packet = SubscribePacket::new(pid, options.subscription_identifier, subscribe_filters)
-            .expect("SUBSCRIBE with a single topic can not exceed VarByteInt::MAX_ENCODABLE");
+        let packet = SubscribePacket::<1, MAX_USER_PROPERTIES>::new(
+            pid,
+            options.subscription_identifier.map(Into::into),
+            options
+                .user_properties
+                .iter()
+                .map(MqttStringPair::as_borrowed)
+                .map(Into::into)
+                .collect(),
+            subscribe_filters,
+        )
+        .expect("SUBSCRIBE with a single topic can not exceed VarByteInt::MAX_ENCODABLE");
 
         if self.server_config.maximum_packet_size.as_u32() < packet.encoded_len() as u32 {
             return Err(MqttError::ServerMaximumPacketSizeExceeded);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -671,11 +671,23 @@ impl<
     ///   with MQTT's [`VarByteInt`]
     /// * [`MqttError::ServerMaximumPacketSizeExceeded`] if the server's maximum packet size would be
     ///   exceeded by sending this PUBLISH packet
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the length of the `user_properties` slice in the [`PublicationOptions`]
+    /// is greater than `MAX_USER_PROPERTIES`.
     pub async fn publish(
         &mut self,
         options: &PublicationOptions<'_>,
         message: Bytes<'_>,
     ) -> Result<Option<PacketIdentifier>, MqttError<'c, 0>> {
+        assert!(
+            options.user_properties.len() <= MAX_USER_PROPERTIES,
+            "Attempted to publish {} > {} (MAX_USER_PROPERTIES) properties",
+            options.user_properties.len(),
+            MAX_USER_PROPERTIES
+        );
+
         if options.qos > QoS::AtMostOnce {
             if self.remaining_send_quota() == 0 {
                 info!("server receive maximum reached");
@@ -701,7 +713,7 @@ impl<
             return Err(MqttError::InvalidTopicAlias);
         }
 
-        let packet: PublishPacket<'_, 0> = PublishPacket::new(
+        let packet = PublishPacket::<0, MAX_USER_PROPERTIES>::new(
             false,
             identified_qos,
             options.retain,
@@ -713,6 +725,12 @@ impl<
                 .correlation_data
                 .as_ref()
                 .map(MqttBinary::as_borrowed),
+            options
+                .user_properties
+                .iter()
+                .map(MqttStringPair::as_borrowed)
+                .map(Into::into)
+                .collect(),
             options
                 .content_type
                 .as_ref()
@@ -785,12 +803,21 @@ impl<
     /// # Panics
     ///
     /// This function may panic if the [`QoS`] in the `options` is [`QoS::AtMostOnce`].
+    /// This function panics if the length of the `user_properties` slice in the [`PublicationOptions`]
+    /// is greater than `MAX_USER_PROPERTIES`.
     pub async fn republish(
         &mut self,
         packet_identifier: PacketIdentifier,
         options: &PublicationOptions<'_>,
         message: Bytes<'_>,
     ) -> Result<(), MqttError<'c, 0>> {
+        assert!(
+            options.user_properties.len() <= MAX_USER_PROPERTIES,
+            "Attempted to publish {} > {} (MAX_USER_PROPERTIES) properties",
+            options.user_properties.len(),
+            MAX_USER_PROPERTIES
+        );
+
         if options.qos == QoS::AtMostOnce {
             panic!("QoS 0 packets cannot be republished");
         }
@@ -838,7 +865,7 @@ impl<
             return Err(MqttError::InvalidTopicAlias);
         }
 
-        let packet: PublishPacket<'_, 0> = PublishPacket::new(
+        let packet = PublishPacket::<0, MAX_USER_PROPERTIES>::new(
             true,
             identified_qos,
             options.retain,
@@ -850,6 +877,12 @@ impl<
                 .correlation_data
                 .as_ref()
                 .map(MqttBinary::as_borrowed),
+            options
+                .user_properties
+                .iter()
+                .map(MqttStringPair::as_borrowed)
+                .map(Into::into)
+                .collect(),
             options
                 .content_type
                 .as_ref()
@@ -1179,7 +1212,9 @@ impl<
             PacketType::Publish => {
                 let publish = self
                     .raw
-                    .recv_body::<PublishPacket<'_, MAX_SUBSCRIPTION_IDENTIFIERS>>(&header)
+                    .recv_body::<PublishPacket<MAX_SUBSCRIPTION_IDENTIFIERS, MAX_USER_PROPERTIES>>(
+                        &header,
+                    )
                     .await?;
 
                 // Our topic alias maximum is always 0, the moment we receive a topic alias, this is an error.
@@ -1202,6 +1237,11 @@ impl<
                         .map(Property::into_inner),
                     response_topic: publish.response_topic.map(Property::into_inner),
                     correlation_data: publish.correlation_data.map(Property::into_inner),
+                    user_properties: publish
+                        .user_properties
+                        .into_iter()
+                        .map(Property::into_inner)
+                        .collect(),
                     subscription_identifiers: publish
                         .subscription_identifiers
                         .into_iter()

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1157,13 +1157,12 @@ impl<
 
                 if Self::remove_packet_identifier_if_exists(&mut self.pending_suback, pid) {
                     // We only send SUBSCRIBE packets with exactly 1 topic
-                    if suback.reason_codes.len() != 1 {
+
+                    let [r] = suback.reason_codes.as_slice() else {
                         error!("received mismatched SUBACK");
                         self.raw.close_with(Some(ReasonCode::ProtocolError));
                         return Err(MqttError::Server);
-                    }
-
-                    let r = suback.reason_codes.first().unwrap();
+                    };
 
                     Event::Suback(Suback {
                         packet_identifier: pid,
@@ -1191,13 +1190,11 @@ impl<
 
                 if Self::remove_packet_identifier_if_exists(&mut self.pending_unsuback, pid) {
                     // We only send UNSUBSCRIBE packets with exactly 1 topic
-                    if unsuback.reason_codes.len() != 1 {
+                    let [r] = unsuback.reason_codes.as_slice() else {
                         error!("received mismatched UNSUBACK");
                         self.raw.close_with(Some(ReasonCode::ProtocolError));
                         return Err(MqttError::Server);
-                    }
-
-                    let r = unsuback.reason_codes.first().unwrap();
+                    };
 
                     Event::Unsuback(Suback {
                         packet_identifier: pid,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -931,7 +931,7 @@ impl<
             .filter(|s| s.state == CPublishFlightState::AwaitingPubcomp)
             .map(|p| p.packet_identifier)
         {
-            let pubrel = PubrelPacket::new(packet_identifier, ReasonCode::Success);
+            let pubrel = PubrelPacket::<0>::new(packet_identifier, ReasonCode::Success);
 
             // Don't check whether length exceeds servers maximum packet size because we don't
             // add properties to PUBREL packets -> length is always minimal at 6 bytes.
@@ -1263,7 +1263,7 @@ impl<
                         // We could disconnect here using ReasonCode::ReceiveMaximumExceeded, but incoming QoS 1 publications
                         // don't require resources outside of this scope which means we can just accept these packets.
 
-                        let puback = PubackPacket::new(pid, ReasonCode::Success);
+                        let puback = PubackPacket::<0>::new(pid, ReasonCode::Success);
 
                         debug!("sending PUBACK packet");
 
@@ -1293,7 +1293,7 @@ impl<
                             }
                         };
 
-                        let pubrec = PubrecPacket::new(pid, ReasonCode::Success);
+                        let pubrec = PubrecPacket::<0>::new(pid, ReasonCode::Success);
 
                         debug!("sending PUBREC packet");
 
@@ -1308,7 +1308,7 @@ impl<
                 }
             }
             PacketType::Puback => {
-                let puback = self.raw.recv_body::<PubackPacket>(&header).await?;
+                let puback = self.raw.recv_body::<PubackPacket<_>>(&header).await?;
                 let pid = puback.packet_identifier;
                 let reason_code = puback.reason_code;
 
@@ -1316,18 +1316,12 @@ impl<
                     Some(CPublishFlightState::AwaitingPuback) if reason_code.is_success() => {
                         debug!("publication with packet identifier {} complete", pid);
 
-                        Event::PublishAcknowledged(Puback {
-                            packet_identifier: pid,
-                            reason_code,
-                        })
+                        Event::PublishAcknowledged(Puback::from(puback))
                     }
                     Some(CPublishFlightState::AwaitingPuback) => {
                         debug!("publication with packet identifier {} aborted", pid);
 
-                        Event::PublishRejected(Pubrej {
-                            packet_identifier: pid,
-                            reason_code,
-                        })
+                        Event::PublishRejected(Pubrej::from(puback))
                     }
                     Some(
                         s @ CPublishFlightState::AwaitingPubrec
@@ -1353,7 +1347,7 @@ impl<
                 }
             }
             PacketType::Pubrec => {
-                let pubrec = self.raw.recv_body::<PubrecPacket>(&header).await?;
+                let pubrec = self.raw.recv_body::<PubrecPacket<_>>(&header).await?;
                 let pid = pubrec.packet_identifier;
                 let reason_code = pubrec.reason_code;
 
@@ -1363,7 +1357,7 @@ impl<
                         // removing a cpublish frees space to add a new in flight entry.
                         unsafe { self.session.await_pubcomp(pid) };
 
-                        let pubrel = PubrelPacket::new(pid, ReasonCode::Success);
+                        let pubrel = PubrelPacket::<0>::new(pid, ReasonCode::Success);
 
                         debug!("sending PUBREL packet");
 
@@ -1373,10 +1367,7 @@ impl<
                         self.raw.send(&pubrel).await?;
                         self.raw.flush().await?;
 
-                        Event::PublishReceived(Puback {
-                            packet_identifier: pid,
-                            reason_code,
-                        })
+                        Event::PublishReceived(Puback::from(pubrec))
                     }
                     Some(CPublishFlightState::AwaitingPubrec) => {
                         // After receiving an erroneous PUBREC, we have to treat any subsequent PUBLISH packet
@@ -1385,10 +1376,7 @@ impl<
 
                         debug!("publication with packet identifier {} aborted", pid);
 
-                        Event::PublishRejected(Pubrej {
-                            packet_identifier: pid,
-                            reason_code,
-                        })
+                        Event::PublishRejected(Pubrej::from(pubrec))
                     }
                     Some(
                         s @ CPublishFlightState::AwaitingPuback
@@ -1410,7 +1398,8 @@ impl<
                     None => {
                         debug!("packet identifier {} in PUBREC not in use", pid);
 
-                        let pubrel = PubrelPacket::new(pid, ReasonCode::PacketIdentifierNotFound);
+                        let pubrel =
+                            PubrelPacket::<0>::new(pid, ReasonCode::PacketIdentifierNotFound);
 
                         debug!("sending PUBREL packet");
 
@@ -1425,13 +1414,13 @@ impl<
                 }
             }
             PacketType::Pubrel => {
-                let pubrel = self.raw.recv_body::<PubrelPacket>(&header).await?;
+                let pubrel = self.raw.recv_body::<PubrelPacket<_>>(&header).await?;
                 let pid = pubrel.packet_identifier;
                 let reason_code = pubrel.reason_code;
 
                 match self.session.remove_spublish(pid) {
                     Some(SPublishFlightState::AwaitingPubrel) if reason_code.is_success() => {
-                        let pubcomp = PubcompPacket::new(pid, ReasonCode::Success);
+                        let pubcomp = PubcompPacket::<0>::new(pid, ReasonCode::Success);
 
                         debug!("sending PUBCOMP packet");
 
@@ -1441,23 +1430,18 @@ impl<
                         self.raw.send(&pubcomp).await?;
                         self.raw.flush().await?;
 
-                        Event::PublishReleased(Puback {
-                            packet_identifier: pid,
-                            reason_code,
-                        })
+                        Event::PublishReleased(Puback::from(pubrel))
                     }
                     Some(SPublishFlightState::AwaitingPubrel) => {
                         debug!("publication with packet identifier {} aborted", pid);
 
-                        Event::PublishRejected(Pubrej {
-                            packet_identifier: pid,
-                            reason_code,
-                        })
+                        Event::PublishRejected(Pubrej::from(pubrel))
                     }
                     None => {
                         debug!("packet identifier {} in PUBREL not in use", pid);
 
-                        let pubcomp = PubcompPacket::new(pid, ReasonCode::PacketIdentifierNotFound);
+                        let pubcomp =
+                            PubcompPacket::<0>::new(pid, ReasonCode::PacketIdentifierNotFound);
 
                         debug!("sending PUBCOMP packet");
 
@@ -1472,7 +1456,7 @@ impl<
                 }
             }
             PacketType::Pubcomp => {
-                let pubcomp = self.raw.recv_body::<PubcompPacket>(&header).await?;
+                let pubcomp = self.raw.recv_body::<PubcompPacket<_>>(&header).await?;
                 let pid = pubcomp.packet_identifier;
                 let reason_code = pubcomp.reason_code;
 
@@ -1480,18 +1464,12 @@ impl<
                     Some(CPublishFlightState::AwaitingPubcomp) if reason_code.is_success() => {
                         debug!("publication with packet identifier {} complete", pid);
 
-                        Event::PublishComplete(Puback {
-                            packet_identifier: pid,
-                            reason_code: pubcomp.reason_code,
-                        })
+                        Event::PublishComplete(Puback::from(pubcomp))
                     }
                     Some(CPublishFlightState::AwaitingPubcomp) => {
                         debug!("publication with packet identifier {} aborted", pid);
 
-                        Event::PublishRejected(Pubrej {
-                            packet_identifier: pid,
-                            reason_code,
-                        })
+                        Event::PublishRejected(Pubrej::from(pubcomp))
                     }
                     Some(
                         s @ CPublishFlightState::AwaitingPuback

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -557,8 +557,7 @@ impl<
         let subscribe_filter = SubscriptionFilter::new(topic_filter, options);
 
         let pid = self.packet_identifier();
-        let mut subscribe_filters = Vec::<_, 1>::new();
-        let _ = subscribe_filters.push(subscribe_filter);
+        let subscribe_filters = [subscribe_filter].into();
         let packet = SubscribePacket::<1, MAX_USER_PROPERTIES>::new(
             pid,
             options.subscription_identifier.map(Into::into),
@@ -624,8 +623,7 @@ impl<
         }
 
         let pid = self.packet_identifier();
-        let mut topic_filters = Vec::<_, 1>::new();
-        let _ = topic_filters.push(topic_filter);
+        let topic_filters = [topic_filter].into();
         let packet = UnsubscribePacket::<1, MAX_USER_PROPERTIES>::new(
             pid,
             options

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -270,7 +270,7 @@ impl<
         net: N,
         options: &ConnectOptions<'_>,
         client_identifier: Option<MqttString<'d>>,
-    ) -> Result<ConnectInfo<'d>, MqttError<'c>>
+    ) -> Result<ConnectInfo<'d, MAX_USER_PROPERTIES>, MqttError<'c, MAX_USER_PROPERTIES>>
     where
         'c: 'd,
     {
@@ -378,7 +378,7 @@ impl<
         let header = self.raw.recv_header().await?;
 
         match header.packet_type() {
-            Ok(ConnackPacket::PACKET_TYPE) => debug!(
+            Ok(ConnackPacket::<MAX_USER_PROPERTIES>::PACKET_TYPE) => debug!(
                 "received CONNACK packet header (remaining length: {})",
                 header.remaining_len.value()
             ),
@@ -395,7 +395,7 @@ impl<
             }
         }
 
-        let ConnackPacket {
+        let ConnackPacket::<MAX_USER_PROPERTIES> {
             session_present,
             reason_code,
             session_expiry_interval,
@@ -406,6 +406,7 @@ impl<
             assigned_client_identifier,
             topic_alias_maximum,
             reason_string,
+            user_properties,
             wildcard_subscription_available,
             subscription_identifier_available,
             shared_subscription_available,
@@ -466,6 +467,10 @@ impl<
             Ok(ConnectInfo {
                 session_present,
                 client_identifier,
+                user_properties: user_properties
+                    .into_iter()
+                    .map(Property::into_inner)
+                    .collect(),
                 response_information: response_information.map(Property::into_inner),
                 server_reference: server_reference.map(Property::into_inner),
             })
@@ -480,6 +485,10 @@ impl<
             Err(MqttError::Disconnect {
                 reason: reason_code,
                 reason_string: reason_string.map(Property::into_inner),
+                user_properties: user_properties
+                    .into_iter()
+                    .map(Property::into_inner)
+                    .collect(),
                 server_reference: server_reference.map(Property::into_inner),
             })
         }
@@ -491,7 +500,7 @@ impl<
     ///
     /// * [`MqttError::RecoveryRequired`] if an unrecoverable error occured previously
     /// * [`MqttError::Network`] if the underlying [`Transport`] returned an error
-    pub async fn ping(&mut self) -> Result<(), MqttError<'c>> {
+    pub async fn ping(&mut self) -> Result<(), MqttError<'c, 0>> {
         debug!("sending PINGREQ packet");
 
         // PINGREQ has length 2 which really shouldn't exceed server's max packet size.
@@ -527,7 +536,7 @@ impl<
         &mut self,
         topic_filter: TopicFilter<'_>,
         options: SubscriptionOptions,
-    ) -> Result<PacketIdentifier, MqttError<'c>> {
+    ) -> Result<PacketIdentifier, MqttError<'c, 0>> {
         if self.pending_suback.len() == MAX_SUBSCRIBES {
             info!("maximum concurrent subscriptions reached");
             return Err(MqttError::SessionBuffer);
@@ -573,7 +582,7 @@ impl<
     pub async fn unsubscribe(
         &mut self,
         topic_filter: TopicFilter<'_>,
-    ) -> Result<PacketIdentifier, MqttError<'c>> {
+    ) -> Result<PacketIdentifier, MqttError<'c, 0>> {
         if self.pending_unsuback.len() == MAX_SUBSCRIBES {
             info!("maximum concurrent unsubscriptions reached");
             return Err(MqttError::SessionBuffer);
@@ -622,7 +631,7 @@ impl<
         &mut self,
         options: &PublicationOptions<'_>,
         message: Bytes<'_>,
-    ) -> Result<Option<PacketIdentifier>, MqttError<'c>> {
+    ) -> Result<Option<PacketIdentifier>, MqttError<'c, 0>> {
         if options.qos > QoS::AtMostOnce {
             if self.remaining_send_quota() == 0 {
                 info!("server receive maximum reached");
@@ -737,7 +746,7 @@ impl<
         packet_identifier: PacketIdentifier,
         options: &PublicationOptions<'_>,
         message: Bytes<'_>,
-    ) -> Result<(), MqttError<'c>> {
+    ) -> Result<(), MqttError<'c, 0>> {
         if options.qos == QoS::AtMostOnce {
             panic!("QoS 0 packets cannot be republished");
         }
@@ -837,7 +846,7 @@ impl<
     ///
     /// * [`MqttError::RecoveryRequired`] if an unrecoverable error occured previously
     /// * [`MqttError::Network`] if the underlying [`Transport`] returned an error
-    pub async fn rerelease(&mut self) -> Result<(), MqttError<'c>> {
+    pub async fn rerelease(&mut self) -> Result<(), MqttError<'c, 0>> {
         for packet_identifier in self
             .session
             .pending_client_publishes
@@ -885,7 +894,22 @@ impl<
     /// * [`MqttError::IllegalDisconnectSessionExpiryInterval`] if the session expiry interval in the
     ///   CONNECT packet was zero and the session expiry interval in the [`DisconnectOptions`] is [`Some`]
     ///   and not [`SessionExpiryInterval::EndOnDisconnect`].
-    pub async fn disconnect(&mut self, options: &DisconnectOptions) -> Result<(), MqttError<'c>> {
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the length of the `user_properties` slice in the [`DisconnectOptions`]
+    /// is greater than `MAX_USER_PROPERTIES`.
+    pub async fn disconnect(
+        &mut self,
+        options: &DisconnectOptions<'_>,
+    ) -> Result<(), MqttError<'c, 0>> {
+        assert!(
+            options.user_properties.len() <= MAX_USER_PROPERTIES,
+            "Attempted to send DISCONNECT with {} > {} (MAX_USER_PROPERTIES) properties",
+            options.user_properties.len(),
+            MAX_USER_PROPERTIES
+        );
+
         let connect_session_expiry_interval_was_zero =
             self.client_config.session_expiry_interval == SessionExpiryInterval::EndOnDisconnect;
         let disconnect_session_expiry_interval_is_non_zero = options
@@ -904,7 +928,15 @@ impl<
             ReasonCode::Success
         };
 
-        let mut packet = DisconnectPacket::new(reason_code);
+        let mut packet = DisconnectPacket::<0>::new(
+            reason_code,
+            options
+                .user_properties
+                .iter()
+                .map(MqttStringPair::as_borrowed)
+                .map(Into::into)
+                .collect(),
+        );
         if let Some(s) = options.session_expiry_interval {
             packet.add_session_expiry_interval(s);
         }
@@ -940,8 +972,10 @@ impl<
     ///
     /// Returns the errors that [`Client::poll_header`] and [`Client::poll_body`] return.
     /// For further information view their docs.
-    pub async fn poll(&mut self) -> Result<Event<'c, MAX_SUBSCRIPTION_IDENTIFIERS>, MqttError<'c>> {
-        let header = self.poll_header().await?;
+    pub async fn poll(
+        &mut self,
+    ) -> Result<Event<'c, MAX_SUBSCRIPTION_IDENTIFIERS>, MqttError<'c, MAX_USER_PROPERTIES>> {
+        let header = self.poll_header().await.map_err(MqttError::inflate)?;
         self.poll_body(header).await
     }
 
@@ -963,7 +997,7 @@ impl<
     /// * [`MqttError::Server`] if:
     ///   * the server sends a malformed packet header
     ///   * the packet following this header exceeds the client's maximum packet size
-    pub async fn poll_header(&mut self) -> Result<FixedHeader, MqttError<'c>> {
+    pub async fn poll_header(&mut self) -> Result<FixedHeader, MqttError<'c, 0>> {
         let header = self.raw.recv_header().await?;
 
         if let Ok(p) = header.packet_type() {
@@ -1018,7 +1052,7 @@ impl<
     pub async fn poll_body(
         &mut self,
         header: FixedHeader,
-    ) -> Result<Event<'c, MAX_SUBSCRIPTION_IDENTIFIERS>, MqttError<'c>> {
+    ) -> Result<Event<'c, MAX_SUBSCRIPTION_IDENTIFIERS>, MqttError<'c, MAX_USER_PROPERTIES>> {
         let event = match header.packet_type()? {
             PacketType::Pingresp => {
                 self.raw.recv_body::<PingrespPacket>(&header).await?;
@@ -1377,11 +1411,19 @@ impl<
                 }
             }
             PacketType::Disconnect => {
-                let disconnect = self.raw.recv_body::<DisconnectPacket>(&header).await?;
+                let disconnect = self
+                    .raw
+                    .recv_body::<DisconnectPacket<MAX_USER_PROPERTIES>>(&header)
+                    .await?;
 
                 return Err(MqttError::Disconnect {
                     reason: disconnect.reason_code,
                     reason_string: disconnect.reason_string.map(Property::into_inner),
+                    user_properties: disconnect
+                        .user_properties
+                        .into_iter()
+                        .map(Property::into_inner)
+                        .collect(),
                     server_reference: disconnect.server_reference.map(Property::into_inner),
                 });
             }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1308,7 +1308,10 @@ impl<
                 }
             }
             PacketType::Puback => {
-                let puback = self.raw.recv_body::<PubackPacket<_>>(&header).await?;
+                let puback = self
+                    .raw
+                    .recv_body::<PubackPacket<MAX_USER_PROPERTIES>>(&header)
+                    .await?;
                 let pid = puback.packet_identifier;
                 let reason_code = puback.reason_code;
 
@@ -1347,7 +1350,10 @@ impl<
                 }
             }
             PacketType::Pubrec => {
-                let pubrec = self.raw.recv_body::<PubrecPacket<_>>(&header).await?;
+                let pubrec = self
+                    .raw
+                    .recv_body::<PubrecPacket<MAX_USER_PROPERTIES>>(&header)
+                    .await?;
                 let pid = pubrec.packet_identifier;
                 let reason_code = pubrec.reason_code;
 
@@ -1414,7 +1420,10 @@ impl<
                 }
             }
             PacketType::Pubrel => {
-                let pubrel = self.raw.recv_body::<PubrelPacket<_>>(&header).await?;
+                let pubrel = self
+                    .raw
+                    .recv_body::<PubrelPacket<MAX_USER_PROPERTIES>>(&header)
+                    .await?;
                 let pid = pubrel.packet_identifier;
                 let reason_code = pubrel.reason_code;
 
@@ -1456,7 +1465,10 @@ impl<
                 }
             }
             PacketType::Pubcomp => {
-                let pubcomp = self.raw.recv_body::<PubcompPacket<_>>(&header).await?;
+                let pubcomp = self
+                    .raw
+                    .recv_body::<PubcompPacket<MAX_USER_PROPERTIES>>(&header)
+                    .await?;
                 let pid = pubcomp.packet_identifier;
                 let reason_code = pubcomp.reason_code;
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1018,7 +1018,10 @@ impl<
     /// For further information view their docs.
     pub async fn poll(
         &mut self,
-    ) -> Result<Event<'c, MAX_SUBSCRIPTION_IDENTIFIERS>, MqttError<'c, MAX_USER_PROPERTIES>> {
+    ) -> Result<
+        Event<'c, MAX_SUBSCRIPTION_IDENTIFIERS, MAX_USER_PROPERTIES>,
+        MqttError<'c, MAX_USER_PROPERTIES>,
+    > {
         let header = self.poll_header().await.map_err(MqttError::inflate)?;
         self.poll_body(header).await
     }
@@ -1096,7 +1099,10 @@ impl<
     pub async fn poll_body(
         &mut self,
         header: FixedHeader,
-    ) -> Result<Event<'c, MAX_SUBSCRIPTION_IDENTIFIERS>, MqttError<'c, MAX_USER_PROPERTIES>> {
+    ) -> Result<
+        Event<'c, MAX_SUBSCRIPTION_IDENTIFIERS, MAX_USER_PROPERTIES>,
+        MqttError<'c, MAX_USER_PROPERTIES>,
+    > {
         let event = match header.packet_type()? {
             PacketType::Pingresp => {
                 self.raw.recv_body::<PingrespPacket>(&header).await?;
@@ -1106,7 +1112,10 @@ impl<
                 // We only send SUBSCRIBE packets with exactly 1 topic
                 // -> Packets with more than 1 reason code are currently rejected by the RxPacket::receive implementation
                 //    with RxError::Protocol error. This is correct as long as we only send SUBSCRIBE packets with 1 topic.
-                let suback = self.raw.recv_body::<SubackPacket<'_, 1>>(&header).await?;
+                let suback = self
+                    .raw
+                    .recv_body::<SubackPacket<1, MAX_USER_PROPERTIES>>(&header)
+                    .await?;
                 let pid = suback.packet_identifier;
 
                 if Self::remove_packet_identifier_if_exists(&mut self.pending_suback, pid) {
@@ -1121,6 +1130,11 @@ impl<
 
                     Event::Suback(Suback {
                         packet_identifier: pid,
+                        user_properties: suback
+                            .user_properties
+                            .into_iter()
+                            .map(Property::into_inner)
+                            .collect(),
                         reason_code: *r,
                     })
                 } else {
@@ -1132,7 +1146,10 @@ impl<
                 // We only send UNSUBSCRIBE packets with exactly 1 topic
                 // -> Packets with more than 1 reason code are currently rejected by the RxPacket::receive implementation
                 //    with RxError::Protocol error. This is correct as long as we only send UNSUBSCRIBE packets with 1 topic.
-                let unsuback = self.raw.recv_body::<UnsubackPacket<'_, 1>>(&header).await?;
+                let unsuback = self
+                    .raw
+                    .recv_body::<UnsubackPacket<1, MAX_USER_PROPERTIES>>(&header)
+                    .await?;
                 let pid = unsuback.packet_identifier;
 
                 if Self::remove_packet_identifier_if_exists(&mut self.pending_unsuback, pid) {
@@ -1147,6 +1164,11 @@ impl<
 
                     Event::Unsuback(Suback {
                         packet_identifier: pid,
+                        user_properties: unsuback
+                            .user_properties
+                            .into_iter()
+                            .map(Property::into_inner)
+                            .collect(),
                         reason_code: *r,
                     })
                 } else {

--- a/src/client/options/connect.rs
+++ b/src/client/options/connect.rs
@@ -5,7 +5,7 @@ use const_fn::const_fn;
 use crate::{
     client::options::WillOptions,
     config::{KeepAlive, MaximumPacketSize, SessionExpiryInterval},
-    types::{MqttBinary, MqttString},
+    types::{MqttBinary, MqttString, MqttStringPair},
 };
 
 /// Options for a connection.
@@ -26,6 +26,11 @@ pub struct Options<'c> {
 
     /// When set to true, the broker may return response information used to construct response topics.
     pub request_response_information: bool,
+
+    /// Arbitrary key-value pairs of strings sent as the user property entries of the CONNECT packet.
+    /// Note that this slice's length must be less than [`crate::client::Client`]'s const generic
+    /// parameter `MAX_USER_PROPERTIES`.
+    pub user_properties: &'c [MqttStringPair<'c>],
 
     /// The user name the client wishes to authenticate with.
     pub user_name: Option<MqttString<'c>>,
@@ -53,6 +58,7 @@ impl<'c> Options<'c> {
             session_expiry_interval: SessionExpiryInterval::EndOnDisconnect,
             maximum_packet_size: MaximumPacketSize::Unlimited,
             request_response_information: false,
+            user_properties: &[],
             user_name: None,
             password: None,
             will: None,
@@ -88,6 +94,13 @@ impl<'c> Options<'c> {
     #[must_use]
     pub const fn request_response_information(mut self) -> Self {
         self.request_response_information = true;
+        self
+    }
+    /// Sets the user properties. Note that this slice's length must be less than
+    /// [`crate::client::Client`]'s const generic parameter `MAX_USER_PROPERTIES`.
+    #[must_use]
+    pub const fn user_properties(mut self, user_properties: &'c [MqttStringPair<'c>]) -> Self {
+        self.user_properties = user_properties;
         self
     }
     /// Sets the user name.

--- a/src/client/options/disconnect.rs
+++ b/src/client/options/disconnect.rs
@@ -1,9 +1,9 @@
-use crate::config::SessionExpiryInterval;
+use crate::{config::SessionExpiryInterval, types::MqttStringPair};
 
 /// Options for a disconnection to the server with a DISCONNECT packet.
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Options {
+pub struct Options<'d> {
     /// If set to true, the server publishes the will message.
     pub publish_will: bool,
 
@@ -11,21 +11,27 @@ pub struct Options {
     /// if the session expiry interval property in the CONNECT packet has been 0.
     /// This value overrides the session expiry interval negotiated in the handshake.
     pub session_expiry_interval: Option<SessionExpiryInterval>,
+
+    /// Arbitrary key-value pairs of strings sent as the user property entries of the DISCONNECT
+    /// packet. Note that this slice's length must be less than [`crate::client::Client`]'s const
+    /// generic parameter `MAX_USER_PROPERTIES`.
+    pub user_properties: &'d [MqttStringPair<'d>],
 }
 
-impl Default for Options {
+impl Default for Options<'_> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Options {
+impl<'d> Options<'d> {
     /// Creates new disconnect options with will publication disabled and no session expiry interval.
     #[must_use]
     pub const fn new() -> Self {
         Self {
             publish_will: false,
             session_expiry_interval: None,
+            user_properties: &[],
         }
     }
 
@@ -39,6 +45,13 @@ impl Options {
     #[must_use]
     pub const fn session_expiry_interval(mut self, interval: SessionExpiryInterval) -> Self {
         self.session_expiry_interval = Some(interval);
+        self
+    }
+    /// Sets the user properties. Note that this slice's length must be less than
+    /// [`crate::client::Client`]'s const generic parameter `MAX_USER_PROPERTIES`.
+    #[must_use]
+    pub const fn user_properties(mut self, user_properties: &'d [MqttStringPair<'d>]) -> Self {
+        self.user_properties = user_properties;
         self
     }
 }

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -4,10 +4,12 @@ mod connect;
 mod disconnect;
 mod publish;
 mod subscribe;
+mod unsubscribe;
 mod will;
 
 pub use connect::Options as ConnectOptions;
 pub use disconnect::Options as DisconnectOptions;
 pub use publish::{Options as PublicationOptions, TopicReference};
 pub use subscribe::{Options as SubscriptionOptions, RetainHandling};
+pub use unsubscribe::Options as UnsubscriptionOptions;
 pub use will::Options as WillOptions;

--- a/src/client/options/publish.rs
+++ b/src/client/options/publish.rs
@@ -1,6 +1,6 @@
 use const_fn::const_fn;
 
-use crate::types::{MqttBinary, MqttString, QoS, TopicName};
+use crate::types::{MqttBinary, MqttString, MqttStringPair, QoS, TopicName};
 
 /// Options for a publication.
 #[derive(Debug, Clone)]
@@ -40,6 +40,10 @@ pub struct Options<'p> {
     /// their response with this request.
     pub correlation_data: Option<MqttBinary<'p>>,
 
+    /// Arbitrary key-value pairs of strings. Note that this slice's length must be less than
+    /// [`crate::client::Client`]'s const generic parameter `MAX_USER_PROPERTIES`.
+    pub user_properties: &'p [MqttStringPair<'p>],
+
     /// The custom content type of the message.
     pub content_type: Option<MqttString<'p>>,
 }
@@ -57,6 +61,7 @@ impl<'p> Options<'p> {
             message_expiry_interval: None,
             response_topic: None,
             correlation_data: None,
+            user_properties: &[],
             content_type: None,
         }
     }
@@ -107,6 +112,13 @@ impl<'p> Options<'p> {
     #[must_use]
     pub const fn correlation_data(mut self, data: MqttBinary<'p>) -> Self {
         self.correlation_data = Some(data);
+        self
+    }
+    /// Sets the user properties. Note that this slice's length must be less than
+    /// [`crate::client::Client`]'s const generic parameter `MAX_USER_PROPERTIES`.
+    #[must_use]
+    pub const fn user_properties(mut self, user_properties: &'p [MqttStringPair<'p>]) -> Self {
+        self.user_properties = user_properties;
         self
     }
     /// Sets the content type property.

--- a/src/client/options/subscribe.rs
+++ b/src/client/options/subscribe.rs
@@ -1,9 +1,9 @@
-use crate::types::{QoS, VarByteInt};
+use crate::types::{MqttStringPair, QoS, VarByteInt};
 
 /// Options for subscription included for every topic.
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Options {
+pub struct Options<'s> {
     /// Serverside retain handling configuration for this subscription.
     pub retain_handling: RetainHandling,
 
@@ -29,15 +29,20 @@ pub struct Options {
     /// subscription identifier properties in its PUBLISH packets to the values of
     /// all matching subscriptions with a subscription identifier.
     pub subscription_identifier: Option<VarByteInt>,
+
+    /// Arbitrary key-value pairs of strings sent as the user property entries of the SUBSCRIBE packet.
+    /// Note that this slice's length must be less than [`crate::client::Client`]'s const generic
+    /// parameter `MAX_USER_PROPERTIES`.
+    pub user_properties: &'s [MqttStringPair<'s>],
 }
 
-impl Default for Options {
+impl Default for Options<'_> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Options {
+impl<'s> Options<'s> {
     /// Creates options with values coherent to the [`Default`] implementations of the fields and
     /// [`QoS::AtMostOnce`].
     #[must_use]
@@ -48,6 +53,7 @@ impl Options {
             no_local: false,
             qos: QoS::AtMostOnce,
             subscription_identifier: None,
+            user_properties: &[],
         }
     }
 
@@ -89,6 +95,13 @@ impl Options {
     #[must_use]
     pub const fn subscription_identifier(mut self, subscription_identifier: VarByteInt) -> Self {
         self.subscription_identifier = Some(subscription_identifier);
+        self
+    }
+    /// Sets the user properties. Note that this slice's length must be less than
+    /// [`crate::client::Client`]'s const generic parameter `MAX_USER_PROPERTIES`.
+    #[must_use]
+    pub const fn user_properties(mut self, user_properties: &'s [MqttStringPair<'s>]) -> Self {
+        self.user_properties = user_properties;
         self
     }
 }

--- a/src/client/options/unsubscribe.rs
+++ b/src/client/options/unsubscribe.rs
@@ -1,0 +1,35 @@
+use crate::types::MqttStringPair;
+
+/// Options for unsubscription included for every topic.
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Options<'s> {
+    /// Arbitrary key-value pairs of strings sent as the user property entries of the UNSUBSCRIBE packet.
+    /// Note that this slice's length must be less than [`crate::client::Client`]'s const generic
+    /// parameter `MAX_USER_PROPERTIES`.
+    pub user_properties: &'s [MqttStringPair<'s>],
+}
+
+impl Default for Options<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'s> Options<'s> {
+    /// Creates options with values coherent to the [`Default`] implementations of the fields.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            user_properties: &[],
+        }
+    }
+
+    /// Sets the user properties. Note that this slice's length must be less than
+    /// [`crate::client::Client`]'s const generic parameter `MAX_USER_PROPERTIES`.
+    #[must_use]
+    pub const fn user_properties(mut self, user_properties: &'s [MqttStringPair<'s>]) -> Self {
+        self.user_properties = user_properties;
+        self
+    }
+}

--- a/src/client/options/will.rs
+++ b/src/client/options/will.rs
@@ -1,7 +1,7 @@
 use const_fn::const_fn;
 
 use crate::{
-    types::{MqttBinary, MqttString, QoS, TopicName, Will},
+    types::{MqttBinary, MqttString, MqttStringPair, QoS, TopicName, Will},
     v5::property::WillDelayInterval,
 };
 
@@ -51,6 +51,10 @@ pub struct Options<'c> {
     /// on the network.
     pub correlation_data: Option<MqttBinary<'c>>,
 
+    /// The user properties in the will publication. Note that this slice's length must be less than
+    /// [`crate::client::Client`]'s const generic parameter `MAX_USER_PROPERTIES`.
+    pub user_properties: &'c [MqttStringPair<'c>],
+
     /// The payload of the will publication.
     pub will_message: MqttBinary<'c>,
 }
@@ -70,6 +74,7 @@ impl<'c> Options<'c> {
             content_type: None,
             response_topic: None,
             correlation_data: None,
+            user_properties: &[],
             will_message: message,
         }
     }
@@ -136,10 +141,19 @@ impl<'c> Options<'c> {
         self.correlation_data = Some(correlation_data);
         self
     }
+    /// Sets the user properties. Note that this slice's length must be less than
+    /// [`crate::client::Client`]'s const generic parameter `MAX_USER_PROPERTIES`.
+    #[must_use]
+    pub const fn user_properties(mut self, user_properties: &'c [MqttStringPair<'c>]) -> Self {
+        self.user_properties = user_properties;
+        self
+    }
 }
 
 impl<'c> Options<'c> {
-    pub(crate) fn as_borrowed_will(&'c self) -> Will<'c> {
+    pub(crate) fn as_borrowed_will<const MAX_USER_PROPERTIES: usize>(
+        &'c self,
+    ) -> Will<'c, MAX_USER_PROPERTIES> {
         Will {
             will_topic: self.will_topic.as_borrowed(),
             will_delay_interval: match self.will_delay_interval {
@@ -163,6 +177,12 @@ impl<'c> Options<'c> {
                 .as_ref()
                 .map(MqttBinary::as_borrowed)
                 .map(Into::into),
+            user_properties: self
+                .user_properties
+                .iter()
+                .map(MqttStringPair::as_borrowed)
+                .map(Into::into)
+                .collect(),
             will_message: self.will_message.as_borrowed(),
         }
     }

--- a/src/client/raw/header.rs
+++ b/src/client/raw/header.rs
@@ -242,7 +242,7 @@ mod unit {
                 h,
                 FixedHeader {
                     type_and_flags: 0x89,
-                    remaining_len: VarByteInt::from(110u8),
+                    remaining_len: VarByteInt::from(110u8)
                 }
             );
 
@@ -257,7 +257,7 @@ mod unit {
                 h,
                 FixedHeader {
                     type_and_flags: 0xA0,
-                    remaining_len: VarByteInt::from(16_383u16),
+                    remaining_len: VarByteInt::from(16_383u16)
                 }
             );
         };

--- a/src/client/raw/mod.rs
+++ b/src/client/raw/mod.rs
@@ -7,6 +7,8 @@ mod net;
 pub(crate) use err::Error as RawError;
 pub(crate) use net::Error as NetStateError;
 
+use heapless::Vec;
+
 #[cfg(debug_assertions)]
 use crate::fmt::unreachable;
 use crate::{
@@ -74,7 +76,7 @@ impl<'b, N: Transport, B: BufferProvider<'b>> Raw<'b, N, B> {
 
         match &mut self.n {
             NetState::Faulted(n, r) => {
-                let packet = DisconnectPacket::new(*r);
+                let packet = DisconnectPacket::<0>::new(*r, Vec::new());
 
                 debug!("sending DISCONNECT packet with reason code: {:?}", r);
 

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,6 +1,15 @@
 #![allow(unused)]
 
 #[clippy::format_args]
+macro_rules! const_assert_ {
+    ($($x:tt)*) => {
+        {
+            ::core::assert!($($x)*);
+        }
+    };
+}
+
+#[clippy::format_args]
 macro_rules! assert_ {
     ($($x:tt)*) => {
         {
@@ -190,9 +199,10 @@ pub(crate) use trace;
 pub(crate) use verbose;
 pub(crate) use warn_ as warn;
 
-pub(crate) use assert_ as assert;
-
+pub(crate) use const_assert_ as const_assert;
 pub(crate) use const_debug_assert_ as const_debug_assert;
+
+pub(crate) use assert_ as assert;
 
 pub(crate) use debug_assert_ as debug_assert;
 pub(crate) use debug_assert_eq_ as debug_assert_eq;

--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -6,7 +6,7 @@ use crate::{
     eio::{ErrorType, Read},
     fmt::{unreachable, verbose},
     io::err::{BodyReadError, ReadError},
-    types::{MqttBinary, MqttString, TopicName, VarByteInt},
+    types::{MqttBinary, MqttString, MqttStringPair, TopicName, VarByteInt},
 };
 
 pub trait Readable<R: Read>: Sized {
@@ -18,7 +18,7 @@ pub trait Store<'a>: Read {
 }
 
 impl<R: Read, const N: usize> Readable<R> for [u8; N] {
-    async fn read(read: &mut R) -> Result<Self, ReadError<<R>::Error>> {
+    async fn read(read: &mut R) -> Result<Self, ReadError<R::Error>> {
         verbose!("reading array of {} byte(s)", N);
 
         let mut array = [0; N];
@@ -50,7 +50,7 @@ int_read_impl!(u16);
 int_read_impl!(u32);
 
 impl<R: Read> Readable<R> for bool {
-    async fn read(read: &mut R) -> Result<Self, ReadError<<R>::Error>> {
+    async fn read(read: &mut R) -> Result<Self, ReadError<R::Error>> {
         match u8::read(read).await? {
             0 => Ok(false),
             1 => Ok(true),
@@ -105,6 +105,14 @@ impl<'s, R: Read + Store<'s>> Readable<R> for MqttString<'s> {
             .await?
             .try_into()
             .map_err(|_| ReadError::MalformedPacket)
+    }
+}
+impl<'s, R: Read + Store<'s>> Readable<R> for MqttStringPair<'s> {
+    async fn read(read: &mut R) -> Result<Self, ReadError<R::Error>> {
+        let name = MqttString::read(read).await?;
+        let value = MqttString::read(read).await?;
+
+        Ok(MqttStringPair::new(name, value))
     }
 }
 impl<'s, R: Read + Store<'s>> Readable<R> for TopicName<'s> {
@@ -341,7 +349,7 @@ mod unit {
                 read::{BodyReader, Readable},
             },
             test::read::SliceReader,
-            types::{MqttBinary, MqttString, VarByteInt},
+            types::{MqttBinary, MqttString, MqttStringPair, VarByteInt},
         };
 
         #[tokio::test]
@@ -500,6 +508,25 @@ mod unit {
 
         #[tokio::test]
         #[test_log::test]
+        async fn read_string_pair() {
+            let mut s = SliceReader::new(&[
+                0x00, 0x03, b'k', b'e', b'y', 0x00, 0x05, b'v', b'a', b'l', b'u', b'e',
+            ]);
+            #[cfg(feature = "alloc")]
+            let mut b = AllocBuffer;
+            #[cfg(feature = "bump")]
+            let mut b = [0; 64];
+            #[cfg(feature = "bump")]
+            let mut b = BumpBuffer::new(&mut b);
+
+            let mut r = BodyReader::new(&mut s, &mut b, 12);
+            let v = assert_ok!(MqttStringPair::read(&mut r).await);
+            assert_eq!(v.name.as_ref(), "key");
+            assert_eq!(v.value.as_ref(), "value");
+        }
+
+        #[tokio::test]
+        #[test_log::test]
         async fn read_stream() {
             #[rustfmt::skip]
             let mut s = SliceReader::new(
@@ -511,6 +538,8 @@ mod unit {
                     0x80, 0x01,                              // varbyteint
                     0x00, 0x03, 0xAA, 0xBB, 0xCC,            // binary
                     0x00, 0x04, b't', b'e', b's', b't',      // string
+                    0x00, 0x03, b'k', b'e', b'y',            // string pair name
+                    0x00, 0x05, b'v', b'a', b'l', b'u', b'e',// string pair value
                     0x11, 0x22, 0x33,                        // array[3]
                 ]
             );
@@ -521,7 +550,7 @@ mod unit {
             #[cfg(feature = "bump")]
             let mut b = BumpBuffer::new(&mut b);
 
-            let mut r = BodyReader::new(&mut s, &mut b, 24);
+            let mut r = BodyReader::new(&mut s, &mut b, 36);
 
             let v_u8 = assert_ok!(u8::read(&mut r).await);
             assert_eq!(v_u8, 0x42);
@@ -543,6 +572,10 @@ mod unit {
 
             let v_string = assert_ok!(MqttString::read(&mut r).await);
             assert_eq!(v_string.as_ref(), "test");
+
+            let v_string_pair = assert_ok!(MqttStringPair::read(&mut r).await);
+            assert_eq!(v_string_pair.name.as_ref(), "key");
+            assert_eq!(v_string_pair.value.as_ref(), "value");
 
             let v_array = assert_ok!(<[u8; 3]>::read(&mut r).await);
             assert_eq!(v_array, [0x11, 0x22, 0x33]);
@@ -661,6 +694,32 @@ mod unit {
 
             let mut r = BodyReader::new(&mut s, &mut b, 6);
             let e = assert_err!(MqttString::read(&mut r).await);
+            assert_eq!(e, ReadError::UnexpectedEOF);
+
+            // MqttStringPair - EOF when reading name length
+            let mut s = SliceReader::new(b"\x00");
+            #[cfg(feature = "alloc")]
+            let mut b = AllocBuffer;
+            #[cfg(feature = "bump")]
+            let mut b = [0; 64];
+            #[cfg(feature = "bump")]
+            let mut b = BumpBuffer::new(&mut b);
+
+            let mut r = BodyReader::new(&mut s, &mut b, 2);
+            let e = assert_err!(MqttStringPair::read(&mut r).await);
+            assert_eq!(e, ReadError::UnexpectedEOF);
+
+            // MqttStringPair - EOF when reading value string
+            let mut s = SliceReader::new(&[0x00, 0x03, b'k', b'e', b'y', 0x00, 0x05, b'v', b'a']);
+            #[cfg(feature = "alloc")]
+            let mut b = AllocBuffer;
+            #[cfg(feature = "bump")]
+            let mut b = [0; 64];
+            #[cfg(feature = "bump")]
+            let mut b = BumpBuffer::new(&mut b);
+
+            let mut r = BodyReader::new(&mut s, &mut b, 12);
+            let e = assert_err!(MqttStringPair::read(&mut r).await);
             assert_eq!(e, ReadError::UnexpectedEOF);
         }
 
@@ -884,6 +943,25 @@ mod unit {
 
             let mut r = BodyReader::new(&mut s, &mut b, 2);
             let e = assert_err!(MqttString::read(&mut r).await);
+            assert_eq!(e, ReadError::Read(BodyReadError::InsufficientRemainingLen));
+        }
+
+        #[tokio::test]
+        #[test_log::test]
+        async fn read_insufficient_remaining_len_string_pair() {
+            // Insufficient remaining length while reading value string
+            let mut s = SliceReader::new(&[
+                0x00, 0x03, b'k', b'e', b'y', 0x00, 0x05, b'v', b'a', b'l', b'u', b'e',
+            ]);
+            #[cfg(feature = "alloc")]
+            let mut b = AllocBuffer;
+            #[cfg(feature = "bump")]
+            let mut b = [0; 64];
+            #[cfg(feature = "bump")]
+            let mut b = BumpBuffer::new(&mut b);
+
+            let mut r = BodyReader::new(&mut s, &mut b, 11);
+            let e = assert_err!(MqttStringPair::read(&mut r).await);
             assert_eq!(e, ReadError::Read(BodyReadError::InsufficientRemainingLen));
         }
     }

--- a/src/io/write.rs
+++ b/src/io/write.rs
@@ -2,7 +2,7 @@ use crate::{
     eio::Write,
     fmt::unreachable,
     io::err::WriteError,
-    types::{MqttBinary, MqttString, TopicFilter, TopicName, VarByteInt},
+    types::{MqttBinary, MqttString, MqttStringPair, TopicFilter, TopicName, VarByteInt},
 };
 
 pub trait Writable {
@@ -125,6 +125,16 @@ impl Writable for MqttString<'_> {
 
     async fn write<W: Write>(&self, write: &mut W) -> Result<(), WriteError<W::Error>> {
         self.0.write(write).await
+    }
+}
+impl Writable for MqttStringPair<'_> {
+    fn written_len(&self) -> usize {
+        self.name.written_len() + self.value.written_len()
+    }
+
+    async fn write<W: Write>(&self, write: &mut W) -> Result<(), WriteError<W::Error>> {
+        self.name.write(write).await?;
+        self.value.write(write).await
     }
 }
 impl Writable for TopicName<'_> {

--- a/src/types/int.rs
+++ b/src/types/int.rs
@@ -3,7 +3,7 @@ use crate::{
     types::TooLargeToEncode,
 };
 
-/// MQTT's variable byte integer encoding. The value has to be less than
+/// MQTT's variable byte integer encoding. The value has to be less than or equal to
 /// [`VarByteInt::MAX_ENCODABLE`] (`268_435_455`). Exceeding this ultimately leads to
 /// panics or malformed packets.
 ///

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -17,7 +17,7 @@ pub use int::VarByteInt;
 pub use pid::PacketIdentifier;
 pub use qos::{IdentifiedQoS, QoS};
 pub use reason_code::ReasonCode;
-pub use string::{MqttString, MqttStringError};
+pub use string::{MqttString, MqttStringError, MqttStringPair};
 pub use topic::{TopicFilter, TopicName};
 
 /// The error returned when types are larger than what is representable according to the specification.

--- a/src/types/pid.rs
+++ b/src/types/pid.rs
@@ -54,7 +54,7 @@ impl defmt::Format for PacketIdentifier {
 }
 
 impl<R: Read> Readable<R> for PacketIdentifier {
-    async fn read(read: &mut R) -> Result<Self, ReadError<<R>::Error>> {
+    async fn read(read: &mut R) -> Result<Self, ReadError<R::Error>> {
         u16::read(read)
             .await
             .map(NonZero::new)?

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -254,3 +254,52 @@ impl<'s> MqttString<'s> {
         Self(self.0.as_borrowed())
     }
 }
+
+/// A name-value pair of two [`MqttString`]'s.
+#[derive(Default, Clone, PartialEq, Eq)]
+pub struct MqttStringPair<'s> {
+    /// The name part of the string pair.
+    pub name: MqttString<'s>,
+
+    /// The value part of the string pair.
+    pub value: MqttString<'s>,
+}
+
+impl<'s> core::fmt::Debug for MqttStringPair<'s> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MqttStringPair")
+            .field("name", &self.name.as_str())
+            .field("value", &self.value.as_str())
+            .finish()
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<'a> defmt::Format for MqttStringPair<'a> {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(
+            fmt,
+            "MqttStringPair {{ name: {:?}, value: {:?} }}",
+            self.name.as_str(),
+            self.value.as_str()
+        );
+    }
+}
+
+impl<'s> MqttStringPair<'s> {
+    /// Creates a new [`MqttStringPair`]
+    #[must_use]
+    pub const fn new(name: MqttString<'s>, value: MqttString<'s>) -> Self {
+        Self { name, value }
+    }
+
+    /// Delegates to [`crate::Bytes::as_borrowed`].
+    #[inline]
+    #[must_use]
+    pub const fn as_borrowed(&'s self) -> Self {
+        Self {
+            name: self.name.as_borrowed(),
+            value: self.value.as_borrowed(),
+        }
+    }
+}

--- a/src/types/will.rs
+++ b/src/types/will.rs
@@ -1,17 +1,19 @@
+use heapless::Vec;
+
 use crate::{
     client::options::WillOptions,
     eio::Write,
     io::{err::WriteError, write::Writable},
-    types::{MqttBinary, TopicName, VarByteInt},
+    types::{MqttBinary, MqttStringPair, TopicName, VarByteInt},
     v5::property::{
         ContentType, CorrelationData, MessageExpiryInterval, PayloadFormatIndicator, ResponseTopic,
-        WillDelayInterval,
+        UserProperty, WillDelayInterval,
     },
 };
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Will<'w> {
+pub struct Will<'w, const MAX_USER_PROPERTIES: usize> {
     pub will_topic: TopicName<'w>,
 
     // Will properties
@@ -21,11 +23,12 @@ pub struct Will<'w> {
     pub content_type: Option<ContentType<'w>>,
     pub response_topic: Option<ResponseTopic<'w>>,
     pub correlation_data: Option<CorrelationData<'w>>,
+    pub user_properties: Vec<UserProperty<'w>, MAX_USER_PROPERTIES>,
 
     pub will_message: MqttBinary<'w>,
 }
 
-impl<'w> From<WillOptions<'w>> for Will<'w> {
+impl<'w, const MAX_USER_PROPERTIES: usize> From<WillOptions<'w>> for Will<'w, MAX_USER_PROPERTIES> {
     fn from(options: WillOptions<'w>) -> Self {
         Self {
             will_topic: options.will_topic,
@@ -38,15 +41,27 @@ impl<'w> From<WillOptions<'w>> for Will<'w> {
             content_type: options.content_type.map(Into::into),
             response_topic: options.response_topic.map(Into::into),
             correlation_data: options.correlation_data.map(Into::into),
+            user_properties: options
+                .user_properties
+                .iter()
+                .map(MqttStringPair::as_borrowed)
+                .map(Into::into)
+                .collect(),
             will_message: options.will_message,
         }
     }
 }
 
-impl Writable for Will<'_> {
+impl<const MAX_USER_PROPERTIES: usize> Writable for Will<'_, MAX_USER_PROPERTIES> {
     fn written_len(&self) -> usize {
         let will_properties_length = self.will_properties_length();
 
+        // max length = MAX_USER_PROPERTIES * 131077 + 327704
+        //
+        // will property length: 4
+        // will properties: MAX_USER_PROPERTIES * 131077 + 196626
+        // will topic: 65537
+        // will message: 65537
         will_properties_length.written_len()
             + will_properties_length.size()
             + self.will_topic.written_len()
@@ -65,6 +80,10 @@ impl Writable for Will<'_> {
         self.response_topic.write(write).await?;
         self.correlation_data.write(write).await?;
 
+        for user_property in &self.user_properties {
+            user_property.write(write).await?;
+        }
+
         self.will_topic.write(write).await?;
         self.will_message.write(write).await?;
 
@@ -72,22 +91,30 @@ impl Writable for Will<'_> {
     }
 }
 
-impl Will<'_> {
+impl<const MAX_USER_PROPERTIES: usize> Will<'_, MAX_USER_PROPERTIES> {
     pub fn will_properties_length(&self) -> VarByteInt {
         let will_properties_length = self.will_delay_interval.written_len()
             + self.payload_format_indicator.written_len()
             + self.message_expiry_interval.written_len()
             + self.content_type.written_len()
             + self.response_topic.written_len()
-            + self.correlation_data.written_len();
+            + self.correlation_data.written_len()
+            + self
+                .user_properties
+                .iter()
+                .map(Writable::written_len)
+                .sum::<usize>();
 
-        // Invariant: 196626 < VarByteInt::MAX_ENCODABLE
+        // max length = MAX_USER_PROPERTIES * 131077 + 196626
+        // Invariant: MAX_USER_PROPERTIES <= 2046 => max length <= VarByteInt::MAX_ENCODABLE
+        //
         // will delay interval: 5
         // payload format indicator: 2
         // message expiry interval: 5
         // content type: 65538
         // response topic: 65538
         // correlation data: 65538
+        // user properties: MAX_USER_PROPERTIES * 131077
         VarByteInt::new_unchecked(will_properties_length as u32)
     }
 }

--- a/src/v5/packet/connack.rs
+++ b/src/v5/packet/connack.rs
@@ -404,4 +404,42 @@ mod unit {
         //     ))
         // );
     }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn decode_incomplete_user_properties() {
+        #[rustfmt::skip]
+        let packet = decode!(
+            ConnackPacket<1>,
+            30,
+            [
+                0x20,
+                0x1E,
+
+                0x00, // connect acknowledge flags
+                0x00, // reason code
+                0x1B, // property length
+
+                // User Property
+                0x26, 0x00, 0x02, b'k', b'1',
+                      0x00, 0x02, b'v', b'1',
+
+                // User Property
+                0x26, 0x00, 0x02, b'k', b'2',
+                      0x00, 0x02, b'v', b'2',
+
+                // User Property
+                0x26, 0x00, 0x02, b'k', b'3',
+                      0x00, 0x02, b'v', b'3',
+            ]
+        );
+
+        assert_eq!(
+            packet.user_properties.first().unwrap(),
+            &UserProperty(MqttStringPair::new(
+                MqttString::try_from("k1").unwrap(),
+                MqttString::try_from("v1").unwrap()
+            ))
+        );
+    }
 }

--- a/src/v5/packet/connack.rs
+++ b/src/v5/packet/connack.rs
@@ -1,3 +1,5 @@
+use heapless::Vec;
+
 use crate::{
     buffer::BufferProvider,
     config::{MaximumPacketSize, ReceiveMaximum, SessionExpiryInterval},
@@ -11,13 +13,13 @@ use crate::{
         AssignedClientIdentifier, AtMostOnceProperty, MaximumQoS, PropertyType, ReasonString,
         ResponseInformation, RetainAvailable, ServerKeepAlive, ServerReference,
         SharedSubscriptionAvailable, SubscriptionIdentifierAvailable, TopicAliasMaximum,
-        WildcardSubscriptionAvailable,
+        UserProperty, WildcardSubscriptionAvailable,
     },
 };
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct ConnackPacket<'p> {
+pub struct ConnackPacket<'p, const MAX_USER_PROPERTIES: usize> {
     pub session_present: bool,
     pub reason_code: ReasonCode,
 
@@ -30,6 +32,7 @@ pub struct ConnackPacket<'p> {
     pub assigned_client_identifier: Option<AssignedClientIdentifier<'p>>,
     pub topic_alias_maximum: Option<TopicAliasMaximum>,
     pub reason_string: Option<ReasonString<'p>>,
+    pub user_properties: Vec<UserProperty<'p>, MAX_USER_PROPERTIES>,
     pub wildcard_subscription_available: Option<WildcardSubscriptionAvailable>,
     pub subscription_identifier_available: Option<SubscriptionIdentifierAvailable>,
     pub shared_subscription_available: Option<SharedSubscriptionAvailable>,
@@ -42,10 +45,10 @@ pub struct ConnackPacket<'p> {
     // pub authentication_data: Option<AuthenticationData<'p>>,
 }
 
-impl Packet for ConnackPacket<'_> {
+impl<const MAX_USER_PROPERTIES: usize> Packet for ConnackPacket<'_, MAX_USER_PROPERTIES> {
     const PACKET_TYPE: PacketType = PacketType::Connack;
 }
-impl<'p> RxPacket<'p> for ConnackPacket<'p> {
+impl<'p, const MAX_USER_PROPERTIES: usize> RxPacket<'p> for ConnackPacket<'p, MAX_USER_PROPERTIES> {
     async fn receive<R: Read, B: BufferProvider<'p>>(
         header: &FixedHeader,
         mut reader: BodyReader<'_, 'p, R, B>,
@@ -98,26 +101,6 @@ impl<'p> RxPacket<'p> for ConnackPacket<'p> {
             return Err(RxError::ProtocolError);
         }
 
-        let mut packet = Self {
-            session_present: connack_flags > 0,
-            reason_code: connect_reason_code,
-
-            session_expiry_interval: None,
-            receive_maximum: None,
-            maximum_qos: None,
-            retain_available: None,
-            maximum_packet_size: None,
-            assigned_client_identifier: None,
-            topic_alias_maximum: None,
-            reason_string: None,
-            wildcard_subscription_available: None,
-            subscription_identifier_available: None,
-            shared_subscription_available: None,
-            server_keep_alive: None,
-            response_information: None,
-            server_reference: None,
-        };
-
         verbose!("reading property length field");
         let properties_length = VarByteInt::read(r).await?.size();
 
@@ -127,6 +110,22 @@ impl<'p> RxPacket<'p> for ConnackPacket<'p> {
             trace!("invalid CONNACK property length for remaining packet length");
             return Err(RxError::MalformedPacket);
         }
+
+        let mut session_expiry_interval = None;
+        let mut receive_maximum = None;
+        let mut maximum_qos = None;
+        let mut retain_available = None;
+        let mut maximum_packet_size = None;
+        let mut assigned_client_identifier = None;
+        let mut topic_alias_maximum = None;
+        let mut reason_string = None;
+        let mut user_properties = Vec::new();
+        let mut wildcard_subscription_available = None;
+        let mut subscription_identifier_available = None;
+        let mut shared_subscription_available = None;
+        let mut server_keep_alive = None;
+        let mut response_information = None;
+        let mut server_reference = None;
 
         let mut seen_authentication_method = false;
         let mut seen_authentication_data = false;
@@ -145,20 +144,29 @@ impl<'p> RxPacket<'p> for ConnackPacket<'p> {
             );
             #[rustfmt::skip]
             match property_type {
-                PropertyType::SessionExpiryInterval => packet.session_expiry_interval.try_set(r).await?,
-                PropertyType::ReceiveMaximum => packet.receive_maximum.try_set(r).await?,
-                PropertyType::MaximumQoS => packet.maximum_qos.try_set(r).await?,
-                PropertyType::RetainAvailable => packet.retain_available.try_set(r).await?,
-                PropertyType::MaximumPacketSize => packet.maximum_packet_size.try_set(r).await?,
-                PropertyType::AssignedClientIdentifier => packet.assigned_client_identifier.try_set(r).await?,
-                PropertyType::TopicAliasMaximum => packet.topic_alias_maximum.try_set(r).await?,
-                PropertyType::ReasonString => packet.reason_string.try_set(r).await?,
-                PropertyType::WildcardSubscriptionAvailable => packet.wildcard_subscription_available.try_set(r).await?,
-                PropertyType::SubscriptionIdentifierAvailable => packet.subscription_identifier_available.try_set(r).await?,
-                PropertyType::SharedSubscriptionAvailable => packet.shared_subscription_available.try_set(r).await?,
-                PropertyType::ServerKeepAlive => packet.server_keep_alive.try_set(r).await?,
-                PropertyType::ResponseInformation => packet.response_information.try_set(r).await?,
-                PropertyType::ServerReference => packet.server_reference.try_set(r).await?,
+                PropertyType::SessionExpiryInterval => session_expiry_interval.try_set(r).await?,
+                PropertyType::ReceiveMaximum => receive_maximum.try_set(r).await?,
+                PropertyType::MaximumQoS => maximum_qos.try_set(r).await?,
+                PropertyType::RetainAvailable => retain_available.try_set(r).await?,
+                PropertyType::MaximumPacketSize => maximum_packet_size.try_set(r).await?,
+                PropertyType::AssignedClientIdentifier => assigned_client_identifier.try_set(r).await?,
+                PropertyType::TopicAliasMaximum => topic_alias_maximum.try_set(r).await?,
+                PropertyType::ReasonString => reason_string.try_set(r).await?,
+                PropertyType::UserProperty if !user_properties.is_full() => {
+                    let user_property = UserProperty::read(r).await?;
+
+                    // Safety: `!Vec::is_full` guarantees there is space
+                    unsafe { user_properties.push_unchecked(user_property) };
+                },
+                PropertyType::UserProperty => {
+                    UserProperty::skip(r).await?;
+                },
+                PropertyType::WildcardSubscriptionAvailable => wildcard_subscription_available.try_set(r).await?,
+                PropertyType::SubscriptionIdentifierAvailable => subscription_identifier_available.try_set(r).await?,
+                PropertyType::SharedSubscriptionAvailable => shared_subscription_available.try_set(r).await?,
+                PropertyType::ServerKeepAlive => server_keep_alive.try_set(r).await?,
+                PropertyType::ResponseInformation => response_information.try_set(r).await?,
+                PropertyType::ServerReference => server_reference.try_set(r).await?,
                 PropertyType::AuthenticationMethod if seen_authentication_method => return Err(RxError::ProtocolError),
                 PropertyType::AuthenticationMethod => {
                     seen_authentication_method = true;
@@ -173,14 +181,6 @@ impl<'p> RxPacket<'p> for ConnackPacket<'p> {
                     verbose!("skipping authentication data ({} bytes)", len);
                     r.skip(len).await?;
                 },
-                PropertyType::UserProperty => {
-                    let len = u16::read(r).await? as usize;
-                    verbose!("skipping user property name ({} bytes)", len);
-                    r.skip(len).await?;
-                    let len = u16::read(r).await? as usize;
-                    verbose!("skipping user property value ({} bytes)", len);
-                    r.skip(len).await?;
-                },
                 p => {
                     // Malformed packet according to <https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901029>
                     trace!("invalid CONNACK property: {:?}", p);
@@ -189,7 +189,25 @@ impl<'p> RxPacket<'p> for ConnackPacket<'p> {
             };
         }
 
-        Ok(packet)
+        Ok(Self {
+            session_present: connack_flags > 0,
+            reason_code: connect_reason_code,
+            session_expiry_interval,
+            receive_maximum,
+            maximum_qos,
+            retain_available,
+            maximum_packet_size,
+            assigned_client_identifier,
+            topic_alias_maximum,
+            reason_string,
+            user_properties,
+            wildcard_subscription_available,
+            subscription_identifier_available,
+            shared_subscription_available,
+            server_keep_alive,
+            response_information,
+            server_reference,
+        })
     }
 }
 
@@ -200,13 +218,14 @@ mod unit {
     use crate::{
         config::{KeepAlive, MaximumPacketSize, ReceiveMaximum, SessionExpiryInterval},
         test::rx::decode,
-        types::{MqttString, QoS, ReasonCode},
+        types::{MqttString, MqttStringPair, QoS, ReasonCode},
         v5::{
             packet::ConnackPacket,
             property::{
                 AssignedClientIdentifier, MaximumQoS, ReasonString, ResponseInformation,
                 RetainAvailable, ServerKeepAlive, ServerReference, SharedSubscriptionAvailable,
-                SubscriptionIdentifierAvailable, TopicAliasMaximum, WildcardSubscriptionAvailable,
+                SubscriptionIdentifierAvailable, TopicAliasMaximum, UserProperty,
+                WildcardSubscriptionAvailable,
             },
         },
     };
@@ -214,7 +233,7 @@ mod unit {
     #[tokio::test]
     #[test_log::test]
     async fn decode_simple() {
-        let packet = decode!(ConnackPacket, 3, [0x20, 0x03, 0x01, 0x9D, 0x00]);
+        let packet = decode!(ConnackPacket<16>, 3, [0x20, 0x03, 0x01, 0x9D, 0x00]);
 
         assert_eq!(packet.reason_code, ReasonCode::ServerMoved);
         assert!(packet.session_present);
@@ -226,6 +245,7 @@ mod unit {
         assert!(packet.maximum_packet_size.is_none());
         assert!(packet.assigned_client_identifier.is_none());
         assert!(packet.topic_alias_maximum.is_none());
+        assert!(packet.user_properties.is_empty());
         assert!(packet.reason_string.is_none());
         assert!(packet.wildcard_subscription_available.is_none());
         assert!(packet.subscription_identifier_available.is_none());
@@ -242,7 +262,7 @@ mod unit {
     async fn decode_properties() {
         #[rustfmt::skip]
         let packet = decode!(
-            ConnackPacket,
+            ConnackPacket<16>,
             127,
             [
                 0x20, // packet type
@@ -332,6 +352,14 @@ mod unit {
         assert_eq!(
             packet.reason_string,
             Some(ReasonString(MqttString::try_from("OK").unwrap()))
+        );
+        assert_eq!(packet.user_properties.len(), 1);
+        assert_eq!(
+            packet.user_properties.first().unwrap(),
+            &UserProperty(MqttStringPair::new(
+                MqttString::try_from("key").unwrap(),
+                MqttString::try_from("value").unwrap()
+            ))
         );
         assert_eq!(
             packet.wildcard_subscription_available,

--- a/src/v5/packet/connect.rs
+++ b/src/v5/packet/connect.rs
@@ -1,5 +1,7 @@
 use core::num::NonZero;
 
+use heapless::Vec;
+
 use crate::{
     config::{KeepAlive, MaximumPacketSize, ReceiveMaximum, SessionExpiryInterval},
     eio::Write,
@@ -9,13 +11,13 @@ use crate::{
     types::{MqttBinary, MqttString, QoS, VarByteInt, Will},
     v5::property::{
         AuthenticationData, AuthenticationMethod, RequestProblemInformation,
-        RequestResponseInformation, TopicAliasMaximum,
+        RequestResponseInformation, TopicAliasMaximum, UserProperty,
     },
 };
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct ConnectPacket<'p> {
+pub struct ConnectPacket<'p, const MAX_USER_PROPERTIES: usize> {
     // CONNECT connect flags (will flag is implicit due to `will` being an Option<T>)
     will_retain: bool,
     will_qos: QoS,
@@ -31,6 +33,7 @@ pub struct ConnectPacket<'p> {
     topic_alias_maximum: Option<TopicAliasMaximum>,
     request_response_information: Option<RequestResponseInformation>,
     request_problem_information: Option<RequestProblemInformation>,
+    user_properties: Vec<UserProperty<'p>, MAX_USER_PROPERTIES>,
     authentication_method: Option<AuthenticationMethod<'p>>,
     authentication_data: Option<AuthenticationData<'p>>,
 
@@ -39,17 +42,17 @@ pub struct ConnectPacket<'p> {
     client_identifier: MqttString<'p>,
 
     /// Has to be present if `will_flag` is set
-    will: Option<Will<'p>>,
+    will: Option<Will<'p, MAX_USER_PROPERTIES>>,
 
     /// Has to be present if `user_name` flag is set
     user_name: Option<MqttString<'p>>,
     /// Has to be present if `password` flag is set
     password: Option<MqttBinary<'p>>,
 }
-impl Packet for ConnectPacket<'_> {
+impl<const MAX_USER_PROPERTIES: usize> Packet for ConnectPacket<'_, MAX_USER_PROPERTIES> {
     const PACKET_TYPE: PacketType = PacketType::Connect;
 }
-impl TxPacket for ConnectPacket<'_> {
+impl<const MAX_USER_PROPERTIES: usize> TxPacket for ConnectPacket<'_, MAX_USER_PROPERTIES> {
     fn remaining_len(&self) -> VarByteInt {
         let variable_header_length = wlen!([u8; 7]) + wlen!(u8) + wlen!(u16);
 
@@ -63,11 +66,14 @@ impl TxPacket for ConnectPacket<'_> {
 
         let total_length = variable_header_length + total_properties_length + body_length;
 
-        // Invariant: Max length = 393253 < VarByteInt::MAX_ENCODABLE
-        // variable header: 8
+        // max length: MAX_USER_PROPERTIES * 2 * 131077 + 654882
+        // Invariant: MAX_USER_PROPERTIES <= 1021 => max length <= VarByteInt::MAX_ENCODABLE
+        //
+        // variable header: 10
         // property length: 4
-        // properties: 131093
-        // will: 2 * 65537 (will topic & will payload)
+        // properties: MAX_USER_PROPERTIES * 131077 + 131093
+        // will: MAX_USER_PROPERTIES * 131077 + 327704
+        // client identifier: 65357
         // username: 65537
         // password: 65537
         VarByteInt::new_unchecked(total_length as u32)
@@ -103,6 +109,11 @@ impl TxPacket for ConnectPacket<'_> {
         self.topic_alias_maximum.write(write).await?;
         self.request_response_information.write(write).await?;
         self.request_problem_information.write(write).await?;
+
+        for user_property in &self.user_properties {
+            user_property.write(write).await?;
+        }
+
         self.authentication_method.write(write).await?;
         self.authentication_data.write(write).await?;
 
@@ -115,7 +126,8 @@ impl TxPacket for ConnectPacket<'_> {
     }
 }
 
-impl<'p> ConnectPacket<'p> {
+impl<'p, const MAX_USER_PROPERTIES: usize> ConnectPacket<'p, MAX_USER_PROPERTIES> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         client_identifier: MqttString<'p>,
         clean_start: bool,
@@ -124,6 +136,7 @@ impl<'p> ConnectPacket<'p> {
         session_expiry_interval: SessionExpiryInterval,
         receive_maximum: NonZero<u16>,
         request_response_information: bool,
+        user_properties: Vec<UserProperty<'p>, MAX_USER_PROPERTIES>,
     ) -> Self {
         Self {
             will_retain: false,
@@ -138,6 +151,7 @@ impl<'p> ConnectPacket<'p> {
                 .then_some(true)
                 .map(Into::into),
             request_problem_information: None,
+            user_properties,
             authentication_method: None,
             authentication_data: None,
             client_identifier,
@@ -161,15 +175,23 @@ impl<'p> ConnectPacket<'p> {
             + self.topic_alias_maximum.written_len()
             + self.request_response_information.written_len()
             + self.request_problem_information.written_len()
+            + self
+                .user_properties
+                .iter()
+                .map(Writable::written_len)
+                .sum::<usize>()
             + self.authentication_method.written_len()
             + self.authentication_data.written_len();
 
-        // Invariant: Max length = 131093 < VarByteInt::MAX_ENCODABLE
+        // max length = MAX_USER_PROPERTIES * 131077 + 131093
+        // Invariant: MAX_USER_PROPERTIES <= 2046 => max length <= VarByteInt::MAX_ENCODABLE
+        //
         // session expiry interval: 5
         // maximum packet size: 5
         // topic alias maximum: 3
         // request response information: 2
         // request problem information: 2
+        // user properties: MAX_USER_PROPERTIES * 131077
         // authentication method: 65538
         // authentication data: 65538
         VarByteInt::new_unchecked(len as u32)
@@ -182,7 +204,12 @@ impl<'p> ConnectPacket<'p> {
         self.password = Some(password);
     }
 
-    pub fn add_will(&mut self, will: Will<'p>, will_qos: QoS, will_retain: bool) {
+    pub fn add_will(
+        &mut self,
+        will: Will<'p, MAX_USER_PROPERTIES>,
+        will_qos: QoS,
+        will_retain: bool,
+    ) {
         self.will_retain = will_retain;
         self.will_qos = will_qos;
         self.will = Some(will);
@@ -193,14 +220,17 @@ impl<'p> ConnectPacket<'p> {
 mod unit {
     use core::num::NonZero;
 
+    use heapless::Vec;
+
     use crate::{
         config::{KeepAlive, MaximumPacketSize, SessionExpiryInterval},
         test::tx::encode,
-        types::{MqttBinary, MqttString, QoS, TopicName, Will},
+        types::{MqttBinary, MqttString, MqttStringPair, QoS, TopicName, Will},
         v5::{
             packet::ConnectPacket,
             property::{
-                ContentType, MessageExpiryInterval, PayloadFormatIndicator, WillDelayInterval,
+                ContentType, MessageExpiryInterval, PayloadFormatIndicator, UserProperty,
+                WillDelayInterval,
             },
         },
     };
@@ -208,7 +238,7 @@ mod unit {
     #[tokio::test]
     #[test_log::test]
     async fn encode_simple() {
-        let packet = ConnectPacket::new(
+        let packet = ConnectPacket::<16>::new(
             MqttString::try_from("a").unwrap(),
             true,
             KeepAlive::Seconds(NonZero::new(7439).unwrap()),
@@ -216,6 +246,7 @@ mod unit {
             SessionExpiryInterval::EndOnDisconnect,
             NonZero::new(u16::MAX).unwrap(),
             false,
+            Vec::new(),
         );
 
         #[rustfmt::skip]
@@ -242,7 +273,7 @@ mod unit {
     #[tokio::test]
     #[test_log::test]
     async fn encode_properties() {
-        let packet = ConnectPacket::new(
+        let packet = ConnectPacket::<16>::new(
             MqttString::try_from("a").unwrap(),
             false,
             KeepAlive::Infinite,
@@ -250,12 +281,27 @@ mod unit {
             SessionExpiryInterval::Seconds(8136391),
             NonZero::new(63543).unwrap(),
             true,
+            [
+                UserProperty(MqttStringPair::new(
+                    MqttString::from_str("triple 1").unwrap(),
+                    MqttString::from_str("tick").unwrap(),
+                )),
+                UserProperty(MqttStringPair::new(
+                    MqttString::from_str("triple 2").unwrap(),
+                    MqttString::from_str("trick").unwrap(),
+                )),
+                UserProperty(MqttStringPair::new(
+                    MqttString::from_str("triple 3").unwrap(),
+                    MqttString::from_str("track").unwrap(),
+                )),
+            ]
+            .into(),
         );
 
         #[rustfmt::skip]
         encode!(packet, [
             0x10,       //
-            0x1D,       // remaining length
+            0x52,       // remaining length
             0x00,       // ---
             0x04,       //
             b'M',       //
@@ -266,7 +312,7 @@ mod unit {
             0b00000000, // Connect flags
             0x00,       // Keep alive MSB
             0x00,       // Keep alive LSB
-            0x0F,       // Property length
+            0x44,       // Property length
 
             0x11,       // Session expiry interval
             0x00, 0x7C, 0x26, 0xC7,
@@ -280,6 +326,16 @@ mod unit {
             0x19,       // Request response information
             0x01,
 
+            0x26,       // User property
+            0x00, 0x08, b't', b'r', b'i', b'p', b'l', b'e', b' ', b'1', 
+            0x00, 0x04, b't', b'i', b'c', b'k',
+            0x26,       // User property
+            0x00, 0x08, b't', b'r', b'i', b'p', b'l', b'e', b' ', b'2', 
+            0x00, 0x05, b't', b'r', b'i', b'c', b'k',
+            0x26,       // User property
+            0x00, 0x08, b't', b'r', b'i', b'p', b'l', b'e', b' ', b'3', 
+            0x00, 0x05, b't', b'r', b'a', b'c', b'k',
+
             0x00,       // Client identifier len MSB
             0x01,       // Client identifier len LSB
             b'a',       // Client identifier
@@ -289,7 +345,7 @@ mod unit {
     #[tokio::test]
     #[test_log::test]
     async fn encode_payload() {
-        let mut packet = ConnectPacket::new(
+        let mut packet = ConnectPacket::<16>::new(
             MqttString::try_from("giuqen").unwrap(),
             false,
             KeepAlive::Seconds(NonZero::new(6789).unwrap()),
@@ -297,6 +353,7 @@ mod unit {
             SessionExpiryInterval::EndOnDisconnect,
             NonZero::new(u16::MAX).unwrap(),
             false,
+            Vec::new(),
         );
 
         packet.add_user_name(MqttString::try_from("Franz").unwrap());
@@ -351,7 +408,7 @@ mod unit {
     #[tokio::test]
     #[test_log::test]
     async fn encode_will() {
-        let mut packet = ConnectPacket::new(
+        let mut packet = ConnectPacket::<16>::new(
             MqttString::try_from("cba").unwrap(),
             false,
             KeepAlive::Seconds(NonZero::new(6789).unwrap()),
@@ -359,6 +416,7 @@ mod unit {
             SessionExpiryInterval::Seconds(893475),
             NonZero::new(u16::MAX).unwrap(),
             true,
+            Vec::new(),
         );
 
         packet.add_user_name(MqttString::try_from("Franz").unwrap());
@@ -372,6 +430,7 @@ mod unit {
                 content_type: Some(ContentType(MqttString::try_from("text/plain").unwrap())),
                 response_topic: None,
                 correlation_data: None,
+                user_properties: Vec::new(),
                 will_message: MqttBinary::try_from([12, 8, 98].as_slice()).unwrap(),
             },
             QoS::ExactlyOnce,

--- a/src/v5/packet/disconnect.rs
+++ b/src/v5/packet/disconnect.rs
@@ -150,15 +150,13 @@ impl<'p, const MAX_USER_PROPERTIES: usize> RxPacket<'p>
             };
         }
 
-        let packet = Self {
+        Ok(Self {
             reason_code: disconnect_reason_code,
             session_expiry_interval: None,
             reason_string,
             user_properties,
             server_reference,
-        };
-
-        Ok(packet)
+        })
     }
 }
 impl<const MAX_USER_PROPERTIES: usize> TxPacket for DisconnectPacket<'_, MAX_USER_PROPERTIES> {

--- a/src/v5/packet/disconnect.rs
+++ b/src/v5/packet/disconnect.rs
@@ -1,3 +1,5 @@
+use heapless::Vec;
+
 #[cfg(test)]
 use crate::types::MqttString;
 use crate::{
@@ -12,24 +14,27 @@ use crate::{
     },
     packet::{Packet, RxError, RxPacket, TxError, TxPacket},
     types::{ReasonCode, VarByteInt},
-    v5::property::{AtMostOnceProperty, PropertyType, ReasonString, ServerReference},
+    v5::property::{AtMostOnceProperty, PropertyType, ReasonString, ServerReference, UserProperty},
 };
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct DisconnectPacket<'p> {
+pub struct DisconnectPacket<'p, const MAX_USER_PROPERTIES: usize> {
     pub reason_code: ReasonCode,
 
     /// Never sent by server
     pub session_expiry_interval: Option<SessionExpiryInterval>,
     pub reason_string: Option<ReasonString<'p>>,
+    pub user_properties: Vec<UserProperty<'p>, MAX_USER_PROPERTIES>,
     pub server_reference: Option<ServerReference<'p>>,
 }
 
-impl Packet for DisconnectPacket<'_> {
+impl<const MAX_USER_PROPERTIES: usize> Packet for DisconnectPacket<'_, MAX_USER_PROPERTIES> {
     const PACKET_TYPE: PacketType = PacketType::Disconnect;
 }
-impl<'p> RxPacket<'p> for DisconnectPacket<'p> {
+impl<'p, const MAX_USER_PROPERTIES: usize> RxPacket<'p>
+    for DisconnectPacket<'p, MAX_USER_PROPERTIES>
+{
     async fn receive<R: Read, B: BufferProvider<'p>>(
         header: &FixedHeader,
         mut reader: BodyReader<'_, 'p, R, B>,
@@ -91,13 +96,6 @@ impl<'p> RxPacket<'p> for DisconnectPacket<'p> {
             return Err(RxError::ProtocolError);
         }
 
-        let mut packet = Self {
-            reason_code: disconnect_reason_code,
-            session_expiry_interval: None,
-            reason_string: None,
-            server_reference: None,
-        };
-
         let properties_length = if header.remaining_len.size() < 2 {
             verbose!("DISCONNECT packet has implicit property length = 0");
             0
@@ -113,6 +111,10 @@ impl<'p> RxPacket<'p> for DisconnectPacket<'p> {
             return Err(RxError::MalformedPacket);
         }
 
+        let mut reason_string = None;
+        let mut user_properties = Vec::new();
+        let mut server_reference = None;
+
         while r.remaining_len() > 0 {
             verbose!(
                 "reading property identifier (remaining length: {} bytes)",
@@ -127,18 +129,19 @@ impl<'p> RxPacket<'p> for DisconnectPacket<'p> {
             );
             #[rustfmt::skip]
             match property_type {
-                PropertyType::ReasonString => packet.reason_string.try_set(r).await?,
-                PropertyType::ServerReference => packet.server_reference.try_set(r).await?,
-                PropertyType::UserProperty => {
-                    let len = u16::read(r).await? as usize;
-                    verbose!("skipping user property name ({} bytes)", len);
-                    r.skip(len).await?;
-                    let len = u16::read(r).await? as usize;
-                    verbose!("skipping user property value ({} bytes)", len);
-                    r.skip(len).await?;
-                },
                 // Protocol error according to [MQTT-3.14.2-2]
                 PropertyType::SessionExpiryInterval => return Err(RxError::ProtocolError),
+                PropertyType::ReasonString => reason_string.try_set(r).await?,
+                PropertyType::UserProperty if !user_properties.is_full() => {
+                    let user_property = UserProperty::read(r).await?;
+
+                    // Safety: `!Vec::is_full` guarantees there is space
+                    unsafe { user_properties.push_unchecked(user_property) };
+                },
+                PropertyType::UserProperty => {
+                    UserProperty::skip(r).await?;
+                },
+                PropertyType::ServerReference => server_reference.try_set(r).await?,
                 // Malformed packet according to <https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901029>
                 p => {
                     trace!("invalid DISCONNECT property: {:?}", p);
@@ -147,10 +150,18 @@ impl<'p> RxPacket<'p> for DisconnectPacket<'p> {
             };
         }
 
+        let packet = Self {
+            reason_code: disconnect_reason_code,
+            session_expiry_interval: None,
+            reason_string,
+            user_properties,
+            server_reference,
+        };
+
         Ok(packet)
     }
 }
-impl TxPacket for DisconnectPacket<'_> {
+impl<const MAX_USER_PROPERTIES: usize> TxPacket for DisconnectPacket<'_, MAX_USER_PROPERTIES> {
     async fn send<W: Write>(&self, write: &mut W) -> Result<(), TxError<W::Error>> {
         FixedHeader::new(Self::PACKET_TYPE, 0x00, self.remaining_len())
             .write(write)
@@ -163,6 +174,11 @@ impl TxPacket for DisconnectPacket<'_> {
 
         self.session_expiry_interval.write(write).await?;
         self.reason_string.write(write).await?;
+
+        for user_property in &self.user_properties {
+            user_property.write(write).await?;
+        }
+
         self.server_reference.write(write).await?;
 
         Ok(())
@@ -176,20 +192,25 @@ impl TxPacket for DisconnectPacket<'_> {
 
         let total_length = variable_header_length + total_properties_length;
 
-        // Invariant: Max length: 131086 < VarByteInt::MAX_ENCODABLE
+        // max length = MAX_USER_PROPERTIES * 131077 + 131086
+        // Invariant: MAX_USER_PROPERTIES <= 2046 => max length <= VarByteInt::MAX_ENCODABLE
         // variable header (reason_code): 1
         // property length: 4
-        // properties: 131081
+        // properties: MAX_USER_PROPERTIES * 131077 + 131081
         VarByteInt::new_unchecked(total_length as u32)
     }
 }
 
-impl<'p> DisconnectPacket<'p> {
-    pub const fn new(reason_code: ReasonCode) -> Self {
+impl<'p, const MAX_USER_PROPERTIES: usize> DisconnectPacket<'p, MAX_USER_PROPERTIES> {
+    pub const fn new(
+        reason_code: ReasonCode,
+        user_properties: Vec<UserProperty<'p>, MAX_USER_PROPERTIES>,
+    ) -> Self {
         Self {
             reason_code,
             session_expiry_interval: None,
             reason_string: None,
+            user_properties,
             server_reference: None,
         }
     }
@@ -206,11 +227,19 @@ impl<'p> DisconnectPacket<'p> {
     fn properties_length(&self) -> VarByteInt {
         let len = self.session_expiry_interval.written_len()
             + self.reason_string.written_len()
+            + self
+                .user_properties
+                .iter()
+                .map(Writable::written_len)
+                .sum::<usize>()
             + self.server_reference.written_len();
 
-        // Invariant: Max length = 131081 < VarByteInt::MAX_ENCODABLE
+        // max length = MAX_USER_PROPERTIES * 131077 + 131081
+        // Invariant: MAX_USER_PROPERTIES <= 2046 => max length <= VarByteInt::MAX_ENCODABLE
+        //
         // session expiry interval: 5
         // reason string: 65538
+        // user properties: MAX_USER_PROPERTIES * 131077
         // server reference: 65538
         VarByteInt::new_unchecked(len as u32)
     }
@@ -218,20 +247,22 @@ impl<'p> DisconnectPacket<'p> {
 
 #[cfg(test)]
 mod unit {
+    use heapless::Vec;
+
     use crate::{
         config::SessionExpiryInterval,
         test::{rx::decode, tx::encode},
-        types::{MqttString, ReasonCode},
+        types::{MqttString, MqttStringPair, ReasonCode},
         v5::{
             packet::DisconnectPacket,
-            property::{ReasonString, ServerReference},
+            property::{ReasonString, ServerReference, UserProperty},
         },
     };
 
     #[tokio::test]
     #[test_log::test]
     async fn encode_simple() {
-        let packet = DisconnectPacket::new(ReasonCode::MaximumConnectTime);
+        let packet = DisconnectPacket::<16>::new(ReasonCode::MaximumConnectTime, Vec::new());
 
         #[rustfmt::skip]
         encode!(packet, [
@@ -245,20 +276,44 @@ mod unit {
     #[tokio::test]
     #[test_log::test]
     async fn encode_properties() {
-        let mut packet = DisconnectPacket::new(ReasonCode::MaximumConnectTime);
+        let mut packet = DisconnectPacket::<16>::new(
+            ReasonCode::MaximumConnectTime,
+            [
+                UserProperty(MqttStringPair::new(
+                    MqttString::from_str("status").unwrap(),
+                    MqttString::from_str("dead").unwrap(),
+                )),
+                UserProperty(MqttStringPair::new(
+                    MqttString::from_str("cause").unwrap(),
+                    MqttString::from_str("tripped on the wifi").unwrap(),
+                )),
+            ]
+            .into(),
+        );
         packet.add_session_expiry_interval(SessionExpiryInterval::Seconds(23089475));
         packet.add_reason_string(MqttString::try_from("Accroitre Momentum").unwrap());
 
         #[rustfmt::skip]
         encode!(packet, [
                 0xE0, //
-                0x1C, // remaining length
+                0x48, // remaining length
                 0xA0, // reason code
-                0x1A, // property length
+                0x46, // property length
+                
                 // Session Expiry Interval
-                0x11, 0x01, 0x60, 0x51, 0x43, // Reason String
+                0x11, 0x01, 0x60, 0x51, 0x43, 
+                
+                // Reason String
                 0x1F, 0x00, 0x12, b'A', b'c', b'c', b'r', b'o', b'i', b't', b'r', b'e', b' ', b'M',
                 b'o', b'm', b'e', b'n', b't', b'u', b'm',
+
+                0x26,       // User property
+                0x00, 0x06, b's', b't', b'a', b't', b'u', b's', 
+                0x00, 0x04, b'd', b'e', b'a', b'd',
+
+                0x26,       // User property
+                0x00, 0x05, b'c', b'a', b'u', b's', b'e', 
+                0x00, 0x13, b't', b'r', b'i', b'p', b'p', b'e', b'd', b' ', b'o', b'n', b' ', b't', b'h', b'e', b' ', b'w', b'i', b'f', b'i', 
             ]
         );
     }
@@ -266,7 +321,7 @@ mod unit {
     #[tokio::test]
     #[test_log::test]
     async fn encode_zero_session_expiry_interval() {
-        let mut packet = DisconnectPacket::new(ReasonCode::MaximumConnectTime);
+        let mut packet = DisconnectPacket::<16>::new(ReasonCode::MaximumConnectTime, Vec::new());
         packet.add_session_expiry_interval(SessionExpiryInterval::EndOnDisconnect);
 
         #[rustfmt::skip]
@@ -284,33 +339,36 @@ mod unit {
     #[tokio::test]
     #[test_log::test]
     async fn decode_simple() {
-        let packet = decode!(DisconnectPacket, 2, [0xE0, 0x02, 0x94, 0x00]);
+        let packet = decode!(DisconnectPacket<16>, 2, [0xE0, 0x02, 0x94, 0x00]);
 
         assert_eq!(packet.reason_code, ReasonCode::TopicAliasInvalid);
         assert!(packet.session_expiry_interval.is_none());
         assert!(packet.reason_string.is_none());
+        assert!(packet.user_properties.is_empty());
         assert!(packet.server_reference.is_none());
     }
 
     #[tokio::test]
     #[test_log::test]
     async fn decode_abbreviated() {
-        let packet = decode!(DisconnectPacket, 1, [0xE0, 0x01, 0x8E]);
+        let packet = decode!(DisconnectPacket<16>, 1, [0xE0, 0x01, 0x8E]);
 
         assert_eq!(packet.reason_code, ReasonCode::SessionTakenOver);
         assert!(packet.session_expiry_interval.is_none());
         assert!(packet.reason_string.is_none());
+        assert!(packet.user_properties.is_empty());
         assert!(packet.server_reference.is_none());
     }
 
     #[tokio::test]
     #[test_log::test]
     async fn decode_minimal() {
-        let packet = decode!(DisconnectPacket, 0, [0xE0, 0x00]);
+        let packet = decode!(DisconnectPacket<16>, 0, [0xE0, 0x00]);
 
         assert_eq!(packet.reason_code, ReasonCode::Success);
         assert!(packet.session_expiry_interval.is_none());
         assert!(packet.reason_string.is_none());
+        assert!(packet.user_properties.is_empty());
         assert!(packet.server_reference.is_none());
     }
 
@@ -318,7 +376,7 @@ mod unit {
     #[test_log::test]
     async fn decode_properties() {
         #[rustfmt::skip]
-        let packet = decode!(DisconnectPacket, 50, [
+        let packet = decode!(DisconnectPacket<16>, 50, [
             0xE0,
             0x32,
             0x04, // Reason code
@@ -344,6 +402,19 @@ mod unit {
         assert_eq!(
             packet.reason_string,
             Some(ReasonString(MqttString::try_from("deadbeef").unwrap()))
+        );
+        assert_eq!(
+            packet.user_properties.as_slice(),
+            &[
+                UserProperty(MqttStringPair::new(
+                    MqttString::from_str("lol").unwrap(),
+                    MqttString::from_str("hey").unwrap()
+                )),
+                UserProperty(MqttStringPair::new(
+                    MqttString::from_str("lol").unwrap(),
+                    MqttString::from_str("bang").unwrap()
+                ))
+            ]
         );
         assert_eq!(
             packet.server_reference,

--- a/src/v5/packet/disconnect.rs
+++ b/src/v5/packet/disconnect.rs
@@ -421,4 +421,36 @@ mod unit {
             ))
         );
     }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn decode_incomplete_user_properties() {
+        #[rustfmt::skip]
+        let packet = decode!(DisconnectPacket<1>, 29, [
+            0xE0,
+            0x1D,
+            0x00, // Reason code
+            0x1B, // Property length
+
+            // User Property
+            0x26, 0x00, 0x02, b'k', b'1',
+                  0x00, 0x02, b'v', b'1',
+
+            // User Property
+            0x26, 0x00, 0x02, b'k', b'2',
+                  0x00, 0x02, b'v', b'2',
+
+            // User Property
+            0x26, 0x00, 0x02, b'k', b'3',
+                  0x00, 0x02, b'v', b'3',
+        ]);
+
+        assert_eq!(
+            packet.user_properties.as_slice(),
+            &[UserProperty(MqttStringPair::new(
+                MqttString::from_str("k1").unwrap(),
+                MqttString::from_str("v1").unwrap()
+            ))]
+        );
+    }
 }

--- a/src/v5/packet/mod.rs
+++ b/src/v5/packet/mod.rs
@@ -14,7 +14,7 @@ pub use connack::ConnackPacket;
 pub use connect::ConnectPacket;
 pub use disconnect::DisconnectPacket;
 pub use pings::{PingreqPacket, PingrespPacket};
-pub use pubacks::*;
+pub use pubacks::{GenericPubackPacket, PubackPacket, PubcompPacket, PubrecPacket, PubrelPacket};
 pub use publish::PublishPacket;
 pub use subacks::{SubackPacket, UnsubackPacket};
 pub use subscribe::SubscribePacket;

--- a/src/v5/packet/pings/mod.rs
+++ b/src/v5/packet/pings/mod.rs
@@ -48,7 +48,7 @@ impl<'p, T: PingPacketType> RxPacket<'p> for GenericPingPacket<T> {
 }
 impl<T: PingPacketType> TxPacket for GenericPingPacket<T> {
     fn remaining_len(&self) -> VarByteInt {
-        // Invariant: 0 < VarByteInt::MAX_ENCODABLE
+        // Invariant: 0 <= VarByteInt::MAX_ENCODABLE
         VarByteInt::new_unchecked(0)
     }
 

--- a/src/v5/packet/pubacks/mod.rs
+++ b/src/v5/packet/pubacks/mod.rs
@@ -333,6 +333,44 @@ mod unit {
                 ))
             );
         }
+
+        #[tokio::test]
+        #[test_log::test]
+        async fn decode_incomplete_user_properties() {
+            #[rustfmt::skip]
+            let packet = decode!(PubackPacket<2>, 31, [
+                0x40, 0x1F,
+                0x12, 0x34, // Packet Identifier
+                0x00,       // Reason Code
+                0x1B,       // Property length
+
+                // User Property
+                0x26, 0x00, 0x02, b'k', b'1',
+                      0x00, 0x02, b'v', b'1',
+
+                // User Property
+                0x26, 0x00, 0x02, b'k', b'2',
+                      0x00, 0x02, b'v', b'2',
+
+                // User Property
+                0x26, 0x00, 0x02, b'k', b'3',
+                      0x00, 0x02, b'v', b'3',
+            ]);
+
+            assert_eq!(
+                packet.user_properties.as_slice(),
+                &[
+                    UserProperty(MqttStringPair::new(
+                        MqttString::try_from("k1").unwrap(),
+                        MqttString::try_from("v1").unwrap()
+                    )),
+                    UserProperty(MqttStringPair::new(
+                        MqttString::try_from("k2").unwrap(),
+                        MqttString::try_from("v2").unwrap()
+                    ))
+                ]
+            );
+        }
     }
 
     mod rec {
@@ -439,6 +477,38 @@ mod unit {
                     MqttString::try_from("test-name").unwrap(),
                     MqttString::try_from("test-value").unwrap()
                 ))
+            );
+        }
+
+        #[tokio::test]
+        #[test_log::test]
+        async fn decode_incomplete_user_properties() {
+            #[rustfmt::skip]
+            let packet = decode!(PubrecPacket<1>, 31, [
+                0x50, 0x1F,
+                0x12, 0x34, // Packet Identifier
+                0x00,       // Reason Code
+                0x1B,       // Property length
+
+                // User Property
+                0x26, 0x00, 0x02, b'k', b'1',
+                      0x00, 0x02, b'v', b'1',
+
+                // User Property
+                0x26, 0x00, 0x02, b'k', b'2',
+                      0x00, 0x02, b'v', b'2',
+
+                // User Property
+                0x26, 0x00, 0x02, b'k', b'3',
+                      0x00, 0x02, b'v', b'3',
+            ]);
+
+            assert_eq!(
+                packet.user_properties.as_slice(),
+                &[UserProperty(MqttStringPair::new(
+                    MqttString::try_from("k1").unwrap(),
+                    MqttString::try_from("v1").unwrap()
+                ))]
             );
         }
     }
@@ -556,6 +626,38 @@ mod unit {
                 ))
             );
         }
+
+        #[tokio::test]
+        #[test_log::test]
+        async fn decode_incomplete_user_properties() {
+            #[rustfmt::skip]
+            let packet = decode!(PubrelPacket<1>, 31, [
+                0x62, 0x1F,
+                0x12, 0x34, // Packet Identifier
+                0x00,       // Reason Code
+                0x1B,       // Property length
+
+                // User Property
+                0x26, 0x00, 0x02, b'k', b'1',
+                      0x00, 0x02, b'v', b'1',
+
+                // User Property
+                0x26, 0x00, 0x02, b'k', b'2',
+                      0x00, 0x02, b'v', b'2',
+
+                // User Property
+                0x26, 0x00, 0x02, b'k', b'3',
+                      0x00, 0x02, b'v', b'3',
+            ]);
+
+            assert_eq!(
+                packet.user_properties.as_slice(),
+                &[UserProperty(MqttStringPair::new(
+                    MqttString::try_from("k1").unwrap(),
+                    MqttString::try_from("v1").unwrap()
+                ))]
+            );
+        }
     }
 
     mod comp {
@@ -663,6 +765,44 @@ mod unit {
                     MqttString::try_from("test-name").unwrap(),
                     MqttString::try_from("test-value").unwrap()
                 ))
+            );
+        }
+
+        #[tokio::test]
+        #[test_log::test]
+        async fn decode_incomplete_user_properties() {
+            #[rustfmt::skip]
+            let packet = decode!(PubcompPacket<2>, 31, [
+                0x70, 0x1F,
+                0x12, 0x34, // Packet Identifier
+                0x00,       // Reason Code
+                0x1B,       // Property length
+
+                // User Property
+                0x26, 0x00, 0x02, b'k', b'1', 
+                      0x00, 0x02, b'v', b'1',
+
+                // User Property
+                0x26, 0x00, 0x02, b'k', b'2', 
+                      0x00, 0x02, b'v', b'2',
+
+                // User Property
+                0x26, 0x00, 0x02, b'k', b'3', 
+                      0x00, 0x02, b'v', b'3',
+            ]);
+
+            assert_eq!(
+                packet.user_properties.as_slice(),
+                &[
+                    UserProperty(MqttStringPair::new(
+                        MqttString::try_from("k1").unwrap(),
+                        MqttString::try_from("v1").unwrap()
+                    )),
+                    UserProperty(MqttStringPair::new(
+                        MqttString::try_from("k2").unwrap(),
+                        MqttString::try_from("v2").unwrap()
+                    ))
+                ]
             );
         }
     }

--- a/src/v5/packet/pubacks/mod.rs
+++ b/src/v5/packet/pubacks/mod.rs
@@ -4,6 +4,8 @@
 
 use core::marker::PhantomData;
 
+use heapless::Vec;
+
 use crate::{
     buffer::BufferProvider,
     eio::{Read, Write},
@@ -17,31 +19,40 @@ use crate::{
     types::{PacketIdentifier, ReasonCode, VarByteInt},
     v5::{
         packet::pubacks::types::{Ack, Comp, PubackPacketType, Rec, Rel},
-        property::PropertyType,
+        property::{PropertyType, UserProperty},
     },
 };
 
 mod types;
 
-pub type PubackPacket<'p> = GenericPubackPacket<'p, Ack>;
-pub type PubrecPacket<'p> = GenericPubackPacket<'p, Rec>;
-pub type PubrelPacket<'p> = GenericPubackPacket<'p, Rel>;
-pub type PubcompPacket<'p> = GenericPubackPacket<'p, Comp>;
+pub type PubackPacket<'p, const MAX_USER_PROPERTIES: usize> =
+    GenericPubackPacket<'p, Ack, MAX_USER_PROPERTIES>;
+pub type PubrecPacket<'p, const MAX_USER_PROPERTIES: usize> =
+    GenericPubackPacket<'p, Rec, MAX_USER_PROPERTIES>;
+pub type PubrelPacket<'p, const MAX_USER_PROPERTIES: usize> =
+    GenericPubackPacket<'p, Rel, MAX_USER_PROPERTIES>;
+pub type PubcompPacket<'p, const MAX_USER_PROPERTIES: usize> =
+    GenericPubackPacket<'p, Comp, MAX_USER_PROPERTIES>;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct GenericPubackPacket<'p, T: PubackPacketType> {
+pub struct GenericPubackPacket<'p, T, const MAX_USER_PROPERTIES: usize> {
     pub packet_identifier: PacketIdentifier,
     pub reason_code: ReasonCode,
     // reason string is currently unused and does not have to be read into memory.
     // reason_string: Option<ReasonString<'p>>,
+    pub user_properties: Vec<UserProperty<'p>, MAX_USER_PROPERTIES>,
     _phantom_data: PhantomData<&'p T>,
 }
 
-impl<T: PubackPacketType> Packet for GenericPubackPacket<'_, T> {
+impl<T: PubackPacketType, const MAX_USER_PROPERTIES: usize> Packet
+    for GenericPubackPacket<'_, T, MAX_USER_PROPERTIES>
+{
     const PACKET_TYPE: PacketType = T::PACKET_TYPE;
 }
-impl<'p, T: PubackPacketType> RxPacket<'p> for GenericPubackPacket<'p, T> {
+impl<'p, T: PubackPacketType, const MAX_USER_PROPERTIES: usize> RxPacket<'p>
+    for GenericPubackPacket<'p, T, MAX_USER_PROPERTIES>
+{
     async fn receive<R: Read, B: BufferProvider<'p>>(
         header: &FixedHeader,
         mut reader: BodyReader<'_, 'p, R, B>,
@@ -74,8 +85,6 @@ impl<'p, T: PubackPacketType> RxPacket<'p> for GenericPubackPacket<'p, T> {
             c
         };
 
-        let mut seen_reason_string = false;
-
         let properties_length = if header.remaining_len.value() < 4 {
             0
         } else {
@@ -92,6 +101,9 @@ impl<'p, T: PubackPacketType> RxPacket<'p> for GenericPubackPacket<'p, T> {
             );
             return Err(RxError::MalformedPacket);
         }
+
+        let mut seen_reason_string = false;
+        let mut user_properties = Vec::new();
 
         while r.remaining_len() > 0 {
             verbose!(
@@ -114,13 +126,14 @@ impl<'p, T: PubackPacketType> RxPacket<'p> for GenericPubackPacket<'p, T> {
                     verbose!("skipping reason string ({} bytes)", len);
                     r.skip(len).await?;
                 },
+                PropertyType::UserProperty if !user_properties.is_full() => {
+                    let user_property = UserProperty::read(r).await?;
+
+                    // Safety: `!Vec::is_full` guarantees there is space
+                    unsafe { user_properties.push_unchecked(user_property) };
+                },
                 PropertyType::UserProperty => {
-                    let len = u16::read(r).await? as usize;
-                    verbose!("skipping user property name ({} bytes)", len);
-                    r.skip(len).await?;
-                    let len = u16::read(r).await? as usize;
-                    verbose!("skipping user property value ({} bytes)", len);
-                    r.skip(len).await?;
+                    UserProperty::skip(r).await?;
                 },
                 p => {
                     // Malformed packet according to <https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901029>
@@ -133,11 +146,14 @@ impl<'p, T: PubackPacketType> RxPacket<'p> for GenericPubackPacket<'p, T> {
         Ok(Self {
             packet_identifier,
             reason_code,
+            user_properties,
             _phantom_data: PhantomData,
         })
     }
 }
-impl<T: PubackPacketType> TxPacket for GenericPubackPacket<'_, T> {
+impl<T: PubackPacketType, const MAX_USER_PROPERTIES: usize> TxPacket
+    for GenericPubackPacket<'_, T, MAX_USER_PROPERTIES>
+{
     fn remaining_len(&self) -> VarByteInt {
         let variable_header_length = self.packet_identifier.written_len() + wlen!(ReasonCode);
 
@@ -146,10 +162,13 @@ impl<T: PubackPacketType> TxPacket for GenericPubackPacket<'_, T> {
 
         let total_length = variable_header_length + total_properties_length;
 
-        // Invariant: Max length = 65545 < VarByteInt::MAX_ENCODABLE
-        // property length: 4
-        // properties: 65538
+        // max length = MAX_USER_PROPERTIES * 131077 + 65545
+        // Invariant: MAX_USER_PROPERTIES <= 2047 => max length <= VarByteInt::MAX_ENCODABLE
+        //
         // variable header: 3
+        // property length: 4
+        // reason string: 65538
+        // user properties: MAX_USER_PROPERTIES * 131077
         VarByteInt::new_unchecked(total_length as u32)
     }
 
@@ -163,41 +182,49 @@ impl<T: PubackPacketType> TxPacket for GenericPubackPacket<'_, T> {
 
         // FIXME(reason string)
         // match &self.reason_string {
-        //     // Invariant: reason string length 65537 < VarByteInt::MAX_ENCODABLE
+        //     // Invariant: reason string length 65537 <= VarByteInt::MAX_ENCODABLE
         //     Some(r) => {
         //         VarByteInt::new_unchecked(r.written_len() as u32)
         //             .write(write)
         //             .await?;
         //         r.write(write).await?;
         //     }
-        //     // Invariant: 0 < VarByteInt::MAX_ENCODABLE
+        //     // Invariant: 0 <= VarByteInt::MAX_ENCODABLE
         //     None => VarByteInt::new_unchecked(0).write(write).await?,
         // }
 
         // FIXME(reason string)
         // write empty property length
-        // Invariant: 0 < VarByteInt::MAX_ENCODABLE
+        // Invariant: 0 <= VarByteInt::MAX_ENCODABLE
         VarByteInt::new_unchecked(0).write(write).await?;
+
+        for user_property in &self.user_properties {
+            user_property.write(write).await?;
+        }
 
         Ok(())
     }
 }
 
-impl<T: PubackPacketType> GenericPubackPacket<'_, T> {
+impl<T: PubackPacketType, const MAX_USER_PROPERTIES: usize>
+    GenericPubackPacket<'_, T, MAX_USER_PROPERTIES>
+{
     pub const fn new(packet_identifier: PacketIdentifier, reason_code: ReasonCode) -> Self {
         Self {
             packet_identifier,
             reason_code,
+            user_properties: Vec::new(),
             _phantom_data: PhantomData,
         }
     }
 
     fn properties_length(&self) -> VarByteInt {
-        // Invariant: Max length of reason string is 65538 < VarByteInt::MAX_ENCODABLE
-        // VarByteInt::new_unchecked(len as u32)
+        let len: usize = self.user_properties.iter().map(Writable::written_len).sum();
 
-        // Invariant: Max length = 0 < VarByteInt::MAX_ENCODABLE
-        VarByteInt::new_unchecked(0)
+        // FIXME(user property): No support for outgoing user properties yet, therefore the
+        // encoded length of user properties is 0
+        // Invariant: Max length = 0 <= VarByteInt::MAX_ENCODABLE
+        VarByteInt::new_unchecked(len as u32)
     }
 }
 
@@ -208,8 +235,8 @@ mod unit {
 
         use crate::{
             test::{rx::decode, tx::encode},
-            types::{PacketIdentifier, ReasonCode},
-            v5::packet::PubackPacket,
+            types::{MqttString, MqttStringPair, PacketIdentifier, ReasonCode},
+            v5::{packet::PubackPacket, property::UserProperty},
         };
 
         #[tokio::test]
@@ -217,7 +244,7 @@ mod unit {
         async fn encode_simple() {
             #[rustfmt::skip]
             encode!(
-                PubackPacket::new(PacketIdentifier::new(NonZero::new(7439).unwrap()), ReasonCode::NotAuthorized),
+                PubackPacket::<0>::new(PacketIdentifier::new(NonZero::new(7439).unwrap()), ReasonCode::NotAuthorized),
                 [
                     0x40,
                     0x04,
@@ -232,7 +259,7 @@ mod unit {
         #[tokio::test]
         #[test_log::test]
         async fn decode_simple() {
-            let packet = decode!(PubackPacket, 4, [0x40, 0x04, 0x26, 0x29, 0x10, 0x00]);
+            let packet = decode!(PubackPacket<2>, 4, [0x40, 0x04, 0x26, 0x29, 0x10, 0x00]);
 
             assert_eq!(
                 packet.packet_identifier,
@@ -240,12 +267,13 @@ mod unit {
             );
             assert_eq!(packet.reason_code, ReasonCode::NoMatchingSubscribers);
             // assert!(packet.reason_string.is_none());
+            assert!(packet.user_properties.is_empty());
         }
 
         #[tokio::test]
         #[test_log::test]
         async fn decode_abbreviated() {
-            let packet = decode!(PubackPacket, 3, [0x40, 0x03, 0x71, 0x59, 0x80]);
+            let packet = decode!(PubackPacket<2>, 3, [0x40, 0x03, 0x71, 0x59, 0x80]);
 
             assert_eq!(
                 packet.packet_identifier,
@@ -253,12 +281,13 @@ mod unit {
             );
             assert_eq!(packet.reason_code, ReasonCode::UnspecifiedError);
             // assert!(packet.reason_string.is_none());
+            assert!(packet.user_properties.is_empty());
         }
 
         #[tokio::test]
         #[test_log::test]
         async fn decode_minimal() {
-            let packet = decode!(PubackPacket, 2, [0x40, 0x02, 0x89, 0x35]);
+            let packet = decode!(PubackPacket<2>, 2, [0x40, 0x02, 0x89, 0x35]);
 
             assert_eq!(
                 packet.packet_identifier,
@@ -266,14 +295,15 @@ mod unit {
             );
             assert_eq!(packet.reason_code, ReasonCode::Success);
             // assert!(packet.reason_string.is_none());
+            assert!(packet.user_properties.is_empty());
         }
 
         #[tokio::test]
         #[test_log::test]
         async fn decode_properties() {
             #[rustfmt::skip]
-            let packet = decode!(PubackPacket, 42, [
-                0x40, 0x2A, 
+            let packet = decode!(PubackPacket<2>, 42, [
+                0x40, 0x2A,
                 0x12, 0x34, // Packet Identifier
                 0x99, // Reason Code
                 0x26, // Property length
@@ -293,6 +323,15 @@ mod unit {
             //     packet.reason_string,
             //     Some(ReasonString(MqttString::try_from("test reason").unwrap()))
             // );
+
+            assert_eq!(packet.user_properties.len(), 1);
+            assert_eq!(
+                packet.user_properties.first().unwrap(),
+                &UserProperty(MqttStringPair::new(
+                    MqttString::try_from("test-name").unwrap(),
+                    MqttString::try_from("test-value").unwrap()
+                ))
+            );
         }
     }
 
@@ -301,8 +340,8 @@ mod unit {
 
         use crate::{
             test::{rx::decode, tx::encode},
-            types::{PacketIdentifier, ReasonCode},
-            v5::packet::PubrecPacket,
+            types::{MqttString, MqttStringPair, PacketIdentifier, ReasonCode},
+            v5::{packet::PubrecPacket, property::UserProperty},
         };
 
         #[tokio::test]
@@ -310,7 +349,7 @@ mod unit {
         async fn encode_simple() {
             #[rustfmt::skip]
             encode!(
-                PubrecPacket::new(PacketIdentifier::new(NonZero::new(876).unwrap()), ReasonCode::QuotaExceeded),
+                PubrecPacket::<0>::new(PacketIdentifier::new(NonZero::new(876).unwrap()), ReasonCode::QuotaExceeded),
                 [
                     0x50,
                     0x04,
@@ -325,7 +364,7 @@ mod unit {
         #[tokio::test]
         #[test_log::test]
         async fn decode_simple() {
-            let packet = decode!(PubrecPacket, 4, [0x50, 0x04, 0x26, 0x94, 0x91, 0x00]);
+            let packet = decode!(PubrecPacket<2>, 4, [0x50, 0x04, 0x26, 0x94, 0x91, 0x00]);
 
             assert_eq!(
                 packet.packet_identifier,
@@ -333,12 +372,13 @@ mod unit {
             );
             assert_eq!(packet.reason_code, ReasonCode::PacketIdentifierInUse);
             // assert!(packet.reason_string.is_none());
+            assert!(packet.user_properties.is_empty());
         }
 
         #[tokio::test]
         #[test_log::test]
         async fn decode_abbreviated() {
-            let packet = decode!(PubrecPacket, 3, [0x50, 0x03, 0x45, 0xC9, 0x83]);
+            let packet = decode!(PubrecPacket<2>, 3, [0x50, 0x03, 0x45, 0xC9, 0x83]);
 
             assert_eq!(
                 packet.packet_identifier,
@@ -346,12 +386,13 @@ mod unit {
             );
             assert_eq!(packet.reason_code, ReasonCode::ImplementationSpecificError);
             // assert!(packet.reason_string.is_none());
+            assert!(packet.user_properties.is_empty());
         }
 
         #[tokio::test]
         #[test_log::test]
         async fn decode_minimal() {
-            let packet = decode!(PubrecPacket, 2, [0x50, 0x02, 0x5B, 0xBF]);
+            let packet = decode!(PubrecPacket<2>, 2, [0x50, 0x02, 0x5B, 0xBF]);
 
             assert_eq!(
                 packet.packet_identifier,
@@ -359,13 +400,14 @@ mod unit {
             );
             assert_eq!(packet.reason_code, ReasonCode::Success);
             // assert!(packet.reason_string.is_none());
+            assert!(packet.user_properties.is_empty());
         }
 
         #[tokio::test]
         #[test_log::test]
         async fn decode_properties() {
             #[rustfmt::skip]
-            let packet = decode!(PubrecPacket, 42, [
+            let packet = decode!(PubrecPacket<2>, 42, [
                 0x50,
                 0x2A,
                 0x26, 0x3A, // Packet Identifier
@@ -389,6 +431,15 @@ mod unit {
             //     packet.reason_string,
             //     Some(ReasonString(MqttString::try_from("test reason").unwrap()))
             // );
+
+            assert_eq!(packet.user_properties.len(), 1);
+            assert_eq!(
+                packet.user_properties.first().unwrap(),
+                &UserProperty(MqttStringPair::new(
+                    MqttString::try_from("test-name").unwrap(),
+                    MqttString::try_from("test-value").unwrap()
+                ))
+            );
         }
     }
 
@@ -397,8 +448,8 @@ mod unit {
 
         use crate::{
             test::{rx::decode, tx::encode},
-            types::{PacketIdentifier, ReasonCode},
-            v5::packet::PubrelPacket,
+            types::{MqttString, MqttStringPair, PacketIdentifier, ReasonCode},
+            v5::{packet::PubrelPacket, property::UserProperty},
         };
 
         #[tokio::test]
@@ -406,7 +457,7 @@ mod unit {
         async fn encode_simple() {
             #[rustfmt::skip]
             encode!(
-                PubrelPacket::new(PacketIdentifier::new(NonZero::new(876).unwrap()), ReasonCode::PacketIdentifierNotFound),
+                PubrelPacket::<0>::new(PacketIdentifier::new(NonZero::new(876).unwrap()), ReasonCode::PacketIdentifierNotFound),
                 [
                     0x62,
                     0x04,
@@ -421,7 +472,7 @@ mod unit {
         #[tokio::test]
         #[test_log::test]
         async fn decode_simple() {
-            let packet = decode!(PubrelPacket, 4, [0x62, 0x04, 0x26, 0x94, 0x00, 0x00]);
+            let packet = decode!(PubrelPacket<2>, 4, [0x62, 0x04, 0x26, 0x94, 0x00, 0x00]);
 
             assert_eq!(
                 packet.packet_identifier,
@@ -429,12 +480,13 @@ mod unit {
             );
             assert_eq!(packet.reason_code, ReasonCode::Success);
             // assert!(packet.reason_string.is_none());
+            assert!(packet.user_properties.is_empty());
         }
 
         #[tokio::test]
         #[test_log::test]
         async fn decode_abbreviated() {
-            let packet = decode!(PubrelPacket, 3, [0x62, 0x03, 0x45, 0xC9, 0x92]);
+            let packet = decode!(PubrelPacket<2>, 3, [0x62, 0x03, 0x45, 0xC9, 0x92]);
 
             assert_eq!(
                 packet.packet_identifier,
@@ -442,12 +494,13 @@ mod unit {
             );
             assert_eq!(packet.reason_code, ReasonCode::PacketIdentifierNotFound);
             // assert!(packet.reason_string.is_none());
+            assert!(packet.user_properties.is_empty());
         }
 
         #[tokio::test]
         #[test_log::test]
         async fn decode_minimal() {
-            let packet = decode!(PubrelPacket, 2, [0x62, 0x02, 0x5B, 0xBF]);
+            let packet = decode!(PubrelPacket<2>, 2, [0x62, 0x02, 0x5B, 0xBF]);
 
             assert_eq!(
                 packet.packet_identifier,
@@ -455,6 +508,7 @@ mod unit {
             );
             assert_eq!(packet.reason_code, ReasonCode::Success);
             // assert!(packet.reason_string.is_none());
+            assert!(packet.user_properties.is_empty());
         }
 
         #[tokio::test]
@@ -462,7 +516,7 @@ mod unit {
         async fn decode_properties() {
             #[rustfmt::skip]
             let packet = decode!(
-                PubrelPacket,
+                PubrelPacket<2>,
                 42,
                 [
                     0x62,
@@ -492,6 +546,15 @@ mod unit {
             //     packet.reason_string,
             //     Some(ReasonString(MqttString::try_from("test reason").unwrap()))
             // );
+
+            assert_eq!(packet.user_properties.len(), 1);
+            assert_eq!(
+                packet.user_properties.first().unwrap(),
+                &UserProperty(MqttStringPair::new(
+                    MqttString::try_from("test-name").unwrap(),
+                    MqttString::try_from("test-value").unwrap()
+                ))
+            );
         }
     }
 
@@ -500,8 +563,8 @@ mod unit {
 
         use crate::{
             test::{rx::decode, tx::encode},
-            types::{PacketIdentifier, ReasonCode},
-            v5::packet::PubcompPacket,
+            types::{MqttString, MqttStringPair, PacketIdentifier, ReasonCode},
+            v5::{packet::PubcompPacket, property::UserProperty},
         };
 
         #[tokio::test]
@@ -509,7 +572,7 @@ mod unit {
         async fn encode_simple() {
             #[rustfmt::skip]
             encode!(
-                PubcompPacket::new(PacketIdentifier::new(NonZero::new(876).unwrap()), ReasonCode::PacketIdentifierNotFound),
+                PubcompPacket::<0>::new(PacketIdentifier::new(NonZero::new(876).unwrap()), ReasonCode::PacketIdentifierNotFound),
                 [
                     0x70,
                     0x04,
@@ -524,7 +587,7 @@ mod unit {
         #[tokio::test]
         #[test_log::test]
         async fn decode_simple() {
-            let packet = decode!(PubcompPacket, 4, [0x70, 0x04, 0x26, 0x94, 0x00, 0x00]);
+            let packet = decode!(PubcompPacket<2>, 4, [0x70, 0x04, 0x26, 0x94, 0x00, 0x00]);
 
             assert_eq!(
                 packet.packet_identifier,
@@ -532,12 +595,13 @@ mod unit {
             );
             assert_eq!(packet.reason_code, ReasonCode::Success);
             // assert!(packet.reason_string.is_none());
+            assert!(packet.user_properties.is_empty());
         }
 
         #[tokio::test]
         #[test_log::test]
         async fn decode_abbreviated() {
-            let packet = decode!(PubcompPacket, 3, [0x70, 0x03, 0x45, 0xC9, 0x92]);
+            let packet = decode!(PubcompPacket<2>, 3, [0x70, 0x03, 0x45, 0xC9, 0x92]);
 
             assert_eq!(
                 packet.packet_identifier,
@@ -545,12 +609,13 @@ mod unit {
             );
             assert_eq!(packet.reason_code, ReasonCode::PacketIdentifierNotFound);
             // assert!(packet.reason_string.is_none());
+            assert!(packet.user_properties.is_empty());
         }
 
         #[tokio::test]
         #[test_log::test]
         async fn decode_minimal() {
-            let packet = decode!(PubcompPacket, 2, [0x70, 0x02, 0x5B, 0xBF]);
+            let packet = decode!(PubcompPacket<2>, 2, [0x70, 0x02, 0x5B, 0xBF]);
 
             assert_eq!(
                 packet.packet_identifier,
@@ -558,13 +623,14 @@ mod unit {
             );
             assert_eq!(packet.reason_code, ReasonCode::Success);
             // assert!(packet.reason_string.is_none());
+            assert!(packet.user_properties.is_empty());
         }
 
         #[tokio::test]
         #[test_log::test]
         async fn decode_properties() {
             #[rustfmt::skip]
-            let packet = decode!(PubcompPacket, 42, [
+            let packet = decode!(PubcompPacket<2>, 42, [
                 0x70,
                 0x2A,
 
@@ -589,6 +655,15 @@ mod unit {
             //     packet.reason_string,
             //     Some(ReasonString(MqttString::try_from("test reason").unwrap()))
             // );
+
+            assert_eq!(packet.user_properties.len(), 1);
+            assert_eq!(
+                packet.user_properties.first().unwrap(),
+                &UserProperty(MqttStringPair::new(
+                    MqttString::try_from("test-name").unwrap(),
+                    MqttString::try_from("test-value").unwrap()
+                ))
+            );
         }
     }
 }

--- a/src/v5/packet/publish.rs
+++ b/src/v5/packet/publish.rs
@@ -380,12 +380,13 @@ mod unit {
         test::{rx::decode, tx::encode},
         types::{
             IdentifiedQoS, MqttBinary, MqttString, MqttStringPair, PacketIdentifier, TopicName,
+            VarByteInt,
         },
         v5::{
             packet::PublishPacket,
             property::{
                 ContentType, CorrelationData, MessageExpiryInterval, PayloadFormatIndicator,
-                Property, ResponseTopic, UserProperty,
+                ResponseTopic, UserProperty,
             },
         },
     };
@@ -667,20 +668,89 @@ mod unit {
             ))]
         );
 
-        assert_eq!(packet.subscription_identifiers.len(), 1);
         assert_eq!(
-            packet
-                .subscription_identifiers
-                .first()
-                .unwrap()
-                .into_inner()
-                .value(),
-            42
+            packet.subscription_identifiers.as_slice(),
+            &[VarByteInt::from(42u8).into()]
         );
 
         assert_eq!(
             packet.content_type,
             Some(ContentType(MqttString::try_from("text/plain").unwrap()))
         );
+    }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn decode_incomplete_subscription_identifiers() {
+        #[rustfmt::skip]
+        let packet = decode!(
+            PublishPacket<'_, 2, 16>,
+            21,
+            [
+                0x30,
+                0x15,
+
+                0x00, 0x04, b't', b'e', b's', b't', // Topic name "test"
+                0x0C, // Property length
+
+                // Subscription Identifier
+                0x0B, 0x80, 0xAD, 0xE2, 0x04,
+
+                // Subscription Identifier
+                0x0B, 0xF4, 0x03,
+
+                // Subscription Identifier
+                0x0B, 0xA0, 0x9C, 0x01,
+
+                // Payload
+                b'O', b'K',
+            ]
+        );
+
+        assert_eq!(
+            packet.subscription_identifiers.as_slice(),
+            &[
+                VarByteInt::try_from(10_000_000u32).unwrap().into(),
+                VarByteInt::from(500u16).into()
+            ]
+        );
+        assert_eq!(packet.message, Bytes::from("OK".as_bytes()));
+    }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn decode_incomplete_user_properties() {
+        #[rustfmt::skip]
+        let packet = decode!(
+            PublishPacket<'_, 1, 1>,
+            27,
+            [
+                0x30,
+                0x1B,
+
+                0x00, 0x04, b't', b'e', b's', b't', // Topic name "test"
+                0x12, // Property length
+
+                // User Property
+                0x26, 0x00, 0x02, b'k', b'1',
+                      0x00, 0x02, b'v', b'1',
+
+                // User Property
+                0x26, 0x00, 0x02, b'k', b'2',
+                      0x00, 0x02, b'v', b'2',
+
+                // Payload
+                b'o', b'k',
+            ]
+        );
+
+        assert_eq!(
+            packet.user_properties.as_slice(),
+            &[UserProperty(MqttStringPair::new(
+                MqttString::from_str("k1").unwrap(),
+                MqttString::from_str("v1").unwrap()
+            ))]
+        );
+        assert_eq!(packet.message, Bytes::from("ok".as_bytes()));
     }
 }

--- a/src/v5/packet/publish.rs
+++ b/src/v5/packet/publish.rs
@@ -9,7 +9,7 @@ use crate::{
     header::{FixedHeader, PacketType},
     io::{
         read::{BodyReader, Readable, Store},
-        write::{Writable, wlen},
+        write::Writable,
     },
     packet::{Packet, RxError, RxPacket, TxError, TxPacket},
     types::{
@@ -19,13 +19,17 @@ use crate::{
     v5::property::{
         AtMostOnceProperty, ContentType, CorrelationData, MessageExpiryInterval,
         PayloadFormatIndicator, Property, PropertyType, ResponseTopic, SubscriptionIdentifier,
-        TopicAlias,
+        TopicAlias, UserProperty,
     },
 };
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct PublishPacket<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize> {
+pub struct PublishPacket<
+    'p,
+    const MAX_SUBSCRIPTION_IDENTIFIERS: usize,
+    const MAX_USER_PROPERTIES: usize,
+> {
     pub dup: bool,
     pub identified_qos: IdentifiedQoS,
     pub retain: bool,
@@ -39,18 +43,19 @@ pub struct PublishPacket<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize> {
     pub message_expiry_interval: Option<MessageExpiryInterval>,
     pub response_topic: Option<ResponseTopic<'p>>,
     pub correlation_data: Option<CorrelationData<'p>>,
+    pub user_properties: Vec<UserProperty<'p>, MAX_USER_PROPERTIES>,
     pub subscription_identifiers: Vec<SubscriptionIdentifier, MAX_SUBSCRIPTION_IDENTIFIERS>,
     pub content_type: Option<ContentType<'p>>,
     pub message: Bytes<'p>,
 }
 
-impl<const MAX_SUBSCRIPTION_IDENTIFIERS: usize> Packet
-    for PublishPacket<'_, MAX_SUBSCRIPTION_IDENTIFIERS>
+impl<const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER_PROPERTIES: usize> Packet
+    for PublishPacket<'_, MAX_SUBSCRIPTION_IDENTIFIERS, MAX_USER_PROPERTIES>
 {
     const PACKET_TYPE: PacketType = PacketType::Publish;
 }
-impl<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize> RxPacket<'p>
-    for PublishPacket<'p, MAX_SUBSCRIPTION_IDENTIFIERS>
+impl<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER_PROPERTIES: usize> RxPacket<'p>
+    for PublishPacket<'p, MAX_SUBSCRIPTION_IDENTIFIERS, MAX_USER_PROPERTIES>
 {
     async fn receive<R: Read, B: BufferProvider<'p>>(
         header: &FixedHeader,
@@ -97,6 +102,7 @@ impl<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize> RxPacket<'p>
         let mut topic_alias: Option<TopicAlias> = None;
         let mut response_topic: Option<ResponseTopic<'_>> = None;
         let mut correlation_data: Option<CorrelationData<'_>> = None;
+        let mut user_properties = Vec::new();
         let mut subscription_identifiers = Vec::new();
         let mut content_type: Option<ContentType<'_>> = None;
 
@@ -146,16 +152,21 @@ impl<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize> RxPacket<'p>
                         .checked_sub(correlation_data.as_ref().unwrap().0.written_len())
                         .ok_or(RxError::MalformedPacket)?;
                 }
-                #[rustfmt::skip]
+                PropertyType::UserProperty if !user_properties.is_full() => {
+                    let user_property = UserProperty::read(r).await?;
+
+                    properties_length = properties_length
+                        .checked_sub(user_property.0.written_len())
+                        .ok_or(RxError::MalformedPacket)?;
+
+                    // Safety: `!Vec::is_full` guarantees there is space
+                    unsafe { user_properties.push_unchecked(user_property) };
+                }
                 PropertyType::UserProperty => {
-                    let len = u16::read(r).await? as usize;
-                    verbose!("skipping user property name ({} bytes)", len);
-                    r.skip(len).await?;
-                    properties_length = properties_length.checked_sub(wlen!(u16) + len).ok_or(RxError::MalformedPacket)?;
-                    let len = u16::read(r).await? as usize;
-                    verbose!("skipping user property value ({} bytes)", len);
-                    r.skip(len).await?;
-                    properties_length = properties_length.checked_sub(wlen!(u16) + len).ok_or(RxError::MalformedPacket)?;
+                    let len = UserProperty::skip(r).await?;
+                    properties_length = properties_length
+                        .checked_sub(len)
+                        .ok_or(RxError::MalformedPacket)?;
                 }
                 PropertyType::SubscriptionIdentifier => {
                     let subscription_identifier = SubscriptionIdentifier::read(r).await?;
@@ -203,14 +214,15 @@ impl<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize> RxPacket<'p>
             message_expiry_interval,
             response_topic,
             correlation_data,
+            user_properties,
             subscription_identifiers,
             content_type,
             message,
         })
     }
 }
-impl<const MAX_SUBSCRIPTION_IDENTIFIERS: usize> TxPacket
-    for PublishPacket<'_, MAX_SUBSCRIPTION_IDENTIFIERS>
+impl<const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER_PROPERTIES: usize> TxPacket
+    for PublishPacket<'_, MAX_SUBSCRIPTION_IDENTIFIERS, MAX_USER_PROPERTIES>
 {
     fn remaining_len(&self) -> VarByteInt {
         // Safety: PUBLISH packets that are too long to encode cannot be created
@@ -242,7 +254,12 @@ impl<const MAX_SUBSCRIPTION_IDENTIFIERS: usize> TxPacket
         self.topic.alias().map(TopicAlias).write(write).await?;
         self.response_topic.write(write).await?;
         self.correlation_data.write(write).await?;
-        // Don't write subscription identifiers as they are irration when publishing from client to server
+
+        for user_property in &self.user_properties {
+            user_property.write(write).await?;
+        }
+
+        // Don't write subscription identifiers as they are irrational when publishing from client to server
         self.content_type.write(write).await?;
 
         self.message.write(write).await?;
@@ -251,8 +268,8 @@ impl<const MAX_SUBSCRIPTION_IDENTIFIERS: usize> TxPacket
     }
 }
 
-impl<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize>
-    PublishPacket<'p, MAX_SUBSCRIPTION_IDENTIFIERS>
+impl<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER_PROPERTIES: usize>
+    PublishPacket<'p, MAX_SUBSCRIPTION_IDENTIFIERS, MAX_USER_PROPERTIES>
 {
     // Invariant: Empty string does not exceed MqttString::MAX_LENGTH
     const EMPTY_TOPIC: MqttString<'static> = MqttString::from_str_unchecked("");
@@ -268,6 +285,7 @@ impl<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize>
         message_expiry_interval: Option<MessageExpiryInterval>,
         response_topic: Option<TopicName<'p>>,
         correlation_data: Option<MqttBinary<'p>>,
+        user_properties: Vec<UserProperty<'p>, MAX_USER_PROPERTIES>,
         content_type: Option<ContentType<'p>>,
         message: Bytes<'p>,
     ) -> Result<Self, TooLargeToEncode> {
@@ -280,6 +298,7 @@ impl<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize>
             message_expiry_interval,
             response_topic: response_topic.map(Into::into),
             correlation_data: correlation_data.map(Into::into),
+            user_properties,
             subscription_identifiers: Vec::new(),
             content_type,
             message,
@@ -304,32 +323,48 @@ impl<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize>
                 .map(Writable::written_len)
                 .unwrap_or_default();
 
-        let properties_length = self.properties_length();
+        let properties_length = self.properties_length().ok_or(TooLargeToEncode)?;
         let total_properties_length = properties_length.size() + properties_length.written_len();
 
         let body_length = self.message.len();
 
         let total_length = variable_header_length + total_properties_length + body_length;
 
+        // max length = MAX_USER_PROPERTIES * 131077 + 262,167 + MAX_MESSAGE_LENGTH
+        //
+        // topic name: 65537
+        // packet identifier: 2
+        // property length: 4
+        // properties: MAX_USER_PROPERTIES * 131077 + 196624
+        // message: MAX_MESSAGE_LENGTH
         VarByteInt::try_from(total_length as u32)
     }
 
-    fn properties_length(&self) -> VarByteInt {
+    fn properties_length(&self) -> Option<VarByteInt> {
         let len = self.payload_format_indicator.written_len()
             + self.message_expiry_interval.written_len()
             + self.topic.alias().map(TopicAlias).written_len()
             + self.response_topic.written_len()
             + self.correlation_data.written_len()
+            + self
+                .user_properties
+                .iter()
+                .map(Writable::written_len)
+                .sum::<usize>()
             + self.content_type.written_len();
 
-        // Invariant: Max length = 196624 < VarByteInt::MAX_ENCODABLE
+        // max length = MAX_USER_PROPERTIES * 131077 + 196624
+        // Invariant: MAX_USER_PROPERTIES <= 2046 => max length <= VarByteInt::MAX_ENCODABLE
+        //
         // payload format indicator: 2
         // message expiry interval: 5
         // topic alias: 3
         // response topic: 65538
         // correlation data: 65538
+        // user properties: MAX_USER_PROPERTIES * 131077
+        // no subscription identifiers in client to server publish
         // content type: 65538
-        VarByteInt::new_unchecked(len as u32)
+        VarByteInt::new(len as u32)
     }
 }
 
@@ -337,16 +372,20 @@ impl<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize>
 mod unit {
     use core::num::NonZero;
 
+    use heapless::Vec;
+
     use crate::{
         bytes::Bytes,
         client::options::TopicReference,
         test::{rx::decode, tx::encode},
-        types::{IdentifiedQoS, MqttBinary, MqttString, PacketIdentifier, TopicName},
+        types::{
+            IdentifiedQoS, MqttBinary, MqttString, MqttStringPair, PacketIdentifier, TopicName,
+        },
         v5::{
             packet::PublishPacket,
             property::{
                 ContentType, CorrelationData, MessageExpiryInterval, PayloadFormatIndicator,
-                Property, ResponseTopic,
+                Property, ResponseTopic, UserProperty,
             },
         },
     };
@@ -354,7 +393,7 @@ mod unit {
     #[tokio::test]
     #[test_log::test]
     async fn encode_simple() {
-        let packet: PublishPacket<'_, 0> = PublishPacket::new(
+        let packet: PublishPacket<'_, 0, 0> = PublishPacket::new(
             false,
             IdentifiedQoS::AtLeastOnce(PacketIdentifier::new(NonZero::new(5897).unwrap())),
             false,
@@ -365,6 +404,7 @@ mod unit {
             None,
             None,
             None,
+            Vec::new(),
             None,
             Bytes::from("hello".as_bytes()),
         )
@@ -400,7 +440,7 @@ mod unit {
     #[tokio::test]
     #[test_log::test]
     async fn encode_properties() {
-        let packet: PublishPacket<'_, 0> = PublishPacket::new(
+        let packet: PublishPacket<'_, 0, 16> = PublishPacket::new(
             true,
             IdentifiedQoS::ExactlyOnce(PacketIdentifier::new(NonZero::new(9624).unwrap())),
             true,
@@ -409,6 +449,17 @@ mod unit {
             Some(481123u32.into()),
             Some(TopicName::new(MqttString::from_str("uno, dos, tres, catorce").unwrap()).unwrap()),
             Some(MqttBinary::from_slice_unchecked(&[0, 1, 2, 3, 4, 5, 6, 7])),
+            [
+                UserProperty(MqttStringPair::new(
+                    MqttString::from_str("donald").unwrap(),
+                    MqttString::from_str("duck").unwrap(),
+                )),
+                UserProperty(MqttStringPair::new(
+                    MqttString::from_str("Gyro").unwrap(),
+                    MqttString::from_str("Gearloose").unwrap(),
+                )),
+            ]
+            .into(),
             Some(
                 MqttString::from_str("application/javascript")
                     .unwrap()
@@ -421,12 +472,12 @@ mod unit {
         #[rustfmt::skip]
         encode!(packet, [
             0x3D,
-            0x52,
+            0x73,
             0x00, // Topic Name
             0x00, // Topic Name
             0x25, // Packet identifier
             0x98, // Packet identifier
-            0x48, // Property length
+            0x69, // Property length
 
             0x01, // Payload format indicator
             0x00, // Payload format indicator
@@ -447,6 +498,14 @@ mod unit {
             0x00, 0x08,
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
 
+            0x26, // User property
+            0x00, 0x06, b'd', b'o', b'n', b'a', b'l', b'd',
+            0x00, 0x04, b'd', b'u', b'c', b'k',
+
+            0x26, // User property
+            0x00, 0x04, b'G', b'y', b'r', b'o',
+            0x00, 0x09, b'G', b'e', b'a', b'r', b'l', b'o', b'o', b's', b'e', 
+
             0x03, // Content type
             0x00, 0x16,
             b'a', b'p', b'p', b'l', b'i', b'c', b'a', b't', b'i', b'o', b'n', b'/', b'j', b'a', b'v', b'a', b's', b'c', b'r', b'i', b'p', b't', 
@@ -463,7 +522,7 @@ mod unit {
     #[test_log::test]
     async fn decode_simple() {
         let packet = decode!(
-            PublishPacket<'_, 0>,
+            PublishPacket<'_, 0, 16>,
             13,
             [
                 0x30, 0x0D, 0x00, 0x0A, b't', b'e', b's', b't', b'/', b't', b'o', b'p', b'i', b'c',
@@ -485,6 +544,8 @@ mod unit {
         assert!(packet.message_expiry_interval.is_none());
         assert!(packet.response_topic.is_none());
         assert!(packet.correlation_data.is_none());
+        assert!(packet.user_properties.is_empty());
+        assert!(packet.subscription_identifiers.is_empty());
         assert!(packet.content_type.is_none());
 
         assert_eq!(packet.message, Bytes::from([].as_slice()));
@@ -494,7 +555,7 @@ mod unit {
     #[test_log::test]
     async fn decode_payload() {
         let packet = decode!(
-            PublishPacket<'_, 0>,
+            PublishPacket<'_, 0, 16>,
             21,
             [
                 0x3D, 0x15, 0x00, 0x04, b't', b'e', b's', b't', 0x54, 0x23, 0x00, b'h', b'e', b'l',
@@ -516,6 +577,8 @@ mod unit {
         assert!(packet.message_expiry_interval.is_none());
         assert!(packet.response_topic.is_none());
         assert!(packet.correlation_data.is_none());
+        assert!(packet.user_properties.is_empty());
+        assert!(packet.subscription_identifiers.is_empty());
         assert!(packet.content_type.is_none());
 
         assert_eq!(packet.message, Bytes::from("hello, there".as_bytes()));
@@ -526,7 +589,7 @@ mod unit {
     async fn decode_properties() {
         #[rustfmt::skip]
         let packet = decode!(
-            PublishPacket<'_, 1>,
+            PublishPacket<'_, 1, 16>,
             79,
             [
                 0x30, 0x4F,
@@ -594,6 +657,14 @@ mod unit {
             Some(CorrelationData(
                 MqttBinary::try_from("corr_id1".as_bytes()).unwrap()
             ))
+        );
+
+        assert_eq!(
+            packet.user_properties.as_slice(),
+            &[UserProperty(MqttStringPair::new(
+                MqttString::from_str("name").unwrap(),
+                MqttString::from_str("value").unwrap()
+            ))]
         );
 
         assert_eq!(packet.subscription_identifiers.len(), 1);

--- a/src/v5/packet/publish.rs
+++ b/src/v5/packet/publish.rs
@@ -205,7 +205,7 @@ impl<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER_PROPERTIES: u
 
         let message = r.read_and_store(r.remaining_len()).await?;
 
-        Ok(PublishPacket {
+        Ok(Self {
             dup,
             identified_qos,
             retain,

--- a/src/v5/packet/subacks/mod.rs
+++ b/src/v5/packet/subacks/mod.rs
@@ -287,6 +287,46 @@ mod unit {
             let reason_codes: Vec<_, 1> = [ReasonCode::Success].into();
             assert_eq!(packet.reason_codes, reason_codes);
         }
+
+        #[tokio::test]
+        #[test_log::test]
+        async fn decode_incomplete_user_properties() {
+            #[rustfmt::skip]
+            let packet = decode!(
+                SubackPacket<1, 1>,
+                31,
+                [
+                    0x90,
+                    0x1F,
+
+                    0x12, 0x34, // packet identifier
+                    0x1B,       // Property length
+
+                    // User Property
+                    0x26, 0x00, 0x02, b'k', b'1',
+                          0x00, 0x02, b'v', b'1',
+
+                    // User Property
+                    0x26, 0x00, 0x02, b'k', b'2',
+                          0x00, 0x02, b'v', b'2',
+
+                    // User Property
+                    0x26, 0x00, 0x02, b'k', b'3',
+                          0x00, 0x02, b'v', b'3',
+
+                    // Reason codes
+                    0x00,
+                ]
+            );
+
+            assert_eq!(
+                packet.user_properties.as_slice(),
+                &[UserProperty(MqttStringPair::new(
+                    MqttString::from_str("k1").unwrap(),
+                    MqttString::from_str("v1").unwrap()
+                ))]
+            );
+        }
     }
 
     mod unsuback {
@@ -394,6 +434,52 @@ mod unit {
 
             let reason_codes: Vec<_, 1> = [ReasonCode::Success].into();
             assert_eq!(packet.reason_codes, reason_codes);
+        }
+
+        #[tokio::test]
+        #[test_log::test]
+        async fn decode_incomplete_user_properties() {
+            #[rustfmt::skip]
+            let packet = decode!(
+                UnsubackPacket<1, 2>,
+                31,
+                [
+                    0xB0,
+                    0x1F,
+
+                    0x12, 0x34, // packet identifier
+                    0x1B,       // Property length
+
+                    // User Property
+                    0x26, 0x00, 0x02, b'k', b'1',
+                          0x00, 0x02, b'v', b'1',
+
+                    // User Property
+                    0x26, 0x00, 0x02, b'k', b'2',
+                          0x00, 0x02, b'v', b'2',
+
+                    // User Property
+                    0x26, 0x00, 0x02, b'k', b'3',
+                          0x00, 0x02, b'v', b'3',
+
+                    // Reason codea
+                    0x00,
+                ]
+            );
+
+            assert_eq!(
+                packet.user_properties.as_slice(),
+                &[
+                    UserProperty(MqttStringPair::new(
+                        MqttString::from_str("k1").unwrap(),
+                        MqttString::from_str("v1").unwrap()
+                    )),
+                    UserProperty(MqttStringPair::new(
+                        MqttString::from_str("k2").unwrap(),
+                        MqttString::from_str("v2").unwrap()
+                    ))
+                ]
+            );
         }
     }
 }

--- a/src/v5/packet/subacks/mod.rs
+++ b/src/v5/packet/subacks/mod.rs
@@ -168,14 +168,12 @@ impl<'p, T: SubackPacketType, const MAX_TOPIC_FILTERS: usize, const MAX_USER_PRO
                 .map_err(|_| RxError::ProtocolError)?;
         }
 
-        let packet = Self {
+        Ok(Self {
             packet_identifier,
             user_properties,
             reason_codes,
             _phantom_data: PhantomData,
-        };
-
-        Ok(packet)
+        })
     }
 }
 

--- a/src/v5/packet/subacks/mod.rs
+++ b/src/v5/packet/subacks/mod.rs
@@ -216,29 +216,21 @@ mod unit {
             // assert!(packet.reason_string.is_none());
             assert!(packet.user_properties.is_empty());
 
-            let mut reason_codes: Vec<_, 12> = Vec::new();
-            reason_codes.push(ReasonCode::Success).unwrap();
-            reason_codes
-                .push(ReasonCode::WildcardSubscriptionsNotSupported)
-                .unwrap();
-            reason_codes.push(ReasonCode::GrantedQoS1).unwrap();
-            reason_codes
-                .push(ReasonCode::SubscriptionIdentifiersNotSupported)
-                .unwrap();
-            reason_codes.push(ReasonCode::GrantedQoS2).unwrap();
-            reason_codes
-                .push(ReasonCode::SharedSubscriptionsNotSupported)
-                .unwrap();
-            reason_codes.push(ReasonCode::UnspecifiedError).unwrap();
-            reason_codes.push(ReasonCode::QuotaExceeded).unwrap();
-            reason_codes
-                .push(ReasonCode::ImplementationSpecificError)
-                .unwrap();
-            reason_codes
-                .push(ReasonCode::PacketIdentifierInUse)
-                .unwrap();
-            reason_codes.push(ReasonCode::NotAuthorized).unwrap();
-            reason_codes.push(ReasonCode::TopicFilterInvalid).unwrap();
+            let reason_codes: Vec<_, 12> = [
+                ReasonCode::Success,
+                ReasonCode::WildcardSubscriptionsNotSupported,
+                ReasonCode::GrantedQoS1,
+                ReasonCode::SubscriptionIdentifiersNotSupported,
+                ReasonCode::GrantedQoS2,
+                ReasonCode::SharedSubscriptionsNotSupported,
+                ReasonCode::UnspecifiedError,
+                ReasonCode::QuotaExceeded,
+                ReasonCode::ImplementationSpecificError,
+                ReasonCode::PacketIdentifierInUse,
+                ReasonCode::NotAuthorized,
+                ReasonCode::TopicFilterInvalid,
+            ]
+            .into();
             assert_eq!(packet.reason_codes, reason_codes);
         }
 
@@ -292,8 +284,7 @@ mod unit {
                 ]
             );
 
-            let mut reason_codes: Vec<_, 1> = Vec::new();
-            reason_codes.push(ReasonCode::Success).unwrap();
+            let reason_codes: Vec<_, 1> = [ReasonCode::Success].into();
             assert_eq!(packet.reason_codes, reason_codes);
         }
     }
@@ -334,21 +325,16 @@ mod unit {
             // assert!(packet.reason_string.is_none());
             assert!(packet.user_properties.is_empty());
 
-            let mut reason_codes: Vec<_, 7> = Vec::new();
-
-            reason_codes.push(ReasonCode::Success).unwrap();
-            reason_codes
-                .push(ReasonCode::PacketIdentifierInUse)
-                .unwrap();
-            reason_codes
-                .push(ReasonCode::NoSubscriptionExisted)
-                .unwrap();
-            reason_codes.push(ReasonCode::TopicFilterInvalid).unwrap();
-            reason_codes.push(ReasonCode::UnspecifiedError).unwrap();
-            reason_codes.push(ReasonCode::NotAuthorized).unwrap();
-            reason_codes
-                .push(ReasonCode::ImplementationSpecificError)
-                .unwrap();
+            let reason_codes: Vec<_, 7> = [
+                ReasonCode::Success,
+                ReasonCode::PacketIdentifierInUse,
+                ReasonCode::NoSubscriptionExisted,
+                ReasonCode::TopicFilterInvalid,
+                ReasonCode::UnspecifiedError,
+                ReasonCode::NotAuthorized,
+                ReasonCode::ImplementationSpecificError,
+            ]
+            .into();
 
             assert_eq!(packet.reason_codes, reason_codes);
         }
@@ -406,8 +392,7 @@ mod unit {
                 ]
             );
 
-            let mut reason_codes: Vec<_, 1> = Vec::new();
-            reason_codes.push(ReasonCode::Success).unwrap();
+            let reason_codes: Vec<_, 1> = [ReasonCode::Success].into();
             assert_eq!(packet.reason_codes, reason_codes);
         }
     }

--- a/src/v5/packet/subacks/mod.rs
+++ b/src/v5/packet/subacks/mod.rs
@@ -15,34 +15,42 @@ use crate::{
     types::{PacketIdentifier, ReasonCode, VarByteInt},
     v5::{
         packet::subacks::types::{Suback, SubackPacketType, Unsuback},
-        property::PropertyType,
+        property::{PropertyType, UserProperty},
     },
 };
 
 mod types;
 
-pub type SubackPacket<'p, const MAX_TOPIC_FILTERS: usize> =
-    GenericSubackPacket<'p, Suback, MAX_TOPIC_FILTERS>;
-pub type UnsubackPacket<'p, const MAX_TOPIC_FILTERS: usize> =
-    GenericSubackPacket<'p, Unsuback, MAX_TOPIC_FILTERS>;
+pub type SubackPacket<'p, const MAX_TOPIC_FILTERS: usize, const MAX_USER_PROPERTIES: usize> =
+    GenericSubackPacket<'p, Suback, MAX_TOPIC_FILTERS, MAX_USER_PROPERTIES>;
+pub type UnsubackPacket<'p, const MAX_TOPIC_FILTERS: usize, const MAX_USER_PROPERTIES: usize> =
+    GenericSubackPacket<'p, Unsuback, MAX_TOPIC_FILTERS, MAX_USER_PROPERTIES>;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct GenericSubackPacket<'p, T: SubackPacketType, const MAX_TOPIC_FILTERS: usize> {
+pub struct GenericSubackPacket<
+    'p,
+    T,
+    const MAX_TOPIC_FILTERS: usize,
+    const MAX_USER_PROPERTIES: usize,
+> {
     pub packet_identifier: PacketIdentifier,
+
     // reason string is currently unused and does not have to be read into memory.
     // reason_string: Option<ReasonString<'p>>,
+    pub user_properties: Vec<UserProperty<'p>, MAX_USER_PROPERTIES>,
+
     pub reason_codes: Vec<ReasonCode, MAX_TOPIC_FILTERS>,
     _phantom_data: PhantomData<&'p T>,
 }
 
-impl<T: SubackPacketType, const MAX_TOPIC_FILTERS: usize> Packet
-    for GenericSubackPacket<'_, T, MAX_TOPIC_FILTERS>
+impl<T: SubackPacketType, const MAX_TOPIC_FILTERS: usize, const MAX_USER_PROPERTIES: usize> Packet
+    for GenericSubackPacket<'_, T, MAX_TOPIC_FILTERS, MAX_USER_PROPERTIES>
 {
     const PACKET_TYPE: PacketType = T::PACKET_TYPE;
 }
-impl<'p, T: SubackPacketType, const MAX_TOPIC_FILTERS: usize> RxPacket<'p>
-    for GenericSubackPacket<'static, T, MAX_TOPIC_FILTERS>
+impl<'p, T: SubackPacketType, const MAX_TOPIC_FILTERS: usize, const MAX_USER_PROPERTIES: usize>
+    RxPacket<'p> for GenericSubackPacket<'p, T, MAX_TOPIC_FILTERS, MAX_USER_PROPERTIES>
 {
     async fn receive<R: Read, B: BufferProvider<'p>>(
         header: &FixedHeader,
@@ -80,6 +88,9 @@ impl<'p, T: SubackPacketType, const MAX_TOPIC_FILTERS: usize> RxPacket<'p>
             return Err(RxError::ProtocolError);
         }
 
+        let mut seen_reason_string = false;
+        let mut user_properties = Vec::new();
+
         while properties_length > 0 {
             verbose!(
                 "reading property identifier (remaining length: {} bytes)",
@@ -96,8 +107,6 @@ impl<'p, T: SubackPacketType, const MAX_TOPIC_FILTERS: usize> RxPacket<'p>
                 r.remaining_len()
             );
 
-            let mut seen_reason_string = false;
-
             #[rustfmt::skip]
             match property_type {
                 PropertyType::ReasonString if seen_reason_string => return Err(RxError::ProtocolError),
@@ -106,18 +115,26 @@ impl<'p, T: SubackPacketType, const MAX_TOPIC_FILTERS: usize> RxPacket<'p>
                     let len = u16::read(r).await? as usize;
                     verbose!("skipping reason string ({} bytes)", len);
                     r.skip(len).await?;
-                    properties_length = properties_length.checked_sub(wlen!(u16) + len).ok_or(RxError::MalformedPacket)?;
+                    properties_length = properties_length
+                        .checked_sub(wlen!(u16) + len)
+                        .ok_or(RxError::MalformedPacket)?;
                 },
+                PropertyType::UserProperty if !user_properties.is_full() => {
+                    let user_property = UserProperty::read(r).await?;
+
+                    properties_length = properties_length
+                        .checked_sub(user_property.0.written_len())
+                        .ok_or(RxError::MalformedPacket)?;
+
+                    // Safety: `!Vec::is_full` guarantees there is space
+                    unsafe { user_properties.push_unchecked(user_property) };
+                }
                 PropertyType::UserProperty => {
-                    let len = u16::read(r).await? as usize;
-                    verbose!("skipping user property name ({} bytes)", len);
-                    r.skip(len).await?;
-                    properties_length = properties_length.checked_sub(wlen!(u16) + len).ok_or(RxError::MalformedPacket)?;
-                    let len = u16::read(r).await? as usize;
-                    verbose!("skipping user property value ({} bytes)", len);
-                    r.skip(len).await?;
-                    properties_length = properties_length.checked_sub(wlen!(u16) + len).ok_or(RxError::MalformedPacket)?;
-                },
+                    let len = UserProperty::skip(r).await?;
+                    properties_length = properties_length
+                        .checked_sub(len)
+                        .ok_or(RxError::MalformedPacket)?;
+                }
                 p => {
                     // Malformed packet according to <https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901029>
                     trace!("invalid {:?} property: {:?}", T::PACKET_TYPE, p);
@@ -153,6 +170,7 @@ impl<'p, T: SubackPacketType, const MAX_TOPIC_FILTERS: usize> RxPacket<'p>
 
         let packet = Self {
             packet_identifier,
+            user_properties,
             reason_codes,
             _phantom_data: PhantomData,
         };
@@ -170,16 +188,16 @@ mod unit {
 
         use crate::{
             test::rx::decode,
-            types::{PacketIdentifier, ReasonCode},
-            v5::packet::SubackPacket,
+            types::{MqttString, MqttStringPair, PacketIdentifier, ReasonCode},
+            v5::{packet::SubackPacket, property::UserProperty},
         };
 
         #[tokio::test]
         #[test_log::test]
         async fn decode_payload() {
             #[rustfmt::skip]
-            let packet: SubackPacket<'_, 12> = decode!(
-                SubackPacket<12>,
+            let packet = decode!(
+                SubackPacket<12, 16>,
                 15,
                 [
                     0x90,
@@ -198,6 +216,7 @@ mod unit {
                 PacketIdentifier::new(NonZero::new(6025).unwrap())
             );
             // assert!(packet.reason_string.is_none());
+            assert!(packet.user_properties.is_empty());
 
             let mut reason_codes: Vec<_, 12> = Vec::new();
             reason_codes.push(ReasonCode::Success).unwrap();
@@ -229,8 +248,8 @@ mod unit {
         #[test_log::test]
         async fn decode_properties() {
             #[rustfmt::skip]
-            let packet: SubackPacket<'_, 1> = decode!(
-                SubackPacket<1>,
+            let packet = decode!(
+                SubackPacket<1, 16>,
                 61,
                 [
                     0x90,
@@ -261,6 +280,19 @@ mod unit {
             //     packet.reason_string,
             //     Some(ReasonString(MqttString::try_from("crazy things").unwrap()))
             // );
+            assert_eq!(
+                packet.user_properties,
+                [
+                    UserProperty(MqttStringPair::new(
+                        MqttString::from_str("some name").unwrap(),
+                        MqttString::from_str("any value").unwrap()
+                    )),
+                    UserProperty(MqttStringPair::new(
+                        MqttString::from_str("any key").unwrap(),
+                        MqttString::from_str("a value").unwrap()
+                    ))
+                ]
+            );
 
             let mut reason_codes: Vec<_, 1> = Vec::new();
             reason_codes.push(ReasonCode::Success).unwrap();
@@ -275,16 +307,16 @@ mod unit {
 
         use crate::{
             test::rx::decode,
-            types::{PacketIdentifier, ReasonCode},
-            v5::packet::UnsubackPacket,
+            types::{MqttString, MqttStringPair, PacketIdentifier, ReasonCode},
+            v5::{packet::UnsubackPacket, property::UserProperty},
         };
 
         #[tokio::test]
         #[test_log::test]
         async fn decode_payload() {
             #[rustfmt::skip]
-            let packet: UnsubackPacket<'_, 7> = decode!(
-                UnsubackPacket<7>,
+            let packet = decode!(
+                UnsubackPacket<7, 16>,
                 10,
                 [
                     0xB0,
@@ -302,6 +334,7 @@ mod unit {
                 PacketIdentifier::new(NonZero::new(41972).unwrap())
             );
             // assert!(packet.reason_string.is_none());
+            assert!(packet.user_properties.is_empty());
 
             let mut reason_codes: Vec<_, 7> = Vec::new();
 
@@ -326,8 +359,8 @@ mod unit {
         #[test_log::test]
         async fn decode_properties() {
             #[rustfmt::skip]
-            let packet: UnsubackPacket<'_, 1> = decode!(
-                UnsubackPacket<1>,
+            let packet = decode!(
+                UnsubackPacket<1, 16>,
                 78,
                 [
                     0xB0, 
@@ -361,6 +394,19 @@ mod unit {
             //     packet.reason_string,
             //     Some(ReasonString(MqttString::try_from("get outta here").unwrap()))
             // );
+            assert_eq!(
+                packet.user_properties,
+                [
+                    UserProperty(MqttStringPair::new(
+                        MqttString::from_str("imagine").unwrap(),
+                        MqttString::from_str("all the people").unwrap()
+                    )),
+                    UserProperty(MqttStringPair::new(
+                        MqttString::from_str("pride").unwrap(),
+                        MqttString::from_str("(in the name of love)").unwrap()
+                    ))
+                ]
+            );
 
             let mut reason_codes: Vec<_, 1> = Vec::new();
             reason_codes.push(ReasonCode::Success).unwrap();

--- a/src/v5/packet/subscribe.rs
+++ b/src/v5/packet/subscribe.rs
@@ -6,22 +6,28 @@ use crate::{
     io::write::Writable,
     packet::{Packet, TxError, TxPacket},
     types::{PacketIdentifier, SubscriptionFilter, TooLargeToEncode, VarByteInt},
-    v5::property::SubscriptionIdentifier,
+    v5::property::{SubscriptionIdentifier, UserProperty},
 };
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct SubscribePacket<'p, const MAX_TOPIC_FILTERS: usize> {
+pub struct SubscribePacket<'p, const MAX_TOPIC_FILTERS: usize, const MAX_USER_PROPERTIES: usize> {
     packet_identifier: PacketIdentifier,
 
     subscription_identifier: Option<SubscriptionIdentifier>,
+    user_properties: Vec<UserProperty<'p>, MAX_USER_PROPERTIES>,
+
     subscribe_filters: Vec<SubscriptionFilter<'p>, MAX_TOPIC_FILTERS>,
 }
 
-impl<const MAX_TOPIC_FILTERS: usize> Packet for SubscribePacket<'_, MAX_TOPIC_FILTERS> {
+impl<const MAX_TOPIC_FILTERS: usize, const MAX_USER_PROPERTIES: usize> Packet
+    for SubscribePacket<'_, MAX_TOPIC_FILTERS, MAX_USER_PROPERTIES>
+{
     const PACKET_TYPE: PacketType = PacketType::Subscribe;
 }
-impl<const MAX_TOPIC_FILTERS: usize> TxPacket for SubscribePacket<'_, MAX_TOPIC_FILTERS> {
+impl<const MAX_TOPIC_FILTERS: usize, const MAX_USER_PROPERTIES: usize> TxPacket
+    for SubscribePacket<'_, MAX_TOPIC_FILTERS, MAX_USER_PROPERTIES>
+{
     fn remaining_len(&self) -> VarByteInt {
         // Safety: SUBSCRIBE packets that are too long to encode cannot be created
         unsafe { self.remaining_len_raw().unwrap_unchecked() }
@@ -36,30 +42,38 @@ impl<const MAX_TOPIC_FILTERS: usize> TxPacket for SubscribePacket<'_, MAX_TOPIC_
         self.packet_identifier.write(write).await?;
         self.properties_length().write(write).await?;
         self.subscription_identifier.write(write).await?;
+
+        for user_property in &self.user_properties {
+            user_property.write(write).await?;
+        }
+
         self.subscribe_filters.write(write).await?;
 
         Ok(())
     }
 }
 
-impl<'p, const MAX_TOPIC_FILTERS: usize> SubscribePacket<'p, MAX_TOPIC_FILTERS> {
+impl<'p, const MAX_TOPIC_FILTERS: usize, const MAX_USER_PROPERTIES: usize>
+    SubscribePacket<'p, MAX_TOPIC_FILTERS, MAX_USER_PROPERTIES>
+{
     pub fn new(
         packet_identifier: PacketIdentifier,
-        subscription_identifier: Option<VarByteInt>,
+        subscription_identifier: Option<SubscriptionIdentifier>,
+        user_properties: Vec<UserProperty<'p>, MAX_USER_PROPERTIES>,
         subscribe_filters: Vec<SubscriptionFilter<'p>, MAX_TOPIC_FILTERS>,
     ) -> Result<Self, TooLargeToEncode> {
         let p = Self {
             packet_identifier,
-            subscription_identifier: subscription_identifier.map(Into::into),
+            subscription_identifier,
+            user_properties,
             subscribe_filters,
         };
 
-        const GUARANTEED_ENCODABLE_TOPIC_FILTERS: usize = 4095;
-
-        if MAX_TOPIC_FILTERS > GUARANTEED_ENCODABLE_TOPIC_FILTERS {
-            p.remaining_len_raw().map(|_| p)
-        } else {
+        // Reference to `SubscribePacket::remaining_len_raw` as to why this is true.
+        if MAX_USER_PROPERTIES <= 1021 && MAX_TOPIC_FILTERS <= 2053 {
             Ok(p)
+        } else {
+            p.remaining_len_raw().map(|_| p)
         }
     }
 
@@ -73,20 +87,41 @@ impl<'p, const MAX_TOPIC_FILTERS: usize> SubscribePacket<'p, MAX_TOPIC_FILTERS> 
 
         let total_length = variable_header_length + total_properties_length + body_length;
 
-        // MAX_TOPIC_FILTERS has to be less than or equal to 4095 to guarantee:
-        //   Max length = 11 + MAX_TOPIC_FILTERS * 65538 <= VarByteInt::MAX_ENCODABLE
+        // max length = MAX_USER_PROPERTIES * 131077 + MAX_TOPIC_FILTERS * 65538 + 11
+        // Invariant: The following inequation must be fulfilled to guarantee
+        // max length <= VarByteInt::MAX_ENCODABLE:
+        //
+        // MAX_USER_PROPERTIES * 131077 + MAX_TOPIC_FILTERS * 65538 + 11 <= VarByteInt::MAX_ENCODABLE
+        //
+        // Given the maximum allowed value of MAX_USER_PROPERTIES = 1021 in the client, the following
+        // inequation must be fulfilled:
+        //
+        // 1021 * 131077 + MAX_TOPIC_FILTERS * 65538 + 11 <= VarByteInt::MAX_ENCODABLE
+        //
+        // This results in the statement:
+        //
+        // MAX_TOPIC_FILTERS <= 2053 => max length <= VarByteInt::MAX_ENCODABLE
+        //
         // packet identifier: 2
         // property length: 4
-        // properties: 5
+        // properties: MAX_USER_PROPERTIES * 131077 + 5
         // topic filters: MAX_TOPIC_FILTERS * 65538
         VarByteInt::try_from(total_length as u32)
     }
 
     pub fn properties_length(&self) -> VarByteInt {
-        let len = self.subscription_identifier.written_len();
+        let len = self.subscription_identifier.written_len()
+            + self
+                .user_properties
+                .iter()
+                .map(Writable::written_len)
+                .sum::<usize>();
 
-        // Invariant: Max length = 5 < VarByteInt::MAX_ENCODABLE
+        // max length = MAX_USER_PROPERTIES * 131077 + 5
+        // Invariant: MAX_USER_PROPERTIES <= 2047 => max length <= VarByteInt::MAX_ENCODABLE
+        //
         // subscription identifier: 5
+        // user properties: MAX_USER_PROPERTIES * 131077
         VarByteInt::new_unchecked(len as u32)
     }
 }
@@ -100,44 +135,37 @@ mod unit {
     use crate::{
         client::options::{RetainHandling, SubscriptionOptions},
         test::tx::encode,
-        types::{MqttString, PacketIdentifier, QoS, SubscriptionFilter, TopicFilter, VarByteInt},
-        v5::packet::SubscribePacket,
+        types::{
+            MqttString, MqttStringPair, PacketIdentifier, SubscriptionFilter, TopicFilter,
+            VarByteInt,
+        },
+        v5::{
+            packet::SubscribePacket,
+            property::{SubscriptionIdentifier, UserProperty},
+        },
     };
 
     #[tokio::test]
     #[test_log::test]
     async fn encode_payload() {
-        let mut topics = Vec::new();
-
-        topics
-            .push(SubscriptionFilter::new(
+        let topics = [
+            SubscriptionFilter::new(
                 TopicFilter::new(MqttString::try_from("test/hello").unwrap()).unwrap(),
-                &SubscriptionOptions {
-                    retain_handling: RetainHandling::AlwaysSend,
-                    retain_as_published: false,
-                    no_local: true,
-                    qos: QoS::AtMostOnce,
-                    subscription_identifier: None,
-                },
-            ))
-            .unwrap();
-
-        topics
-            .push(SubscriptionFilter::new(
+                &SubscriptionOptions::new().no_local(),
+            ),
+            SubscriptionFilter::new(
                 TopicFilter::new(MqttString::try_from("asdfjklo/#").unwrap()).unwrap(),
-                &SubscriptionOptions {
-                    retain_handling: RetainHandling::NeverSend,
-                    retain_as_published: true,
-                    no_local: false,
-                    qos: QoS::ExactlyOnce,
-                    subscription_identifier: None,
-                },
-            ))
-            .unwrap();
-        let packet: SubscribePacket<'_, 2> = SubscribePacket::new(
+                &SubscriptionOptions::new()
+                    .retain_handling(RetainHandling::NeverSend)
+                    .retain_as_published()
+                    .exactly_once(),
+            ),
+        ];
+        let packet: SubscribePacket<'_, 2, 0> = SubscribePacket::new(
             PacketIdentifier::new(NonZero::new(23197).unwrap()),
             None,
-            topics,
+            Vec::new(),
+            topics.into(),
         )
         .unwrap();
 
@@ -181,36 +209,57 @@ mod unit {
     #[tokio::test]
     #[test_log::test]
     async fn encode_properties() {
-        let mut topics = Vec::new();
-        topics
-            .push(SubscriptionFilter::new(
-                TopicFilter::new(MqttString::try_from("abc/+/y").unwrap()).unwrap(),
-                &SubscriptionOptions {
-                    retain_handling: RetainHandling::SendIfNotSubscribedBefore,
-                    retain_as_published: true,
-                    no_local: false,
-                    qos: QoS::AtMostOnce,
-                    subscription_identifier: Some(VarByteInt::from(23459u16)),
-                },
-            ))
-            .unwrap();
+        let topics = [SubscriptionFilter::new(
+            TopicFilter::new(MqttString::try_from("abc/+/y").unwrap()).unwrap(),
+            &SubscriptionOptions::new()
+                .retain_handling(RetainHandling::SendIfNotSubscribedBefore)
+                .retain_as_published()
+                .subscription_identifier(VarByteInt::from(23459u16)),
+        )];
 
-        let packet: SubscribePacket<'_, 10> = SubscribePacket::new(
+        let user_properties = [
+            UserProperty(MqttStringPair::new(
+                MqttString::from_str("answer").unwrap(),
+                MqttString::from_str("42").unwrap(),
+            )),
+            UserProperty(MqttStringPair::new(
+                MqttString::from_str("chaos").unwrap(),
+                MqttString::from_str("maximum").unwrap(),
+            )),
+        ];
+
+        let packet: SubscribePacket<'_, 10, 16> = SubscribePacket::new(
             PacketIdentifier::new(NonZero::new(23197).unwrap()),
-            Some(VarByteInt::new(87986078u32).unwrap()),
-            topics,
+            Some(SubscriptionIdentifier(
+                VarByteInt::new(87986078u32).unwrap(),
+            )),
+            user_properties.into(),
+            topics.into(),
         )
         .unwrap();
 
         #[rustfmt::skip]
         encode!(packet, [
                 0x82, //
-                0x12, // remaining length
+                0x30, // remaining length
                 0x5A, // Packet identifier MSB
                 0x9D, // Packet identifier LSB
-                0x05, // Property length
-                // Property - Subscription Identifier
-                0x0B, 0x9E, 0x9F, 0xFA, 0x29, // Payload - Topic Filter
+                0x23, // Property length
+
+                // Subscription Identifier
+                0x0B, 0x9E, 0x9F, 0xFA, 0x29,
+
+                // User Property
+                0x26,
+                0x00, 0x06, b'a', b'n', b's', b'w', b'e', b'r',
+                0x00, 0x02, b'4', b'2',
+
+                // User Property
+                0x26,
+                0x00, 0x05, b'c', b'h', b'a', b'o', b's',
+                0x00, 0x07, b'm', b'a', b'x', b'i', b'm', b'u', b'm',
+                
+                // Payload - Topic Filter
                 0x00, 0x07, b'a', b'b', b'c', b'/', b'+', b'/', b'y', 0x18,
             ]
         );

--- a/src/v5/packet/unsubscribe.rs
+++ b/src/v5/packet/unsubscribe.rs
@@ -5,20 +5,28 @@ use crate::{
     header::{FixedHeader, PacketType},
     io::write::Writable,
     packet::{Packet, TxError, TxPacket},
-    types::{MqttString, PacketIdentifier, TooLargeToEncode, TopicFilter, VarByteInt},
+    types::{PacketIdentifier, TooLargeToEncode, TopicFilter, VarByteInt},
+    v5::property::UserProperty,
 };
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct UnsubscribePacket<'p, const MAX_TOPIC_FILTERS: usize> {
+pub struct UnsubscribePacket<'p, const MAX_TOPIC_FILTERS: usize, const MAX_USER_PROPERTIES: usize> {
     packet_identifier: PacketIdentifier,
+
+    user_properties: Vec<UserProperty<'p>, MAX_USER_PROPERTIES>,
+
     topic_filters: Vec<TopicFilter<'p>, MAX_TOPIC_FILTERS>,
 }
 
-impl<const MAX_TOPIC_FILTERS: usize> Packet for UnsubscribePacket<'_, MAX_TOPIC_FILTERS> {
+impl<const MAX_TOPIC_FILTERS: usize, const MAX_USER_PROPERTIES: usize> Packet
+    for UnsubscribePacket<'_, MAX_TOPIC_FILTERS, MAX_USER_PROPERTIES>
+{
     const PACKET_TYPE: PacketType = PacketType::Unsubscribe;
 }
-impl<const MAX_TOPIC_FILTERS: usize> TxPacket for UnsubscribePacket<'_, MAX_TOPIC_FILTERS> {
+impl<const MAX_TOPIC_FILTERS: usize, const MAX_USER_PROPERTIES: usize> TxPacket
+    for UnsubscribePacket<'_, MAX_TOPIC_FILTERS, MAX_USER_PROPERTIES>
+{
     fn remaining_len(&self) -> VarByteInt {
         // Safety: UNSUBSCRIBE packets that are too long to encode cannot be created
         unsafe { self.remaining_len_raw().unwrap_unchecked() }
@@ -32,6 +40,10 @@ impl<const MAX_TOPIC_FILTERS: usize> TxPacket for UnsubscribePacket<'_, MAX_TOPI
         self.packet_identifier.write(write).await?;
         self.properties_length().write(write).await?;
 
+        for user_property in &self.user_properties {
+            user_property.write(write).await?;
+        }
+
         for t in &self.topic_filters {
             t.write(write).await?;
         }
@@ -40,23 +52,27 @@ impl<const MAX_TOPIC_FILTERS: usize> TxPacket for UnsubscribePacket<'_, MAX_TOPI
     }
 }
 
-impl<'p, const MAX_TOPIC_FILTERS: usize> UnsubscribePacket<'p, MAX_TOPIC_FILTERS> {
-    /// If `MAX_TOPIC_FILTERS` is to less than or equal to 4095, it is guaranteed that `TooLargeToEncode` is never returned.
+impl<'p, const MAX_TOPIC_FILTERS: usize, const MAX_USER_PROPERTIES: usize>
+    UnsubscribePacket<'p, MAX_TOPIC_FILTERS, MAX_USER_PROPERTIES>
+{
+    /// If `MAX_TOPIC_FILTERS` is to less than or equal to 2053 and `MAX_USER_PROPERTIES` is
+    /// less than or equal to 1021, it is guaranteed that `TooLargeToEncode` is never returned.
     pub fn new(
         packet_identifier: PacketIdentifier,
+        user_properties: Vec<UserProperty<'p>, MAX_USER_PROPERTIES>,
         topic_filters: Vec<TopicFilter<'p>, MAX_TOPIC_FILTERS>,
     ) -> Result<Self, TooLargeToEncode> {
         let p = Self {
             packet_identifier,
+            user_properties,
             topic_filters,
         };
 
-        const GUARANTEED_ENCODABLE_TOPIC_FILTERS: usize = 4095;
-
-        if MAX_TOPIC_FILTERS > GUARANTEED_ENCODABLE_TOPIC_FILTERS {
-            p.remaining_len_raw().map(|_| p)
-        } else {
+        // Reference to `UnsubscribePacket::remaining_len_raw` as to why this is true.
+        if MAX_USER_PROPERTIES <= 1021 && MAX_TOPIC_FILTERS <= 2053 {
             Ok(p)
+        } else {
+            p.remaining_len_raw().map(|_| p)
         }
     }
 
@@ -66,27 +82,44 @@ impl<'p, const MAX_TOPIC_FILTERS: usize> UnsubscribePacket<'p, MAX_TOPIC_FILTERS
         let properties_length = self.properties_length();
         let total_properties_length = properties_length.size() + properties_length.written_len();
 
-        let body_length: usize = self
-            .topic_filters
-            .iter()
-            .map(TopicFilter::as_ref)
-            .map(MqttString::written_len)
-            .sum();
+        let body_length: usize = self.topic_filters.iter().map(Writable::written_len).sum();
 
         let total_length = variable_header_length + total_properties_length + body_length;
 
-        // MAX_TOPIC_FILTERS has to be less than or equal to 4095 to guarantee:
-        //   Max length = 3 + MAX_TOPIC_FILTERS * 65537 <= VarByteInt::MAX_ENCODABLE
+        // max length = MAX_USER_PROPERTIES * 131077 + MAX_TOPIC_FILTERS * 65537 + 6
+        // Invariant: The following inequation must be fulfilled to guarantee
+        // max length <= VarByteInt::MAX_ENCODABLE:
+        //
+        // MAX_USER_PROPERTIES * 131077 + MAX_TOPIC_FILTERS * 65537 + 6 <= VarByteInt::MAX_ENCODABLE
+        //
+        // Given the maximum allowed value of MAX_USER_PROPERTIES = 1021 in the client, the following
+        // inequation must be fulfilled:
+        //
+        // 1021 * 131077 + MAX_TOPIC_FILTERS * 65537 + 6 <= VarByteInt::MAX_ENCODABLE
+        //
+        // This results in the statement:
+        //
+        // MAX_TOPIC_FILTERS <= 2053 => max length <= VarByteInt::MAX_ENCODABLE
+        //
         // packet identifier: 2
-        // property length: 1
-        // properties: 0
+        // property length: 4
+        // properties: MAX_USER_PROPERTIES * 131077
         // topic filters: MAX_TOPIC_FILTERS * 65537
         VarByteInt::try_from(total_length as u32)
     }
 
     pub fn properties_length(&self) -> VarByteInt {
-        // Invariant: Max length = 0 < VarByteInt::MAX_ENCODABLE
-        VarByteInt::new_unchecked(0)
+        let len = self
+            .user_properties
+            .iter()
+            .map(Writable::written_len)
+            .sum::<usize>();
+
+        // max length = MAX_USER_PROPERTIES * 131077
+        // Invariant: MAX_USER_PROPERTIES <= 2047 => max length <= VarByteInt::MAX_ENCODABLE
+        //
+        // user properties: MAX_USER_PROPERTIES * 131077
+        VarByteInt::new_unchecked(len as u32)
     }
 }
 
@@ -98,25 +131,24 @@ mod unit {
 
     use crate::{
         test::tx::encode,
-        types::{MqttString, PacketIdentifier, TopicFilter},
-        v5::packet::UnsubscribePacket,
+        types::{MqttString, MqttStringPair, PacketIdentifier, TopicFilter},
+        v5::{packet::UnsubscribePacket, property::UserProperty},
     };
 
     #[tokio::test]
     #[test_log::test]
     async fn encode_payload() {
-        let mut topics = Vec::new();
+        let topics = [
+            TopicFilter::new(MqttString::try_from("test/+/topic").unwrap()).unwrap(),
+            TopicFilter::new(MqttString::try_from("test/#").unwrap()).unwrap(),
+        ];
 
-        topics
-            .push(TopicFilter::new(MqttString::try_from("test/+/topic").unwrap()).unwrap())
-            .unwrap();
-        topics
-            .push(TopicFilter::new(MqttString::try_from("test/#").unwrap()).unwrap())
-            .unwrap();
-
-        let packet: UnsubscribePacket<'_, 2> =
-            UnsubscribePacket::new(PacketIdentifier::new(NonZero::new(9874).unwrap()), topics)
-                .unwrap();
+        let packet = UnsubscribePacket::<2, 16>::new(
+            PacketIdentifier::new(NonZero::new(9874).unwrap()),
+            Vec::new(),
+            topics.into(),
+        )
+        .unwrap();
 
         #[rustfmt::skip]
         encode!(packet, [
@@ -129,6 +161,75 @@ mod unit {
                 0x00, 0x0C, b't', b'e', b's', b't', b'/', b'+', b'/', b't', b'o', b'p', b'i', b'c',
                 // Payload
                 0x00, 0x06, b't', b'e', b's', b't', b'/', b'#',
+            ]
+        );
+    }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn encode_properties() {
+        let topics = [TopicFilter::new(
+            MqttString::try_from("https://www.youtube.com/watch?v=dQw4w9WgXcQ").unwrap(),
+        )
+        .unwrap()];
+        let user_properties = [
+            UserProperty(MqttStringPair::new(
+                MqttString::from_str("give up").unwrap(),
+                MqttString::from_str("false").unwrap(),
+            )),
+            UserProperty(MqttStringPair::new(
+                MqttString::from_str("let down").unwrap(),
+                MqttString::from_str("false").unwrap(),
+            )),
+            UserProperty(MqttStringPair::new(
+                MqttString::from_str("run around").unwrap(),
+                MqttString::from_str("false").unwrap(),
+            )),
+            UserProperty(MqttStringPair::new(
+                MqttString::from_str("hurt").unwrap(),
+                MqttString::from_str("false").unwrap(),
+            )),
+        ];
+
+        let packet = UnsubscribePacket::<1, 16>::new(
+            PacketIdentifier::new(NonZero::new(23913).unwrap()),
+            user_properties.into(),
+            topics.into(),
+        )
+        .unwrap();
+
+        #[rustfmt::skip]
+        encode!(packet, [
+                0xA2,
+                0x75,
+                0x5D, // Packet identifier MSB
+                0x69, // Packet identifier LSB
+                0x45, // Property length
+
+                // User Property
+                0x26,
+                0x00, 0x07, b'g', b'i', b'v', b'e', b' ', b'u', b'p',
+                0x00, 0x05, b'f', b'a', b'l', b's', b'e',
+
+                // User Property
+                0x26,
+                0x00, 0x08, b'l', b'e', b't', b' ', b'd', b'o', b'w', b'n',
+                0x00, 0x05, b'f', b'a', b'l', b's', b'e',
+
+                // User Property
+                0x26,
+                0x00, 0x0A, b'r', b'u', b'n', b' ', b'a', b'r', b'o', b'u', b'n', b'd',
+                0x00, 0x05, b'f', b'a', b'l', b's', b'e',
+
+                // User Property
+                0x26,
+                0x00, 0x04, b'h', b'u', b'r', b't',
+                0x00, 0x05, b'f', b'a', b'l', b's', b'e',
+
+                // Payload
+                0x00, 0x2B, b'h', b't', b't', b'p', b's', b':', b'/', b'/', b'w', b'w', b'w', b'.', b'y',
+                b'o', b'u', b't', b'u', b'b', b'e', b'.', b'c', b'o', b'm', b'/', b'w', b'a', b't', b'c',
+                b'h', b'?', b'v', b'=', b'd', b'Q', b'w', b'4', b'w', b'9', b'W', b'g', b'X', b'c', b'Q', 
             ]
         );
     }

--- a/src/v5/property/values.rs
+++ b/src/v5/property/values.rs
@@ -1,14 +1,17 @@
 use core::num::NonZero;
 
 use crate::{
+    buffer::BufferProvider,
     config::{KeepAlive, MaximumPacketSize, ReceiveMaximum, SessionExpiryInterval},
     eio::{Read, Write},
+    fmt::verbose,
     io::{
         err::{ReadError, WriteError},
-        read::{Readable, Store},
+        read::{BodyReader, Readable, Store},
         write::{Writable, wlen},
     },
-    types::{MqttBinary, MqttString, QoS, TopicName, VarByteInt},
+    packet::RxError,
+    types::{MqttBinary, MqttString, MqttStringPair, QoS, TopicName, VarByteInt},
     v5::property::{Property, PropertyType},
 };
 
@@ -33,7 +36,7 @@ macro_rules! property {
         }
 
         impl<R: Read> Readable<R> for $name {
-            async fn read(read: &mut R) -> Result<Self, ReadError<<R>::Error>> {
+            async fn read(read: &mut R) -> Result<Self, ReadError<R::Error>> {
                 let content = <$ty as Readable<R>>::read(read).await?;
                 Ok(Self(content))
             }
@@ -72,7 +75,7 @@ macro_rules! property {
         }
 
         impl<$lt, R: Read + Store<$lt>> Readable<R> for $name<$lt> {
-            async fn read(read: &mut R) -> Result<Self, ReadError<<R>::Error>> {
+            async fn read(read: &mut R) -> Result<Self, ReadError<R::Error>> {
                 let content = <$ty as Readable<R>>::read(read).await?;
                 Ok(Self(content))
             }
@@ -122,7 +125,22 @@ property!(TopicAlias, u16);
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct MaximumQoS(pub(crate) QoS);
 property!(RetainAvailable, bool);
-// Insert UserProperty here
+property!(UserProperty<'c>, MqttStringPair<'c>);
+
+impl UserProperty<'_> {
+    pub async fn skip<'b, R: Read, B: BufferProvider<'b>>(
+        read: &mut BodyReader<'_, 'b, R, B>,
+    ) -> Result<usize, RxError<R::Error, B::ProvisionError>> {
+        let name_len = u16::read(read).await? as usize;
+        verbose!("skipping user property name ({} bytes)", name_len);
+        read.skip(name_len).await?;
+        let value_len = u16::read(read).await? as usize;
+        verbose!("skipping user property value ({} bytes)", value_len);
+        read.skip(value_len).await?;
+        Ok(wlen!(u16) + name_len + wlen!(u16) + value_len)
+    }
+}
+
 property!(WildcardSubscriptionAvailable, bool);
 property!(SubscriptionIdentifierAvailable, bool);
 property!(SharedSubscriptionAvailable, bool);
@@ -137,7 +155,7 @@ impl Property for ServerKeepAlive {
 }
 
 impl<R: Read> Readable<R> for ServerKeepAlive {
-    async fn read(read: &mut R) -> Result<Self, ReadError<<R>::Error>> {
+    async fn read(read: &mut R) -> Result<Self, ReadError<R::Error>> {
         let value = u16::read(read).await?;
 
         Ok(Self(
@@ -178,7 +196,7 @@ impl Property for SessionExpiryInterval {
 }
 
 impl<R: Read> Readable<R> for SessionExpiryInterval {
-    async fn read(read: &mut R) -> Result<Self, ReadError<<R>::Error>> {
+    async fn read(read: &mut R) -> Result<Self, ReadError<R::Error>> {
         let value = u32::read(read).await?;
 
         Ok(match value {
@@ -216,7 +234,7 @@ impl Property for MaximumQoS {
     }
 }
 impl<R: Read> Readable<R> for MaximumQoS {
-    async fn read(read: &mut R) -> Result<Self, ReadError<<R>::Error>> {
+    async fn read(read: &mut R) -> Result<Self, ReadError<R::Error>> {
         let byte = u8::read(read).await?;
         let qos = QoS::try_from_bits(byte).ok_or(ReadError::MalformedPacket)?;
         Ok(Self(qos))
@@ -232,7 +250,7 @@ impl Property for MaximumPacketSize {
     }
 }
 impl<R: Read> Readable<R> for MaximumPacketSize {
-    async fn read(read: &mut R) -> Result<Self, ReadError<<R>::Error>> {
+    async fn read(read: &mut R) -> Result<Self, ReadError<R::Error>> {
         let max = u32::read(read).await?;
 
         NonZero::new(max)
@@ -267,7 +285,7 @@ impl Property for ReceiveMaximum {
     }
 }
 impl<R: Read> Readable<R> for ReceiveMaximum {
-    async fn read(read: &mut R) -> Result<Self, ReadError<<R>::Error>> {
+    async fn read(read: &mut R) -> Result<Self, ReadError<R::Error>> {
         let max = u16::read(read).await?;
 
         NonZero::new(max).map(Self).ok_or(ReadError::ProtocolError)

--- a/tests/common/assert.rs
+++ b/tests/common/assert.rs
@@ -30,9 +30,9 @@ macro_rules! assert_subscribe {
 }
 
 macro_rules! assert_unsubscribe {
-    ($client:expr, $topic:expr) => {
+    ($client:expr, $options:expr, $topic:expr) => {
         assert_ok!(
-            crate::common::utils::unsubscribe(&mut $client, $topic).await,
+            crate::common::utils::unsubscribe(&mut $client, $options, $topic).await,
             "Failed to unsubscribe"
         );
     };

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -5,10 +5,10 @@ use rust_mqtt::{
     buffer::AllocBuffer,
     client::{
         Client,
-        options::{ConnectOptions, DisconnectOptions, RetainHandling, SubscriptionOptions},
+        options::{ConnectOptions, DisconnectOptions, SubscriptionOptions},
     },
     config::{KeepAlive, MaximumPacketSize, SessionExpiryInterval},
-    types::{MqttBinary, MqttString, QoS},
+    types::{MqttBinary, MqttString},
 };
 use tokio::net::TcpStream;
 
@@ -19,7 +19,7 @@ pub mod failing;
 pub mod fmt;
 pub mod utils;
 
-type DefaultClient<'a, T> = Client<'a, T, AllocBuffer, 1, 1, 1, 1>;
+type DefaultClient<'a, T> = Client<'a, T, AllocBuffer, 1, 1, 1, 1, 16>;
 
 pub type TestClient<'a> = DefaultClient<'a, FromTokio<TcpStream>>;
 pub type FailingClient<'a> = DefaultClient<'a, FromTokio<FailingTcp>>;
@@ -36,17 +36,12 @@ pub const NO_SESSION_CONNECT_OPTIONS: &ConnectOptions<'static> = &ConnectOptions
     maximum_packet_size: MaximumPacketSize::Unlimited,
     session_expiry_interval: SessionExpiryInterval::EndOnDisconnect,
     request_response_information: false,
+    user_properties: &[],
     user_name: Some(USERNAME),
     password: Some(PASSWORD),
     will: None,
 };
 
-pub const DEFAULT_QOS0_SUB_OPTIONS: SubscriptionOptions = SubscriptionOptions {
-    retain_handling: RetainHandling::AlwaysSend,
-    retain_as_published: false,
-    no_local: false,
-    qos: QoS::AtMostOnce,
-    subscription_identifier: None,
-};
+pub const DEFAULT_QOS0_SUB_OPTIONS: &SubscriptionOptions = &SubscriptionOptions::new();
 
 pub const DEFAULT_DC_OPTIONS: &DisconnectOptions = &DisconnectOptions::new().publish_will();

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -8,7 +8,10 @@ use rust_mqtt::{
     client::{
         Client, MqttError,
         event::{Event, Publish, Suback},
-        options::{ConnectOptions, DisconnectOptions, PublicationOptions, SubscriptionOptions},
+        options::{
+            ConnectOptions, DisconnectOptions, PublicationOptions, SubscriptionOptions,
+            UnsubscriptionOptions,
+        },
     },
     types::{
         IdentifiedQoS, MqttBinary, MqttString, PacketIdentifier, QoS, ReasonCode, TopicFilter,
@@ -55,7 +58,7 @@ impl StaticAlloc {
     }
 }
 
-pub async fn tcp_connection_raw(broker: SocketAddr) -> Result<TcpStream, MqttError<'static>> {
+pub async fn tcp_connection_raw(broker: SocketAddr) -> Result<TcpStream, MqttError<'static, 16>> {
     warn_inspect!(
         TcpStream::connect(broker).await,
         "Error while connecting TCP session"
@@ -65,7 +68,7 @@ pub async fn tcp_connection_raw(broker: SocketAddr) -> Result<TcpStream, MqttErr
 
 pub async fn tcp_connection(
     broker: SocketAddr,
-) -> Result<FromTokio<TcpStream>, MqttError<'static>> {
+) -> Result<FromTokio<TcpStream>, MqttError<'static, 16>> {
     tcp_connection_raw(broker).await.map(FromTokio::new)
 }
 
@@ -73,7 +76,7 @@ pub async fn connected_client(
     broker: SocketAddr,
     options: &ConnectOptions<'static>,
     client_identifier: Option<MqttString<'_>>,
-) -> Result<TestClient<'static>, MqttError<'static>> {
+) -> Result<TestClient<'static>, MqttError<'static, 16>> {
     let mut client = Client::new(ALLOC.get());
 
     let tcp = tcp_connection(broker).await?;
@@ -91,7 +94,7 @@ pub async fn connected_failing_client(
     client_identifier: Option<MqttString<'_>>,
     read_limit: ByteLimit,
     write_limit: ByteLimit,
-) -> Result<FailingClient<'static>, MqttError<'static>> {
+) -> Result<FailingClient<'static>, MqttError<'static, 16>> {
     let mut client = Client::new(ALLOC.get());
 
     let tcp = tcp_connection_raw(broker).await?;
@@ -105,7 +108,7 @@ pub async fn connected_failing_client(
     .map(|_| client)
 }
 
-pub async fn disconnect(client: &mut TestClient<'_>, options: &DisconnectOptions) {
+pub async fn disconnect(client: &mut TestClient<'_>, options: &DisconnectOptions<'_>) {
     let _ = warn_inspect!(
         client.disconnect(options).await,
         "Client::disconnect() failed"
@@ -114,18 +117,20 @@ pub async fn disconnect(client: &mut TestClient<'_>, options: &DisconnectOptions
 
 pub async fn subscribe<'c>(
     client: &mut TestClient<'c>,
-    options: SubscriptionOptions,
+    options: &SubscriptionOptions<'_>,
     topic: TopicFilter<'_>,
-) -> Result<QoS, MqttError<'c>> {
+) -> Result<QoS, MqttError<'c, 16>> {
     let pid = warn_inspect!(
         client.subscribe(topic, options).await,
         "Client::subscribe() failed"
-    )?;
+    )
+    .map_err(MqttError::inflate)?;
 
     loop {
         match warn_inspect!(client.poll().await, "Client::poll() failed")? {
             Event::Suback(Suback {
                 packet_identifier,
+                user_properties: _,
                 reason_code,
             }) if packet_identifier == pid => {
                 info!("Subscribed with reason code {:?}", reason_code);
@@ -138,11 +143,14 @@ pub async fn subscribe<'c>(
             }
             Event::Suback(Suback {
                 packet_identifier,
+                user_properties: _,
                 reason_code: _,
-            }) => warn!(
-                "Expected SUBACK for packet identifier {:?}, but received SUBACK for packet identifier {:?}",
-                pid, packet_identifier
-            ),
+            }) => {
+                warn!(
+                    "Expected SUBACK for packet identifier {:?}, but received SUBACK for packet identifier {:?}",
+                    pid, packet_identifier
+                )
+            }
             e => warn!("Expected Event::Suback, but received {:?}", e),
         }
     }
@@ -150,17 +158,20 @@ pub async fn subscribe<'c>(
 
 pub async fn unsubscribe<'c>(
     client: &mut TestClient<'c>,
+    options: &UnsubscriptionOptions<'_>,
     topic: TopicFilter<'_>,
-) -> Result<(), MqttError<'c>> {
+) -> Result<(), MqttError<'c, 16>> {
     let pid = warn_inspect!(
-        client.unsubscribe(topic).await,
+        client.unsubscribe(topic, options).await,
         "Client::unsubscribe() failed"
-    )?;
+    )
+    .map_err(MqttError::inflate)?;
 
     loop {
         match warn_inspect!(client.poll().await, "Client::poll() failed")? {
             Event::Unsuback(Suback {
                 packet_identifier,
+                user_properties: _,
                 reason_code,
             }) if packet_identifier == pid => {
                 info!("Unsubscribed with reason code {:?}", reason_code);
@@ -168,11 +179,14 @@ pub async fn unsubscribe<'c>(
             }
             Event::Unsuback(Suback {
                 packet_identifier,
+                user_properties: _,
                 reason_code: _,
-            }) => warn!(
-                "Expected UNSUBACK for packet identifier {:?}, but received UNSUBACK for packet identifier {:?}",
-                pid, packet_identifier
-            ),
+            }) => {
+                warn!(
+                    "Expected UNSUBACK for packet identifier {:?}, but received UNSUBACK for packet identifier {:?}",
+                    pid, packet_identifier
+                )
+            }
             e => warn!("Expected Event::Unsuback, but received {:?}", e),
         }
     }
@@ -180,7 +194,7 @@ pub async fn unsubscribe<'c>(
 
 pub async fn receive_publish<'c>(
     client: &mut TestClient<'c>,
-) -> Result<Publish<'c, 1>, MqttError<'c>> {
+) -> Result<Publish<'c, 1, 16>, MqttError<'c, 16>> {
     loop {
         match warn_inspect!(client.poll().await, "Client::poll() failed")? {
             Event::Publish(p) => break Ok(p),
@@ -191,7 +205,7 @@ pub async fn receive_publish<'c>(
 
 pub async fn receive_and_complete<'c>(
     client: &mut TestClient<'c>,
-) -> Result<Publish<'c, 1>, MqttError<'c>> {
+) -> Result<Publish<'c, 1, 16>, MqttError<'c, 16>> {
     let publish = receive_publish(client).await?;
 
     match publish.identified_qos {
@@ -218,11 +232,12 @@ pub async fn publish_and_complete<'c>(
     client: &mut TestClient<'c>,
     options: &PublicationOptions<'_>,
     message: Bytes<'_>,
-) -> Result<Option<PacketIdentifier>, MqttError<'c>> {
+) -> Result<Option<PacketIdentifier>, MqttError<'c, 16>> {
     let pid = warn_inspect!(
         client.publish(options, message).await,
         "Client::publish() failed"
-    )?;
+    )
+    .map_err(MqttError::inflate)?;
 
     match options.qos {
         QoS::AtMostOnce => {}

--- a/tests/integration/connect_options.rs
+++ b/tests/integration/connect_options.rs
@@ -58,7 +58,7 @@ async fn maximum_packet_size_not_exceeded() {
     let receiver = async {
         assert_subscribe!(
             rx,
-            DEFAULT_QOS0_SUB_OPTIONS.exactly_once(),
+            &DEFAULT_QOS0_SUB_OPTIONS.exactly_once(),
             topic_filter.clone()
         );
 
@@ -107,7 +107,7 @@ async fn maximum_packet_size_barely_exceeded() {
     let receiver = async {
         assert_subscribe!(
             rx,
-            DEFAULT_QOS0_SUB_OPTIONS.exactly_once(),
+            &DEFAULT_QOS0_SUB_OPTIONS.exactly_once(),
             topic_filter.clone()
         );
 
@@ -160,7 +160,7 @@ async fn maximum_packet_size_decently_exceeded() {
     let receiver = async {
         assert_subscribe!(
             rx,
-            DEFAULT_QOS0_SUB_OPTIONS.exactly_once(),
+            &DEFAULT_QOS0_SUB_OPTIONS.exactly_once(),
             topic_filter.clone()
         );
 
@@ -214,7 +214,7 @@ async fn maximum_packet_size_at_varbyteint_boundary_not_exceeded() {
     let receiver = async {
         assert_subscribe!(
             rx,
-            DEFAULT_QOS0_SUB_OPTIONS.exactly_once(),
+            &DEFAULT_QOS0_SUB_OPTIONS.exactly_once(),
             topic_filter.clone()
         );
 
@@ -261,7 +261,7 @@ async fn maximum_packet_size_at_varbyteint_boundary_exceeded() {
     let receiver = async {
         assert_subscribe!(
             rx,
-            DEFAULT_QOS0_SUB_OPTIONS.exactly_once(),
+            &DEFAULT_QOS0_SUB_OPTIONS.exactly_once(),
             topic_filter.clone()
         );
 
@@ -513,7 +513,7 @@ async fn keep_alive_via_incoming_qos1() {
     };
 
     let receiver = async {
-        assert_subscribe!(rx, DEFAULT_QOS0_SUB_OPTIONS.at_least_once(), topic_filter);
+        assert_subscribe!(rx, &DEFAULT_QOS0_SUB_OPTIONS.at_least_once(), topic_filter);
 
         for _ in 0..10 {
             assert_recv_excl!(rx, topic_name);
@@ -529,7 +529,6 @@ async fn keep_alive_via_incoming_qos1() {
 #[test_log::test]
 async fn keep_alive_via_subscribe() {
     let topic_filter = unique_topic().1;
-    let subscribe_options = SubscriptionOptions::new();
 
     let mut c = assert_ok!(
         connected_client(
@@ -549,7 +548,7 @@ async fn keep_alive_via_subscribe() {
     for _ in 0..10 {
         sleep(Duration::from_millis(950)).await;
         assert_ok!(
-            c.subscribe(topic_filter.as_borrowed(), subscribe_options)
+            c.subscribe(topic_filter.as_borrowed(), DEFAULT_QOS0_SUB_OPTIONS)
                 .await
         );
         let event = assert_ok!(c.poll().await);
@@ -592,6 +591,7 @@ async fn keep_alive_not_kept_alive_idle_network() {
         MqttError::Disconnect {
             reason: ReasonCode::KeepAliveTimeout,
             reason_string: _,
+            user_properties: _,
             server_reference: _,
         } | MqttError::Network(_)
     ));
@@ -691,6 +691,7 @@ async fn keep_alive_not_kept_alive_will_timing() {
         MqttError::Disconnect {
             reason: ReasonCode::KeepAliveTimeout,
             reason_string: _,
+            user_properties: _,
             server_reference: _,
         } | MqttError::Network(_)
     ));
@@ -702,8 +703,8 @@ async fn keep_alive_not_kept_alive_will_timing() {
 #[test_log::test]
 async fn receive_maximum() {
     let (topic_name, topic_filter) = unique_topic();
-    let mut rx: Client<'_, _, _, 1, 2, 0, 0> = Client::new(ALLOC.get());
-    let mut tx: Client<'_, _, _, 1, 1, 10, 0> = Client::new(ALLOC.get());
+    let mut rx: Client<'_, _, _, 1, 2, 0, 0, 16> = Client::new(ALLOC.get());
+    let mut tx: Client<'_, _, _, 1, 1, 10, 0, 16> = Client::new(ALLOC.get());
 
     let tcp_rx = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
     let tcp_tx = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
@@ -712,7 +713,7 @@ async fn receive_maximum() {
     assert_ok!(tx.connect(tcp_tx, NO_SESSION_CONNECT_OPTIONS, None).await);
 
     let pid = assert_ok!(
-        rx.subscribe(topic_filter, SubscriptionOptions::new().exactly_once())
+        rx.subscribe(topic_filter, &SubscriptionOptions::new().exactly_once())
             .await
     );
     let e = assert_ok!(assert_ok!(
@@ -768,7 +769,7 @@ async fn send_maximum_buffer_exceeded() {
     let topic = unique_topic().0;
     const SEND_MAXIMUM_BUFFER_SIZE: usize = 2;
 
-    let mut c: Client<'_, _, _, 1, 1, SEND_MAXIMUM_BUFFER_SIZE, 0> = Client::new(ALLOC.get());
+    let mut c: Client<'_, _, _, 1, 1, SEND_MAXIMUM_BUFFER_SIZE, 0, 16> = Client::new(ALLOC.get());
 
     let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
 
@@ -805,7 +806,7 @@ async fn send_maximum_buffer_exceeded() {
 #[test_log::test]
 async fn server_receive_maximum_exceeded() {
     let topic_name = unique_topic().0;
-    let mut c: Client<'_, _, _, 1, 1, 256, 0> = Client::new(ALLOC.get());
+    let mut c: Client<'_, _, _, 1, 1, 256, 0, 16> = Client::new(ALLOC.get());
 
     let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
 

--- a/tests/integration/creds.rs
+++ b/tests/integration/creds.rs
@@ -21,6 +21,7 @@ async fn connect_no_creds() {
         MqttError::Disconnect {
             reason: _,
             reason_string: _,
+            user_properties: _,
             server_reference: _,
         }
     ));
@@ -41,6 +42,7 @@ async fn connect_no_password() {
         MqttError::Disconnect {
             reason: _,
             reason_string: _,
+            user_properties: _,
             server_reference: _,
         }
     ));
@@ -63,6 +65,7 @@ async fn connect_wrong_password() {
         MqttError::Disconnect {
             reason: _,
             reason_string: _,
+            user_properties: _,
             server_reference: _,
         }
     ));

--- a/tests/integration/message_retry.rs
+++ b/tests/integration/message_retry.rs
@@ -65,7 +65,7 @@ async fn outgoing_qos1_retry() {
         connect_options.clean_start = false;
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-        let mut tx: Client<'_, _, _, 1, 1, 1, 1> = Client::with_session(session, ALLOC.get());
+        let mut tx: Client<'_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
         let info = assert_ok!(warn_inspect!(
             tx.connect(tcp, &connect_options, Some(tx_id.as_borrowed()))
                 .await,
@@ -82,6 +82,7 @@ async fn outgoing_qos1_retry() {
                         Event::PublishAcknowledged(Puback {
                             packet_identifier,
                             reason_code: _,
+                            user_properties: _,
                         }) if packet_identifier == pid => break,
                         _ => {}
                     }
@@ -94,9 +95,8 @@ async fn outgoing_qos1_retry() {
     };
 
     let receiver = async {
-        let mut sub_options = DEFAULT_QOS0_SUB_OPTIONS;
-        sub_options.qos = QoS::AtLeastOnce;
-        assert_subscribe!(rx, sub_options, topic_filter.clone());
+        let sub_options = DEFAULT_QOS0_SUB_OPTIONS.at_least_once();
+        assert_subscribe!(rx, &sub_options, topic_filter.clone());
         let p = assert_ok!(assert_ok!(
             timeout(Duration::from_secs(5), receive_publish(&mut rx)).await
         ));
@@ -152,7 +152,7 @@ async fn outgoing_qos2_retry_publish() {
         connect_options.clean_start = false;
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-        let mut tx: Client<'_, _, _, 1, 1, 1, 1> = Client::with_session(session, ALLOC.get());
+        let mut tx: Client<'_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
         let info = assert_ok!(warn_inspect!(
             tx.connect(tcp, &connect_options, Some(tx_id.as_borrowed()))
                 .await,
@@ -169,6 +169,7 @@ async fn outgoing_qos2_retry_publish() {
                         Event::PublishComplete(Puback {
                             packet_identifier,
                             reason_code: _,
+                            user_properties: _,
                         }) if packet_identifier == pid => break,
                         _ => {}
                     }
@@ -181,9 +182,8 @@ async fn outgoing_qos2_retry_publish() {
     };
 
     let receiver = async {
-        let mut sub_options = DEFAULT_QOS0_SUB_OPTIONS;
-        sub_options.qos = QoS::ExactlyOnce;
-        assert_subscribe!(rx, sub_options, topic_filter.clone());
+        let sub_options = DEFAULT_QOS0_SUB_OPTIONS.exactly_once();
+        assert_subscribe!(rx, &sub_options, topic_filter.clone());
         let p = assert_ok!(assert_ok!(
             timeout(Duration::from_secs(5), receive_publish(&mut rx)).await
         ));
@@ -234,6 +234,7 @@ async fn outgoing_qos2_retry_pubrel() {
                         Event::PublishReceived(Puback {
                             packet_identifier,
                             reason_code: _,
+                            user_properties: _,
                         }) if packet_identifier == pid => break,
                         _ => {}
                     }
@@ -251,7 +252,7 @@ async fn outgoing_qos2_retry_pubrel() {
         connect_options.clean_start = false;
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-        let mut tx: Client<'_, _, _, 1, 1, 1, 1> = Client::with_session(session, ALLOC.get());
+        let mut tx: Client<'_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
         let info = assert_ok!(warn_inspect!(
             tx.connect(tcp, &connect_options, Some(tx_id.as_borrowed()))
                 .await,
@@ -268,6 +269,7 @@ async fn outgoing_qos2_retry_pubrel() {
                         Event::PublishComplete(Puback {
                             packet_identifier,
                             reason_code: _,
+                            user_properties: _,
                         }) if packet_identifier == pid => break,
                         _ => {}
                     }
@@ -280,9 +282,8 @@ async fn outgoing_qos2_retry_pubrel() {
     };
 
     let receiver = async {
-        let mut sub_options = DEFAULT_QOS0_SUB_OPTIONS;
-        sub_options.qos = QoS::ExactlyOnce;
-        assert_subscribe!(rx, sub_options, topic_filter.clone());
+        let sub_options = DEFAULT_QOS0_SUB_OPTIONS.exactly_once();
+        assert_subscribe!(rx, &sub_options, topic_filter.clone());
         let p = assert_ok!(assert_ok!(
             timeout(Duration::from_secs(5), receive_publish(&mut rx)).await
         ));
@@ -329,9 +330,8 @@ async fn incoming_qos2_retry_pubcomp() {
     };
 
     let receiver = async {
-        let mut sub_options = DEFAULT_QOS0_SUB_OPTIONS;
-        sub_options.qos = QoS::ExactlyOnce;
-        assert_subscribe!(rx, sub_options, topic_filter.clone());
+        let sub_options = DEFAULT_QOS0_SUB_OPTIONS.exactly_once();
+        assert_subscribe!(rx, &sub_options, topic_filter.clone());
 
         let publish = assert_ok!(assert_ok!(
             timeout(Duration::from_secs(5), receive_publish(&mut rx)).await
@@ -354,7 +354,7 @@ async fn incoming_qos2_retry_pubcomp() {
         connect_options.clean_start = false;
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-        let mut rx: Client<'_, _, _, 1, 1, 1, 1> = Client::with_session(session, ALLOC.get());
+        let mut rx: Client<'_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
         let info = assert_ok!(warn_inspect!(
             rx.connect(tcp, &connect_options, Some(rx_id.as_borrowed()))
                 .await,
@@ -369,6 +369,7 @@ async fn incoming_qos2_retry_pubcomp() {
                         Event::PublishReleased(Puback {
                             packet_identifier,
                             reason_code: _,
+                            user_properties: _,
                         }) if packet_identifier == pid => {
                             break;
                         }
@@ -446,6 +447,7 @@ async fn outgoing_qos1_write_fail_retry() {
                         Event::PublishAcknowledged(Puback {
                             packet_identifier,
                             reason_code: _,
+                            user_properties: _,
                         }) if pid == packet_identifier => {}
                         _ => panic!("Should only receive a PUBACK"),
                     }
@@ -458,7 +460,7 @@ async fn outgoing_qos1_write_fail_retry() {
 
                 let pid = session.pending_client_publishes.first().copied();
 
-                let mut tx: Client<'_, _, _, 1, 1, 1, 1> =
+                let mut tx: Client<'_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -489,6 +491,7 @@ async fn outgoing_qos1_write_fail_retry() {
                     Event::PublishAcknowledged(Puback {
                         packet_identifier,
                         reason_code: _,
+                        user_properties: _,
                     }) if pid == packet_identifier => {}
                     _ => panic!("Should only receive a PUBACK"),
                 }
@@ -559,6 +562,7 @@ async fn outgoing_qos1_read_fail_retry() {
                         Ok(Event::PublishAcknowledged(Puback {
                             packet_identifier,
                             reason_code: _,
+                            user_properties: _,
                         })) if pid == packet_identifier => {}
                         Ok(_) => panic!("Should only receive a PUBACK"),
                         Err(_) => {
@@ -579,7 +583,7 @@ async fn outgoing_qos1_read_fail_retry() {
                     .unwrap()
                     .packet_identifier;
 
-                let mut tx: Client<'_, _, _, 1, 1, 1, 1> =
+                let mut tx: Client<'_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -596,6 +600,7 @@ async fn outgoing_qos1_read_fail_retry() {
                     Event::PublishAcknowledged(Puback {
                         packet_identifier,
                         reason_code: _,
+                        user_properties: _,
                     }) if pid == packet_identifier => {}
                     _ => panic!("Should only receive a PUBACK"),
                 }
@@ -669,6 +674,7 @@ async fn outgoing_qos2_write_fail_retry() {
                         Ok(Event::PublishReceived(Puback {
                             packet_identifier,
                             reason_code: _,
+                            user_properties: _,
                         })) if pid == packet_identifier => {}
                         Ok(_) => panic!("Should only receive a PUBREC"),
                         Err(_) => {
@@ -682,6 +688,7 @@ async fn outgoing_qos2_write_fail_retry() {
                         Event::PublishComplete(Puback {
                             packet_identifier,
                             reason_code: _,
+                            user_properties: _,
                         }) if pid == packet_identifier => {}
                         _ => panic!("Should only receive a PUBCOMP"),
                     }
@@ -694,7 +701,7 @@ async fn outgoing_qos2_write_fail_retry() {
 
                 let pid = session.pending_client_publishes.first().copied();
 
-                let mut tx: Client<'_, _, _, 1, 1, 1, 1> =
+                let mut tx: Client<'_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -737,6 +744,7 @@ async fn outgoing_qos2_write_fail_retry() {
                         Event::PublishReceived(Puback {
                             packet_identifier,
                             reason_code: _,
+                            user_properties: _,
                         }) if pid == packet_identifier => {}
                         _ => panic!("Should only receive a PUBREC"),
                     }
@@ -746,6 +754,7 @@ async fn outgoing_qos2_write_fail_retry() {
                     Event::PublishComplete(Puback {
                         packet_identifier,
                         reason_code: _,
+                        user_properties: _,
                     }) if pid == packet_identifier => {}
                     _ => panic!("Should only receive a PUBCOMP"),
                 }
@@ -815,6 +824,7 @@ async fn outgoing_qos2_read_fail_retry() {
                         Ok(Event::PublishReceived(Puback {
                             packet_identifier,
                             reason_code: _,
+                            user_properties: _,
                         })) if pid == packet_identifier => {}
                         Ok(_) => panic!("Should only receive a PUBREC"),
                         Err(_) => {
@@ -827,6 +837,7 @@ async fn outgoing_qos2_read_fail_retry() {
                         Ok(Event::PublishComplete(Puback {
                             packet_identifier,
                             reason_code: _,
+                            user_properties: _,
                         })) if pid == packet_identifier => {}
                         Ok(_) => panic!("Should only receive a PUBCOMP"),
                         Err(_) => {
@@ -843,7 +854,7 @@ async fn outgoing_qos2_read_fail_retry() {
 
                 let pid = session.pending_client_publishes.first().copied();
 
-                let mut tx: Client<'_, _, _, 1, 1, 1, 1> =
+                let mut tx: Client<'_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -886,6 +897,7 @@ async fn outgoing_qos2_read_fail_retry() {
                         Event::PublishReceived(Puback {
                             packet_identifier,
                             reason_code: _,
+                            user_properties: _,
                         }) if pid == packet_identifier => {}
                         _ => panic!("Should only receive a PUBREC"),
                     }
@@ -895,6 +907,7 @@ async fn outgoing_qos2_read_fail_retry() {
                     Event::PublishComplete(Puback {
                         packet_identifier,
                         reason_code: _,
+                        user_properties: _,
                     }) if pid == packet_identifier => {}
                     _ => panic!("Should only receive a PUBCOMP"),
                 }
@@ -948,14 +961,14 @@ async fn incoming_qos1_write_fail_retry() {
     let tx = publisher_task(topic_name, QoS::AtLeastOnce, tx_messages, tx_received);
 
     let rx = async move {
-        let mut connect_options = NO_SESSION_CONNECT_OPTIONS.clone();
-        connect_options.session_expiry_interval = SessionExpiryInterval::Seconds(60);
+        let connect_options = NO_SESSION_CONNECT_OPTIONS
+            .clone()
+            .session_expiry_interval(SessionExpiryInterval::Seconds(60));
 
         let mut reconnect_options = NO_SESSION_CONNECT_OPTIONS.clone();
         reconnect_options.clean_start = false;
 
-        let mut sub_options = DEFAULT_QOS0_SUB_OPTIONS;
-        sub_options.qos = QoS::AtLeastOnce;
+        let sub_options = DEFAULT_QOS0_SUB_OPTIONS.at_least_once();
 
         let mut i = 0;
         let mut failed = true;
@@ -983,7 +996,7 @@ async fn incoming_qos1_write_fail_retry() {
                         continue 'outer;
                     };
 
-                    let Ok(pid) = rx.subscribe(topic_filter.as_borrowed(), sub_options).await
+                    let Ok(pid) = rx.subscribe(topic_filter.as_borrowed(), &sub_options).await
                     else {
                         failed = true;
                         continue 'outer;
@@ -993,6 +1006,7 @@ async fn incoming_qos1_write_fail_retry() {
                     match assert_ok!(rx.poll().await) {
                         Event::Suback(Suback {
                             packet_identifier,
+                            user_properties: _,
                             reason_code: _,
                         }) if pid == packet_identifier => {}
                         _ => panic!("Should only receive a SUBACK"),
@@ -1020,7 +1034,7 @@ async fn incoming_qos1_write_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut rx: Client<'_, _, _, 1, 1, 1, 1> =
+                let mut rx: Client<'_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -1060,14 +1074,14 @@ async fn incoming_qos1_read_fail_retry() {
     let tx = publisher_task(topic_name, QoS::AtLeastOnce, tx_messages, tx_received);
 
     let rx = async move {
-        let mut connect_options = NO_SESSION_CONNECT_OPTIONS.clone();
-        connect_options.session_expiry_interval = SessionExpiryInterval::Seconds(60);
+        let connect_options = NO_SESSION_CONNECT_OPTIONS
+            .clone()
+            .session_expiry_interval(SessionExpiryInterval::Seconds(60));
 
         let mut reconnect_options = NO_SESSION_CONNECT_OPTIONS.clone();
         reconnect_options.clean_start = false;
 
-        let mut sub_options = DEFAULT_QOS0_SUB_OPTIONS;
-        sub_options.qos = QoS::AtLeastOnce;
+        let sub_options = DEFAULT_QOS0_SUB_OPTIONS.at_least_once();
 
         let mut i = 0;
         let mut failed = true;
@@ -1097,11 +1111,12 @@ async fn incoming_qos1_read_fail_retry() {
 
                     // Cannot fail because subscribing only sends
                     let pid =
-                        assert_ok!(rx.subscribe(topic_filter.as_borrowed(), sub_options).await);
+                        assert_ok!(rx.subscribe(topic_filter.as_borrowed(), &sub_options).await);
 
                     match rx.poll().await {
                         Ok(Event::Suback(Suback {
                             packet_identifier,
+                            user_properties: _,
                             reason_code: _,
                         })) if pid == packet_identifier => {}
                         Ok(_) => panic!("Should only receive a SUBACK"),
@@ -1133,7 +1148,7 @@ async fn incoming_qos1_read_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut rx: Client<'_, _, _, 1, 1, 1, 1> =
+                let mut rx: Client<'_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -1172,14 +1187,14 @@ async fn incoming_qos2_write_fail_retry() {
     let tx = publisher_task(topic_name, QoS::ExactlyOnce, tx_messages, tx_received);
 
     let rx = async move {
-        let mut connect_options = NO_SESSION_CONNECT_OPTIONS.clone();
-        connect_options.session_expiry_interval = SessionExpiryInterval::Seconds(60);
+        let connect_options = NO_SESSION_CONNECT_OPTIONS
+            .clone()
+            .session_expiry_interval(SessionExpiryInterval::Seconds(60));
 
         let mut reconnect_options = NO_SESSION_CONNECT_OPTIONS.clone();
         reconnect_options.clean_start = false;
 
-        let mut sub_options = DEFAULT_QOS0_SUB_OPTIONS;
-        sub_options.qos = QoS::ExactlyOnce;
+        let sub_options = DEFAULT_QOS0_SUB_OPTIONS.exactly_once();
 
         let mut i = 0;
         let mut failed = true;
@@ -1207,7 +1222,7 @@ async fn incoming_qos2_write_fail_retry() {
                         continue 'outer;
                     };
 
-                    let Ok(pid) = rx.subscribe(topic_filter.as_borrowed(), sub_options).await
+                    let Ok(pid) = rx.subscribe(topic_filter.as_borrowed(), &sub_options).await
                     else {
                         failed = true;
                         continue 'outer;
@@ -1217,6 +1232,7 @@ async fn incoming_qos2_write_fail_retry() {
                     match assert_ok!(rx.poll().await) {
                         Event::Suback(Suback {
                             packet_identifier,
+                            user_properties: _,
                             reason_code: _,
                         }) if pid == packet_identifier => {}
                         _ => panic!("Should only receive a SUBACK"),
@@ -1243,6 +1259,7 @@ async fn incoming_qos2_write_fail_retry() {
                         Ok(Event::PublishReleased(Puback {
                             packet_identifier,
                             reason_code: _,
+                            user_properties: _,
                         })) if packet_identifier == pid => {}
                         Ok(Event::PublishReleased(_)) => panic!("Received non-matching PUBREL"),
                         Ok(_) => panic!("Should only receive a PUBREL"),
@@ -1262,7 +1279,7 @@ async fn incoming_qos2_write_fail_retry() {
                     .first()
                     .map(|c| c.packet_identifier);
 
-                let mut rx: Client<'_, _, _, 1, 1, 1, 1> =
+                let mut rx: Client<'_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -1277,6 +1294,7 @@ async fn incoming_qos2_write_fail_retry() {
                             Event::PublishReleased(Puback {
                                 packet_identifier,
                                 reason_code: _,
+                                user_properties: _,
                             }) if packet_identifier == pid => break,
                             Event::PublishReleased(_) => panic!("Received non-matching PUBREL"),
                             e => panic!("Should only receive PUBLISH or PUBREL: {:?}", e),
@@ -1309,14 +1327,14 @@ async fn incoming_qos2_read_fail_retry() {
     let tx = publisher_task(topic_name, QoS::ExactlyOnce, tx_messages, tx_received);
 
     let rx = async move {
-        let mut connect_options = NO_SESSION_CONNECT_OPTIONS.clone();
-        connect_options.session_expiry_interval = SessionExpiryInterval::Seconds(60);
+        let connect_options = NO_SESSION_CONNECT_OPTIONS
+            .clone()
+            .session_expiry_interval(SessionExpiryInterval::Seconds(60));
 
         let mut reconnect_options = NO_SESSION_CONNECT_OPTIONS.clone();
         reconnect_options.clean_start = false;
 
-        let mut sub_options = DEFAULT_QOS0_SUB_OPTIONS;
-        sub_options.qos = QoS::ExactlyOnce;
+        let sub_options = DEFAULT_QOS0_SUB_OPTIONS.exactly_once();
 
         let mut i = 0;
         let mut failed = true;
@@ -1346,11 +1364,12 @@ async fn incoming_qos2_read_fail_retry() {
 
                     // Cannot fail because subscribing only sends
                     let pid =
-                        assert_ok!(rx.subscribe(topic_filter.as_borrowed(), sub_options).await);
+                        assert_ok!(rx.subscribe(topic_filter.as_borrowed(), &sub_options).await);
 
                     match rx.poll().await {
                         Ok(Event::Suback(Suback {
                             packet_identifier,
+                            user_properties: _,
                             reason_code: _,
                         })) if pid == packet_identifier => {}
                         Ok(_) => panic!("Should only receive a SUBACK"),
@@ -1381,6 +1400,7 @@ async fn incoming_qos2_read_fail_retry() {
                         Ok(Event::PublishReleased(Puback {
                             packet_identifier,
                             reason_code: _,
+                            user_properties: _,
                         })) if packet_identifier == pid => {}
                         Ok(Event::PublishReleased(_)) => panic!("Received non-matching PUBREL"),
                         Ok(_) => panic!("Should only receive a PUBREL"),
@@ -1400,7 +1420,7 @@ async fn incoming_qos2_read_fail_retry() {
                     .first()
                     .map(|c| c.packet_identifier);
 
-                let mut rx: Client<'_, _, _, 1, 1, 1, 1> =
+                let mut rx: Client<'_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -1415,6 +1435,7 @@ async fn incoming_qos2_read_fail_retry() {
                         Event::PublishReleased(Puback {
                             packet_identifier,
                             reason_code: _,
+                            user_properties: _,
                         }) if packet_identifier == pid.unwrap() => break 'complete,
                         Event::PublishReleased(_) => panic!("Received non-matching PUBREL"),
                         Event::Publish(Publish {
@@ -1430,6 +1451,7 @@ async fn incoming_qos2_read_fail_retry() {
                         Event::PublishReleased(Puback {
                             packet_identifier,
                             reason_code: _,
+                            user_properties: _,
                         }) if packet_identifier == pid => break 'complete,
                         Event::PublishReleased(_) => panic!("Received non-matching PUBREL"),
                         e => panic!("Should only receive PUBREL: {:?}", e),

--- a/tests/integration/pub_properties.rs
+++ b/tests/integration/pub_properties.rs
@@ -5,7 +5,7 @@ use rust_mqtt::{
         event::Publish,
         options::{PublicationOptions, TopicReference},
     },
-    types::{MqttString, QoS},
+    types::MqttString,
 };
 use tokio::{
     join,
@@ -41,9 +41,8 @@ async fn message_expiry_interval_basic() {
     };
 
     let receiver = async {
-        let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-        options.qos = QoS::AtLeastOnce;
-        assert_subscribe!(rx, options, topic_filter.clone());
+        let options = DEFAULT_QOS0_SUB_OPTIONS.at_least_once();
+        assert_subscribe!(rx, &options, topic_filter.clone());
 
         let Publish {
             message_expiry_interval,
@@ -85,9 +84,8 @@ async fn message_expiry_interval_partially_expired() {
     let receiver = async {
         sleep(Duration::from_secs(5)).await;
 
-        let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-        options.qos = QoS::AtLeastOnce;
-        assert_subscribe!(rx, options, topic_filter.clone());
+        let options = DEFAULT_QOS0_SUB_OPTIONS.at_least_once();
+        assert_subscribe!(rx, &options, topic_filter.clone());
 
         let Publish {
             message_expiry_interval,
@@ -128,9 +126,8 @@ async fn message_expiry_interval_completely_expired() {
     let receiver = async {
         sleep(Duration::from_secs(6)).await;
 
-        let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-        options.qos = QoS::AtLeastOnce;
-        assert_subscribe!(rx, options, topic_filter.clone());
+        let options = DEFAULT_QOS0_SUB_OPTIONS.at_least_once();
+        assert_subscribe!(rx, &options, topic_filter.clone());
 
         assert_err!(
             timeout(Duration::from_secs(4), async {
@@ -175,9 +172,8 @@ async fn topic_alias_basic() {
     };
 
     let receiver = async {
-        let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-        options.qos = QoS::AtLeastOnce;
-        assert_subscribe!(rx, options, topic_filter.clone());
+        let options = DEFAULT_QOS0_SUB_OPTIONS.at_least_once();
+        assert_subscribe!(rx, &options, topic_filter.clone());
 
         assert_recv!(rx);
         assert_recv!(rx);
@@ -227,9 +223,8 @@ async fn topic_alias_remap() {
     };
 
     let receiver1 = async {
-        let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-        options.qos = QoS::AtLeastOnce;
-        assert_subscribe!(rx1, options, topic_filter1.clone());
+        let options = DEFAULT_QOS0_SUB_OPTIONS.at_least_once();
+        assert_subscribe!(rx1, &options, topic_filter1.clone());
 
         assert_recv!(rx1);
         assert_err!(
@@ -244,9 +239,8 @@ async fn topic_alias_remap() {
     };
 
     let receiver2 = async {
-        let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-        options.qos = QoS::AtLeastOnce;
-        assert_subscribe!(rx2, options, topic_filter2.clone());
+        let options = DEFAULT_QOS0_SUB_OPTIONS.at_least_once();
+        assert_subscribe!(rx2, &options, topic_filter2.clone());
 
         assert_recv!(rx2);
         assert_recv!(rx2);

--- a/tests/integration/pub_properties.rs
+++ b/tests/integration/pub_properties.rs
@@ -5,7 +5,7 @@ use rust_mqtt::{
         event::Publish,
         options::{PublicationOptions, TopicReference},
     },
-    types::MqttString,
+    types::{MqttString, MqttStringPair},
 };
 use tokio::{
     join,
@@ -295,6 +295,75 @@ async fn payload_format_indicator() {
             ..
         } = assert_recv_excl!(rx, topic_name);
         assert_eq!(payload_format_indicator, Some(true));
+
+        disconnect(&mut rx, DEFAULT_DC_OPTIONS).await;
+    };
+
+    join!(receiver, publisher);
+}
+
+#[tokio::test]
+#[test_log::test]
+async fn user_properties() {
+    let publish_user_properties = vec![
+        MqttStringPair::new(
+            MqttString::from_str("last_will").unwrap(),
+            MqttString::from_str("delete_my_browser_history").unwrap(),
+        ),
+        MqttStringPair::new(
+            MqttString::from_str("qos_level").unwrap(),
+            MqttString::from_str("thoughts_and_prayers").unwrap(),
+        ),
+        MqttStringPair::new(
+            MqttString::from_str("retry_strategy").unwrap(),
+            MqttString::from_str("aggressive_procrastination").unwrap(),
+        ),
+        MqttStringPair::new(
+            MqttString::from_str("latency_source").unwrap(),
+            MqttString::from_str("cat_on_the_router").unwrap(),
+        ),
+        MqttStringPair::new(
+            MqttString::from_str("link_type").unwrap(),
+            MqttString::from_str("carrier_pigeon_with_rfc_1149").unwrap(),
+        ),
+    ];
+    let (topic_name, topic_filter) = unique_topic();
+    let msg = "The good thing about reinventing the wheel is that you can get a round one.";
+
+    let mut rx =
+        assert_ok!(connected_client(BROKER_ADDRESS, NO_SESSION_CONNECT_OPTIONS, None).await);
+    let mut tx =
+        assert_ok!(connected_client(BROKER_ADDRESS, NO_SESSION_CONNECT_OPTIONS, None).await);
+
+    let publisher = async {
+        sleep(Duration::from_secs(1)).await;
+
+        let pub_options = PublicationOptions::new(TopicReference::Name(topic_name.clone()));
+        assert_published!(tx, pub_options, msg.into());
+
+        let pub_options = pub_options.user_properties(&publish_user_properties);
+        assert_published!(tx, pub_options, msg.into());
+
+        disconnect(&mut tx, DEFAULT_DC_OPTIONS).await;
+    };
+
+    let receiver = async {
+        assert_subscribe!(rx, DEFAULT_QOS0_SUB_OPTIONS, topic_filter.clone());
+
+        let Publish {
+            user_properties, ..
+        } = assert_recv_excl!(rx, topic_name);
+        assert_eq!(user_properties, &[]);
+
+        let Publish {
+            user_properties, ..
+        } = assert_recv_excl!(rx, topic_name);
+
+        // The Server MUST maintain the order of User Properties when forwarding the Application Message [MQTT-3.3.2-18]
+        assert_eq!(
+            user_properties.as_slice(),
+            publish_user_properties.as_slice()
+        );
 
         disconnect(&mut rx, DEFAULT_DC_OPTIONS).await;
     };

--- a/tests/integration/pub_sub.rs
+++ b/tests/integration/pub_sub.rs
@@ -4,7 +4,7 @@ use log::info;
 use rust_mqtt::{
     client::{
         event::Publish,
-        options::{PublicationOptions, TopicReference},
+        options::{PublicationOptions, TopicReference, UnsubscriptionOptions},
     },
     types::{IdentifiedQoS, QoS},
 };
@@ -89,10 +89,9 @@ async fn publish_recv_qos1() {
     };
 
     let receiver = async {
-        let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-        options.qos = QoS::AtLeastOnce;
+        let options = DEFAULT_QOS0_SUB_OPTIONS.at_least_once();
 
-        assert_subscribe!(rx, options, topic_filter.clone());
+        assert_subscribe!(rx, &options, topic_filter.clone());
         let Publish {
             identified_qos,
             dup,
@@ -137,10 +136,9 @@ async fn publish_recv_qos2() {
     };
 
     let receiver = async {
-        let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-        options.qos = QoS::ExactlyOnce;
+        let options = DEFAULT_QOS0_SUB_OPTIONS.exactly_once();
 
-        assert_subscribe!(rx, options, topic_filter.clone());
+        assert_subscribe!(rx, &options, topic_filter.clone());
         let Publish {
             identified_qos,
             dup,
@@ -257,11 +255,10 @@ async fn publish_recv_multiple_qos1() {
     };
 
     let receiver = async {
-        let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-        options.qos = QoS::AtLeastOnce;
+        let options = DEFAULT_QOS0_SUB_OPTIONS.at_least_once();
 
-        assert_subscribe!(rx, options, topic_filter1.clone());
-        assert_subscribe!(rx, options, topic_filter2.clone());
+        assert_subscribe!(rx, &options, topic_filter1.clone());
+        assert_subscribe!(rx, &options, topic_filter2.clone());
 
         let mut messages = vec![(topic_name1.clone(), msg), (topic_name2.clone(), msg)];
 
@@ -326,11 +323,10 @@ async fn publish_recv_multiple_qos2() {
     };
 
     let receiver = async {
-        let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-        options.qos = QoS::ExactlyOnce;
+        let options = DEFAULT_QOS0_SUB_OPTIONS.exactly_once();
 
-        assert_subscribe!(rx, options, topic_filter1.clone());
-        assert_subscribe!(rx, options, topic_filter2.clone());
+        assert_subscribe!(rx, &options, topic_filter1.clone());
+        assert_subscribe!(rx, &options, topic_filter2.clone());
 
         let mut messages = vec![(topic_name1.clone(), msg), (topic_name2.clone(), msg)];
 
@@ -402,10 +398,10 @@ async fn unsub_no_recv() {
     };
 
     let receiver = async {
-        let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-        options.qos = QoS::AtLeastOnce;
-        assert_subscribe!(rx, options, topic_filter1.clone());
-        assert_subscribe!(rx, options, topic_filter2.clone());
+        let options = DEFAULT_QOS0_SUB_OPTIONS.at_least_once();
+
+        assert_subscribe!(rx, &options, topic_filter1.clone());
+        assert_subscribe!(rx, &options, topic_filter2.clone());
 
         let m = assert_recv_excl!(rx, topic_name1);
         assert_eq!(&*m.message, msg1.as_bytes());
@@ -413,7 +409,7 @@ async fn unsub_no_recv() {
         let m = assert_recv_excl!(rx, topic_name2);
         assert_eq!(&*m.message, msg2.as_bytes());
 
-        assert_unsubscribe!(rx, topic_filter2.clone());
+        assert_unsubscribe!(rx, &UnsubscriptionOptions::new(), topic_filter2.clone());
 
         let m = assert_recv_excl!(rx, topic_name1);
         assert_eq!(&*m.message, msg1.as_bytes());
@@ -499,10 +495,9 @@ async fn recv_min_sub_qos1() {
     };
 
     let receiver = async {
-        let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-        options.qos = QoS::AtLeastOnce;
+        let options = DEFAULT_QOS0_SUB_OPTIONS.at_least_once();
 
-        assert_subscribe!(rx, options, topic_filter.clone());
+        assert_subscribe!(rx, &options, topic_filter.clone());
         let Publish {
             identified_qos,
             dup,
@@ -546,10 +541,9 @@ async fn recv_min_pub_qos0() {
     };
 
     let receiver = async {
-        let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-        options.qos = QoS::ExactlyOnce;
+        let options = DEFAULT_QOS0_SUB_OPTIONS.exactly_once();
 
-        assert_subscribe!(rx, options, topic_filter.clone());
+        assert_subscribe!(rx, &options, topic_filter.clone());
         let Publish {
             identified_qos,
             dup,
@@ -594,10 +588,9 @@ async fn recv_min_pub_qos1() {
     };
 
     let receiver = async {
-        let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-        options.qos = QoS::ExactlyOnce;
+        let options = DEFAULT_QOS0_SUB_OPTIONS.exactly_once();
 
-        assert_subscribe!(rx, options, topic_filter.clone());
+        assert_subscribe!(rx, &options, topic_filter.clone());
         let Publish {
             identified_qos,
             dup,

--- a/tests/integration/session.rs
+++ b/tests/integration/session.rs
@@ -89,7 +89,7 @@ async fn session_continue_connection_dropped() {
     connect_options.clean_start = false;
 
     let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-    let mut c: Client<'_, _, _, 1, 1, 1, 1> = Client::with_session(session, ALLOC.get());
+    let mut c: Client<'_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
     let info = assert_ok!(warn_inspect!(
         c.connect(tcp, &connect_options, Some(id.as_borrowed()))
             .await,
@@ -145,7 +145,7 @@ async fn session_discontinued_clean_start() {
     drop(c);
 
     let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-    let mut c: Client<'_, _, _, 1, 1, 1, 1> = Client::with_session(session, ALLOC.get());
+    let mut c: Client<'_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
     let info = assert_ok!(warn_inspect!(
         c.connect(tcp, &connect_options, Some(id.as_borrowed()))
             .await,
@@ -192,7 +192,7 @@ async fn session_expired() {
     sleep(Duration::from_secs(5)).await;
 
     let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-    let mut c: Client<'_, _, _, 1, 1, 1, 1> = Client::with_session(session, ALLOC.get());
+    let mut c: Client<'_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
     let info = assert_ok!(warn_inspect!(
         c.connect(tcp, &connect_options, Some(id.as_borrowed()))
             .await,

--- a/tests/integration/sub_options.rs
+++ b/tests/integration/sub_options.rs
@@ -5,7 +5,7 @@ use rust_mqtt::{
         Client,
         options::{PublicationOptions, RetainHandling, TopicReference},
     },
-    types::{MqttString, QoS, VarByteInt},
+    types::{MqttString, VarByteInt},
 };
 use tokio::time::{sleep, timeout};
 use tokio_test::assert_err;
@@ -26,10 +26,8 @@ async fn publish_no_local() {
     let mut c =
         assert_ok!(connected_client(BROKER_ADDRESS, NO_SESSION_CONNECT_OPTIONS, None).await);
 
-    let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-    options.qos = QoS::ExactlyOnce;
-    options.no_local = true;
-    assert_subscribe!(c, options, topic_filter.clone());
+    let options = DEFAULT_QOS0_SUB_OPTIONS.exactly_once().no_local();
+    assert_subscribe!(c, &options, topic_filter.clone());
 
     let pub_options =
         PublicationOptions::new(TopicReference::Name(topic_name.clone())).exactly_once();
@@ -76,17 +74,15 @@ async fn subscribe_retain_handling_default() {
     sleep(Duration::from_secs(1)).await;
 
     // Subscribe with RetainHandling::AlwaysSend (default) - should receive retained message
-    let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-    options.qos = QoS::AtLeastOnce;
-    options.retain_handling = RetainHandling::AlwaysSend;
-    assert_subscribe!(rx, options, topic_filter.clone());
+    let options = DEFAULT_QOS0_SUB_OPTIONS.at_least_once();
+    assert_subscribe!(rx, &options, topic_filter.clone());
 
     let publish = assert_recv!(rx);
     assert_eq!(&*publish.message, msg.as_bytes());
     assert!(publish.retain);
 
     // Subscribe again - should receive retained message again with RetainHandling::AlwaysSend
-    assert_subscribe!(rx, options, topic_filter.clone());
+    assert_subscribe!(rx, &options, topic_filter.clone());
 
     let publish = assert_recv!(rx);
     assert_eq!(&*publish.message, msg.as_bytes());
@@ -103,7 +99,7 @@ async fn subscribe_retain_handling_default() {
         )
         .await
     );
-    assert_subscribe!(rx, options, topic_filter.clone());
+    assert_subscribe!(rx, &options, topic_filter.clone());
 
     let publish = assert_recv!(rx);
     assert_eq!(&*publish.message, msg.as_bytes());
@@ -135,10 +131,10 @@ async fn subscribe_retain_handling_never() {
     sleep(Duration::from_secs(1)).await;
 
     // Subscribe with NeverSend - should NOT receive retained message
-    let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-    options.qos = QoS::AtLeastOnce;
-    options.retain_handling = RetainHandling::NeverSend;
-    assert_subscribe!(rx, options, topic_filter.clone());
+    let options = DEFAULT_QOS0_SUB_OPTIONS
+        .at_least_once()
+        .retain_handling(RetainHandling::NeverSend);
+    assert_subscribe!(rx, &options, topic_filter.clone());
 
     assert_err!(
         timeout(Duration::from_secs(5), async {
@@ -149,7 +145,7 @@ async fn subscribe_retain_handling_never() {
     );
 
     // Subscribe again - should still NOT receive retained message
-    assert_subscribe!(rx, options, topic_filter.clone());
+    assert_subscribe!(rx, &options, topic_filter.clone());
 
     assert_err!(
         timeout(Duration::from_secs(5), async {
@@ -185,17 +181,17 @@ async fn subscribe_retain_handling_clean_only() {
     sleep(Duration::from_secs(1)).await;
 
     // Subscribe for the first time with RetainHandling::SendIfNotSubscribedBefore - should receive retained message
-    let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-    options.qos = QoS::AtLeastOnce;
-    options.retain_handling = RetainHandling::SendIfNotSubscribedBefore;
-    assert_subscribe!(rx, options, topic_filter.clone());
+    let options = DEFAULT_QOS0_SUB_OPTIONS
+        .at_least_once()
+        .retain_handling(RetainHandling::SendIfNotSubscribedBefore);
+    assert_subscribe!(rx, &options, topic_filter.clone());
 
     let publish = assert_recv!(rx);
     assert_eq!(&*publish.message, msg.as_bytes());
     assert!(publish.retain);
 
     // Subscribe again - should NOT receive retained message (already subscribed before)
-    assert_subscribe!(rx, options, topic_filter.clone());
+    assert_subscribe!(rx, &options, topic_filter.clone());
 
     assert_err!(
         timeout(Duration::from_secs(5), async {
@@ -269,9 +265,8 @@ async fn subscribe_retain_as_published_true() {
 
     sleep(Duration::from_secs(1)).await;
 
-    let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-    options.retain_as_published = true;
-    assert_subscribe!(rx, options, topic_filter.clone());
+    let options = DEFAULT_QOS0_SUB_OPTIONS.retain_as_published();
+    assert_subscribe!(rx, &options, topic_filter.clone());
 
     let publish = assert_recv!(rx);
     assert_eq!(&*publish.message, msg.as_bytes());
@@ -299,7 +294,7 @@ async fn subscription_identifier() {
     let mut tx =
         assert_ok!(connected_client(BROKER_ADDRESS, NO_SESSION_CONNECT_OPTIONS, None).await);
 
-    let mut rx: Client<'_, _, _, 1, 1, 1, 1> = {
+    let mut rx: Client<'_, _, _, 1, 1, 1, 1, 16> = {
         let mut client = Client::new(ALLOC.get());
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
@@ -313,10 +308,10 @@ async fn subscription_identifier() {
         )
     };
 
-    let mut options = DEFAULT_QOS0_SUB_OPTIONS;
-    options.qos = QoS::AtLeastOnce;
-    options.subscription_identifier = Some(VarByteInt::from(83u16));
-    assert_subscribe!(rx, options, topic_filter.clone());
+    let options = DEFAULT_QOS0_SUB_OPTIONS
+        .at_least_once()
+        .subscription_identifier(VarByteInt::from(83u16));
+    assert_subscribe!(rx, &options, topic_filter.clone());
 
     let pub_options = PublicationOptions::new(TopicReference::Name(topic_name.clone()))
         .retain()

--- a/tests/integration/will.rs
+++ b/tests/integration/will.rs
@@ -7,7 +7,7 @@ use rust_mqtt::{
         options::{DisconnectOptions, WillOptions},
     },
     config::SessionExpiryInterval,
-    types::{IdentifiedQoS, MqttBinary, MqttString, ReasonCode},
+    types::{IdentifiedQoS, MqttBinary, MqttString, MqttStringPair, ReasonCode},
 };
 use tokio::{
     join,
@@ -254,6 +254,20 @@ async fn properties() {
     let will_content_type = MqttString::from_str("application/json").unwrap();
     let will_correlation_data = MqttBinary::from_slice(b"ask3n028cnc+wscuw c09qn").unwrap();
     let will_response_topic = unique_topic().0;
+    let will_user_properties = Box::leak(Box::new([
+        MqttStringPair::new(
+            MqttString::from_str("Magic smoke").unwrap(),
+            MqttString::from_str("escaped").unwrap(),
+        ),
+        MqttStringPair::new(
+            MqttString::from_str("Sensor accuracy").unwrap(),
+            MqttString::from_str("roughly 50/50").unwrap(),
+        ),
+        MqttStringPair::new(
+            MqttString::from_str("Deep sleep").unwrap(),
+            MqttString::from_str("no alarm set").unwrap(),
+        ),
+    ]));
 
     let will = WillOptions::new(
         will_topic_name.clone(),
@@ -263,7 +277,8 @@ async fn properties() {
     .correlation_data(will_correlation_data.clone())
     .payload_format_indicator(true)
     .message_expiry_interval(1234)
-    .response_topic(will_response_topic.clone());
+    .response_topic(will_response_topic.clone())
+    .user_properties(will_user_properties);
 
     let will_connect_options = NO_SESSION_CONNECT_OPTIONS.clone().will(will);
 
@@ -301,6 +316,7 @@ async fn properties() {
         assert_eq!(message_expiry_interval, Some(1234));
         assert_eq!(response_topic, Some(will_response_topic));
         assert_eq!(correlation_data, Some(will_correlation_data));
+        assert_eq!(user_properties.as_slice(), will_user_properties);
         assert!(subscription_identifiers.is_empty());
         assert_eq!(content_type, Some(will_content_type));
         assert_eq!(&*message, will_msg.as_bytes());

--- a/tests/integration/will.rs
+++ b/tests/integration/will.rs
@@ -56,6 +56,7 @@ async fn network_failure() {
             message_expiry_interval,
             response_topic,
             correlation_data,
+            user_properties,
             subscription_identifiers,
             content_type,
             message,
@@ -68,6 +69,7 @@ async fn network_failure() {
         assert_eq!(message_expiry_interval, None);
         assert_eq!(response_topic, None);
         assert_eq!(correlation_data, None);
+        assert!(user_properties.is_empty());
         assert!(subscription_identifiers.is_empty());
         assert_eq!(content_type, None);
         assert_eq!(&*message, will_msg.as_bytes());
@@ -112,6 +114,7 @@ async fn disconnect_with_will_message() {
             message_expiry_interval,
             response_topic,
             correlation_data,
+            user_properties,
             subscription_identifiers,
             content_type,
             message,
@@ -124,6 +127,7 @@ async fn disconnect_with_will_message() {
         assert_eq!(message_expiry_interval, None);
         assert_eq!(response_topic, None);
         assert_eq!(correlation_data, None);
+        assert!(user_properties.is_empty());
         assert!(subscription_identifiers.is_empty());
         assert_eq!(content_type, None);
         assert_eq!(&*message, will_msg.as_bytes());
@@ -284,6 +288,7 @@ async fn properties() {
             message_expiry_interval,
             response_topic,
             correlation_data,
+            user_properties,
             subscription_identifiers,
             content_type,
             message,
@@ -332,7 +337,7 @@ async fn qos0() {
     let receiver = async {
         assert_subscribe!(
             rx,
-            DEFAULT_QOS0_SUB_OPTIONS.exactly_once(),
+            &DEFAULT_QOS0_SUB_OPTIONS.exactly_once(),
             will_topic_filter
         );
 
@@ -373,7 +378,7 @@ async fn qos1() {
     let receiver = async {
         assert_subscribe!(
             rx,
-            DEFAULT_QOS0_SUB_OPTIONS.exactly_once(),
+            &DEFAULT_QOS0_SUB_OPTIONS.exactly_once(),
             will_topic_filter
         );
 
@@ -414,7 +419,7 @@ async fn qos2() {
     let receiver = async {
         assert_subscribe!(
             rx,
-            DEFAULT_QOS0_SUB_OPTIONS.exactly_once(),
+            &DEFAULT_QOS0_SUB_OPTIONS.exactly_once(),
             will_topic_filter
         );
 
@@ -797,6 +802,7 @@ async fn will_existing_session_taken_over_with_session_expiry() {
             MqttError::Disconnect {
                 reason: ReasonCode::SessionTakenOver,
                 reason_string: _,
+                user_properties: _,
                 server_reference: _,
             }
         ));
@@ -863,6 +869,7 @@ async fn will_existing_session_taken_over_with_will_delay() {
             MqttError::Disconnect {
                 reason: ReasonCode::SessionTakenOver,
                 reason_string: _,
+                user_properties: _,
                 server_reference: _,
             }
         ));
@@ -925,6 +932,7 @@ async fn will_existing_session_taken_over_with_clean_start() {
             MqttError::Disconnect {
                 reason: ReasonCode::SessionTakenOver,
                 reason_string: _,
+                user_properties: _,
                 server_reference: _,
             }
         ));
@@ -988,6 +996,7 @@ async fn no_will_existing_session_taken_over() {
             MqttError::Disconnect {
                 reason: ReasonCode::SessionTakenOver,
                 reason_string: _,
+                user_properties: _,
                 server_reference: _,
             }
         ));
@@ -1160,7 +1169,7 @@ async fn retain() {
     let receiver = async {
         assert_subscribe!(
             rx,
-            DEFAULT_QOS0_SUB_OPTIONS.retain_as_published(),
+            &DEFAULT_QOS0_SUB_OPTIONS.retain_as_published(),
             will_topic_filter.clone()
         );
 

--- a/tests/load/mod.rs
+++ b/tests/load/mod.rs
@@ -1,6 +1,6 @@
 use log::info;
 use rust_mqtt::{
-    client::options::{PublicationOptions, SubscriptionOptions, TopicReference},
+    client::options::{PublicationOptions, TopicReference},
     types::{IdentifiedQoS, QoS, TopicName},
 };
 use tokio::{
@@ -9,7 +9,7 @@ use tokio::{
 };
 
 use crate::common::{
-    BROKER_ADDRESS, DEFAULT_DC_OPTIONS, NO_SESSION_CONNECT_OPTIONS,
+    BROKER_ADDRESS, DEFAULT_DC_OPTIONS, DEFAULT_QOS0_SUB_OPTIONS, NO_SESSION_CONNECT_OPTIONS,
     assert::{assert_ok, assert_published, assert_recv, assert_subscribe},
     utils::{connected_client, disconnect, unique_topic},
 };
@@ -57,16 +57,10 @@ async fn receive_multiple(
     let mut client =
         assert_ok!(connected_client(BROKER_ADDRESS, NO_SESSION_CONNECT_OPTIONS, None).await);
 
-    let options = SubscriptionOptions {
-        retain_handling: rust_mqtt::client::options::RetainHandling::AlwaysSend,
-        retain_as_published: false,
-        no_local: false,
-        qos,
-        subscription_identifier: None,
-    };
+    let options = DEFAULT_QOS0_SUB_OPTIONS.qos(qos);
 
     info!("[Receiver] Subscribing to topic {:?}", topic_name.as_ref());
-    assert_subscribe!(client, options, topic_name.into());
+    assert_subscribe!(client, &options, topic_name.into());
 
     info!("[Receiver] Subscription confirmed, signaling ready");
     assert_ok!(ready_tx.send(()));


### PR DESCRIPTION
Adds support for user properties in the following cases:
- CONNECT
- Will
- CONNACK
- SUBSCRIBE
- UNSUBSCRIBE
- SUBACK
- UNSUBACK
- PUBLISH
- incoming PUBACK
- incoming PUBREC
- incoming PUBREL
- incoming PUBCOMP
- DISCONNECT

Missing cases:
- outgoing PUBACK, PUBREC, PUBREL, PUBCOMP packets

Fixes multiple reason strings being allowed in incoming SUBACK and UNSUBACK packets

This addresses #90, but does not resolve it completely as user properties are still not controllable in the missing cases.