### PR TITLE
Fix const generic parameter usage in Session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix swapped const generic parameter usage in `Session`
+
 ## 0.5.0 - 2026-03-27
 
 - Add subscription identifiers in subscriptions & incoming publishes

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -14,9 +14,9 @@ mod flight;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Session<const RECEIVE_MAXIMUM: usize, const SEND_MAXIMUM: usize> {
     /// The currently in-flight outgoing publications.
-    pub pending_client_publishes: Vec<InFlightPublish<CPublishFlightState>, RECEIVE_MAXIMUM>,
+    pub pending_client_publishes: Vec<InFlightPublish<CPublishFlightState>, SEND_MAXIMUM>,
     /// The currently in-flight incoming publications.
-    pub pending_server_publishes: Vec<InFlightPublish<SPublishFlightState>, SEND_MAXIMUM>,
+    pub pending_server_publishes: Vec<InFlightPublish<SPublishFlightState>, RECEIVE_MAXIMUM>,
 }
 
 impl<const RECEIVE_MAXIMUM: usize, const SEND_MAXIMUM: usize>

--- a/tests/integration/connect_options.rs
+++ b/tests/integration/connect_options.rs
@@ -3,7 +3,7 @@ use std::{num::NonZero, time::Duration};
 use rust_mqtt::{
     Bytes,
     client::{
-        MqttError,
+        Client, MqttError,
         event::Event,
         options::{PublicationOptions, SubscriptionOptions, TopicReference, WillOptions},
     },
@@ -20,7 +20,7 @@ use crate::common::{
     BROKER_ADDRESS, DEFAULT_DC_OPTIONS, DEFAULT_QOS0_SUB_OPTIONS, NO_SESSION_CONNECT_OPTIONS,
     assert::{assert_ok, assert_published, assert_recv, assert_recv_excl, assert_subscribe},
     fmt::warn_inspect,
-    utils::{connected_client, disconnect, tcp_connection, unique_topic},
+    utils::{ALLOC, connected_client, disconnect, tcp_connection, unique_topic},
 };
 
 #[tokio::test]
@@ -696,4 +696,145 @@ async fn keep_alive_not_kept_alive_will_timing() {
     ));
 
     disconnect(&mut rx, DEFAULT_DC_OPTIONS).await;
+}
+
+#[tokio::test]
+#[test_log::test]
+async fn receive_maximum() {
+    let (topic_name, topic_filter) = unique_topic();
+    let mut rx: Client<'_, _, _, 1, 2, 0, 0> = Client::new(ALLOC.get());
+    let mut tx: Client<'_, _, _, 1, 1, 10, 0> = Client::new(ALLOC.get());
+
+    let tcp_rx = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
+    let tcp_tx = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
+
+    assert_ok!(rx.connect(tcp_rx, NO_SESSION_CONNECT_OPTIONS, None).await);
+    assert_ok!(tx.connect(tcp_tx, NO_SESSION_CONNECT_OPTIONS, None).await);
+
+    let pid = assert_ok!(
+        rx.subscribe(topic_filter, SubscriptionOptions::new().exactly_once())
+            .await
+    );
+    let e = assert_ok!(assert_ok!(
+        timeout(Duration::from_secs(10), rx.poll()).await
+    ));
+    if let Event::Suback(e) = e {
+        assert_eq!(e.packet_identifier, pid);
+        assert!(e.reason_code.is_success());
+    } else {
+        panic!()
+    }
+
+    let publisher = async {
+        let mut pids = Vec::new();
+        let pub_options = PublicationOptions::new(TopicReference::Name(topic_name)).exactly_once();
+        for _ in 0..10 {
+            pids.push(assert_ok!(tx.publish(&pub_options, "".into()).await).unwrap());
+        }
+        loop {
+            if let Event::PublishComplete(p) =
+                assert_ok!(assert_ok!(timeout(Duration::from_secs(2), tx.poll()).await))
+            {
+                pids.retain(|pid| pid != &p.packet_identifier);
+            }
+            if pids.is_empty() {
+                break;
+            }
+        }
+        assert_ok!(tx.disconnect(DEFAULT_DC_OPTIONS).await);
+    };
+
+    let receiver = async {
+        let mut in_flight = 0;
+        while let Ok(e) = timeout(Duration::from_secs(3), rx.poll()).await {
+            match assert_ok!(e) {
+                Event::Publish(_) => in_flight += 1,
+                Event::PublishReleased(_) => in_flight -= 1,
+                _ => panic!(),
+            }
+            assert!(in_flight >= 0);
+            assert!(in_flight <= 2);
+        }
+
+        assert_ok!(rx.disconnect(DEFAULT_DC_OPTIONS).await);
+    };
+
+    join!(receiver, publisher);
+}
+
+#[tokio::test]
+#[test_log::test]
+async fn send_maximum_buffer_exceeded() {
+    let topic = unique_topic().0;
+    const SEND_MAXIMUM_BUFFER_SIZE: usize = 2;
+
+    let mut c: Client<'_, _, _, 1, 1, SEND_MAXIMUM_BUFFER_SIZE, 0> = Client::new(ALLOC.get());
+
+    let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
+
+    assert_ok!(c.connect(tcp, NO_SESSION_CONNECT_OPTIONS, None).await);
+
+    let server_receive_maximum = c.server_config().receive_maximum.0.get();
+    assert!(
+        server_receive_maximum as usize > SEND_MAXIMUM_BUFFER_SIZE,
+        "server receive maximum must be greater than {SEND_MAXIMUM_BUFFER_SIZE} for this test"
+    );
+
+    let mut pids = Vec::new();
+    let pub_options = PublicationOptions::new(TopicReference::Name(topic)).exactly_once();
+    for _ in 0..SEND_MAXIMUM_BUFFER_SIZE {
+        pids.push(assert_ok!(c.publish(&pub_options, "".into()).await).unwrap());
+    }
+    let e = assert_err!(c.publish(&pub_options, "".into()).await);
+    assert_eq!(e, MqttError::SessionBuffer);
+
+    loop {
+        if let Event::PublishComplete(p) =
+            assert_ok!(assert_ok!(timeout(Duration::from_secs(2), c.poll()).await))
+        {
+            pids.retain(|pid| pid != &p.packet_identifier);
+        }
+        if pids.is_empty() {
+            break;
+        }
+    }
+    assert_ok!(c.disconnect(DEFAULT_DC_OPTIONS).await);
+}
+
+#[tokio::test]
+#[test_log::test]
+async fn server_receive_maximum_exceeded() {
+    let topic_name = unique_topic().0;
+    let mut c: Client<'_, _, _, 1, 1, 256, 0> = Client::new(ALLOC.get());
+
+    let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
+
+    assert_ok!(c.connect(tcp, NO_SESSION_CONNECT_OPTIONS, None).await);
+
+    let server_receive_maximum = c.server_config().receive_maximum.0.get();
+    assert!(
+        server_receive_maximum < 256,
+        "server receive maximum must be less than 256 for this test"
+    );
+
+    let mut pids = Vec::new();
+    let pub_options = PublicationOptions::new(TopicReference::Name(topic_name)).exactly_once();
+    for _ in 0..server_receive_maximum {
+        pids.push(assert_ok!(c.publish(&pub_options, "".into()).await).unwrap());
+    }
+
+    let e = assert_err!(c.publish(&pub_options, "".into()).await);
+    assert_eq!(e, MqttError::SendQuotaExceeded);
+
+    loop {
+        if let Event::PublishComplete(p) =
+            assert_ok!(assert_ok!(timeout(Duration::from_secs(2), c.poll()).await))
+        {
+            pids.retain(|pid| pid != &p.packet_identifier);
+        }
+        if pids.is_empty() {
+            break;
+        }
+    }
+    assert_ok!(c.disconnect(DEFAULT_DC_OPTIONS).await);
 }


### PR DESCRIPTION
Fixes a subtle but significant bug regarding the buffers for packet identifiers in publication flows. The const generic `RECEIVE_MAXIMUM` is used for the Receive Maximum property that is sent to the server to limit its send quota and also to give the clientside buffer for packet identifiers the correct size. The same goes for `SEND_MAXIMUM`, which acts as an upper limit next to the server's Receive Maximum for outgoing publications. However, the buffer size has been swapped between both const generics, leading to potentially unexpected errors or panics.

This PR also adds tests to ensure correct behaviour of
1. the buffers and their size
2. the client and server preventing protocol errors by not exceeding their peer's Receive Maximum