### PR TITLE
Add request problem information & reason string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detect protocol error on a response information property in CONNACK after CONNECT with request response information set to 0
 - Add request problem information support
 - Add reason string to incoming PUBACK, PUBREC, PUBREL, PUBCOMP, SUBACK, UNSUBACK
-- Detect protocol error when server sends user properties (only when `MAX_USER_PROPERTIES` > 0) or a reason string occur in the PUBACK, PUBREC, PUBREL, PUBCOMP, SUBACK and UNSUBACK packets
+- Detect protocol error when server sends user properties (only when `MAX_USER_PROPERTIES` > 0) or a reason string in the PUBACK, PUBREC, PUBREL, PUBCOMP, SUBACK and UNSUBACK packets
 
 ## 0.5.1 - 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add slices of user property `MqttStringPair`'s to `ConnectOptions`, `WillOptions`, `DisconnectOptions`, `PublicationOptions`, `SubscriptionOptions`, `UnsubscriptionOptions`, as well as `Vec`'s of user property `MqttStringPair`'s to `ConnectInfo` and the `Suback`, `Publish`, `Puback` or `Pubrej` event contents
 - Add the `MAX_USER_PROPERTIES` const generic parameter to the client as an upper limit to the amount of user properties the client can process
 - Fix reason string being allowed more than once in incoming SUBACK and UNSUBACK packets
+- Detect protocol error on a response information property in CONNACK after CONNECT with request response information set to 0
+- Add request problem information support
+- Add reason string to incoming PUBACK, PUBREC, PUBREL, PUBCOMP, SUBACK, UNSUBACK
+- Detect protocol error when server sends user properties (only when `MAX_USER_PROPERTIES` > 0) or a reason string occur in the PUBACK, PUBREC, PUBREL, PUBCOMP, SUBACK and UNSUBACK packets
 
 ## 0.5.1 - 2026-04-10
 

--- a/README.md
+++ b/README.md
@@ -29,16 +29,17 @@ The design goal is a strict yet flexible and explicit API that leverages Rust's 
 - Client- & serverside maximum packet size
 - Subscription identifiers
 - Message expiry interval
-- Topic alias
+- Topic alias in outgoing publications
 - Request/Response
-- Reason String in CONNACK & DISCONNECT packets
+- Reason String in CONNACK, SUBACK, UNSUBACK and DISCONNECT packet as well as incoming PUBACK, PUBREC, PUBREL and PUBCOMP packets
 - User Property in CONNECT, CONNACK, PUBLISH, SUBSCRIBE, SUBACK, UNSUBSCRIBE, UNSUBACK and DISCONNECT packets as well as incoming PUBACK, PUBREC, PUBREL and PUBCOMP packets
 
 ### Currently unsupported MQTT features & limitations
 
 - AUTH packet
-- Properties: Authentication Method, Authentication Data, Request Problem Information, Reason String (PUBACK, PUBREC, PUBREL, PUBCOMP, SUBACK, UNSUBACK), User Property (outgoing PUBACK, PUBREC, PUBREL and PUBCOMP)
+- Properties: Authentication Method, Authentication Data, Request Problem Information, Reason String (outgoing PUBACK, PUBREC, PUBREL, PUBCOMP), User Property (outgoing PUBACK, PUBREC, PUBREL and PUBCOMP)
 - Subscribing to multiple topics in a single packet
+- Topic alias in incoming publications
 
 ### Extension plans (more or less by priority)
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -103,6 +103,7 @@ async fn main() {
     match client.poll().await {
         Ok(Event::Suback(Suback {
             packet_identifier: _,
+            reason_string: _,
             user_properties: _,
             reason_code,
         })) => {
@@ -207,6 +208,7 @@ async fn main() {
     match client.poll().await {
         Ok(Event::Unsuback(Suback {
             packet_identifier: _,
+            reason_string: _,
             user_properties: _,
             reason_code,
         })) => {
@@ -310,6 +312,7 @@ async fn main() {
             Ok(Event::PublishComplete(Puback {
                 packet_identifier,
                 reason_code: _,
+                reason_string: _,
                 user_properties: _,
             })) if packet_identifier == incomplete_publish_packet_identifier => {
                 info!("Completed republish of packet identifier {packet_identifier}");

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -67,7 +67,7 @@ async fn main() {
     #[cfg(feature = "bump")]
     let mut buffer = BumpBuffer::new(&mut buffer);
 
-    let mut client = Client::<'_, _, _, 1, 1, 1, 0, 0>::new(&mut buffer);
+    let mut client = Client::<'_, _, _, 1, 1, 1, 0, 1>::new(&mut buffer);
 
     let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8883);
     let connection = TcpStream::connect(addr).await.unwrap();

--- a/src/client/event.rs
+++ b/src/client/event.rs
@@ -108,6 +108,8 @@ pub struct Suback<'s, const MAX_USER_PROPERTIES: usize> {
     /// Packet identifier of the acknowledged SUBSCRIBE packet.
     pub packet_identifier: PacketIdentifier,
 
+    /// The reason string of the SUBACK/UNSUBACK packet.
+    pub reason_string: Option<MqttString<'s>>,
     /// The user property entries in the SUBACK/UNSUBACK packet.
     /// If the vector is full, this list might not be exhaustive.
     pub user_properties: Vec<MqttStringPair<'s>, MAX_USER_PROPERTIES>,
@@ -186,6 +188,8 @@ pub struct Puback<'p, const MAX_USER_PROPERTIES: usize> {
     pub packet_identifier: PacketIdentifier,
     /// Reason code of this state in the publication process
     pub reason_code: ReasonCode,
+    /// The reason string of the PUBACK/PUBREC/PUBREL/PUBCOMP packet.
+    pub reason_string: Option<MqttString<'p>>,
     /// The user property entries in the PUBACK/PUBREC/PUBREL/PUBCOMP packet.
     /// If the vector is full, this list might not be exhaustive.
     pub user_properties: Vec<MqttStringPair<'p>, MAX_USER_PROPERTIES>,
@@ -200,6 +204,7 @@ impl<'p, T, const MAX_USER_PROPERTIES: usize> From<GenericPubackPacket<'p, T, MA
         Self {
             packet_identifier: packet.packet_identifier,
             reason_code: packet.reason_code,
+            reason_string: packet.reason_string.map(Property::into_inner),
             user_properties: packet
                 .user_properties
                 .into_iter()
@@ -219,6 +224,8 @@ pub struct Pubrej<'p, const MAX_USER_PROPERTIES: usize> {
     pub packet_identifier: PacketIdentifier,
     /// Reason code of the rejection.
     pub reason_code: ReasonCode,
+    /// The reason string of the PUBACK/PUBREC/PUBREL/PUBCOMP packet.
+    pub reason_string: Option<MqttString<'p>>,
     /// The user property entries in the PUBACK/PUBREC/PUBREL/PUBCOMP packet.
     /// If the vector is full, this list might not be exhaustive.
     pub user_properties: Vec<MqttStringPair<'p>, MAX_USER_PROPERTIES>,
@@ -233,6 +240,7 @@ impl<'p, T, const MAX_USER_PROPERTIES: usize> From<GenericPubackPacket<'p, T, MA
         Self {
             packet_identifier: packet.packet_identifier,
             reason_code: packet.reason_code,
+            reason_string: packet.reason_string.map(Property::into_inner),
             user_properties: packet
                 .user_properties
                 .into_iter()

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -258,6 +258,8 @@ impl<
     ///   * the first received packet is something other than a CONNACK packet
     ///   * `client_identifier` is [`None`] and the server did not assign a client identifier
     ///   * the server causes a protocol error
+    ///   * the server sends Response Information despite `request_response_information` in [`ConnectOptions`]
+    ///     being 0
     /// * [`MqttError::Disconnect`] if the CONNACK packet's reason code is not successful (>= 0x80)
     /// * [`MqttError::Network`] if the underlying [`Transport`] returned an error
     /// * [`MqttError::Alloc`] if the underlying [`BufferProvider`] returned an error
@@ -416,6 +418,12 @@ impl<
             response_information,
             server_reference,
         } = self.raw.recv_body(&header).await?;
+
+        if !options.request_response_information && response_information.is_some() {
+            error!("server sent response information when request response information was false");
+            self.raw.close_with(Some(ReasonCode::ProtocolError));
+            return Err(MqttError::Server);
+        }
 
         if reason_code.is_success() {
             debug!("CONNACK packet indicates success");

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -55,8 +55,11 @@ pub use err::Error as MqttError;
 ///   can further limit this with its receive maximum. The client will use the minimum of this value and [`Self::server_config`].
 /// - `MAX_SUBSCRIPTION_IDENTIFIERS`: The maximum amount of subscription identifier properties the client can receive within a
 ///   single PUBLISH packet. If a packet with more subscription identifiers is received, the later identifers will be discarded.
-/// - `MAX_USER_PROPERTIES`: The maximum amount of user properties that the client can send and receive in one packet. Must not
-///   be greater than 1021. This limitation currently exists to easily rule out any variable byte integer overflows.
+/// - `MAX_USER_PROPERTIES`: The maximum amount of user properties that the client can send and receive in one packet.
+///   - Must not be greater than 1021. This limitation currently exists to easily rule out any variable byte integer overflows.
+///   - It is recommended (but not strictly required) to use a value >= 1, because if the value is 0, the client does not
+///     guarantee to detect the protocol error and disconnect from the server when the request problem information property in
+///     CONNECT is 0 and the server sends user properties in a packet other than CONNACK, DISCONNECT or PUBLISH.
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Client<
@@ -306,6 +309,11 @@ impl<
         // which session expiry interval can be sent in DISCONNECT packet.
         self.client_config.session_expiry_interval = options.session_expiry_interval;
 
+        // Set request problem information because it is required to detect protocol
+        // errors when server sends a reason string or user properties in any packet
+        // other than PUBLISH, CONNACK, or DISCONNECT
+        self.client_config.request_problem_information = options.request_problem_information;
+
         // Empirical maximum packet size mapping
         // -------------------------------------------------------------------------------------------------------
         //         remaining length              | fixed header length |              max packet size
@@ -352,6 +360,7 @@ impl<
                 // code is only reached when `RECEIVE_MAXIMUM` is greater than 0.
                 unsafe { NonZero::new_unchecked(RECEIVE_MAXIMUM as u16) },
                 options.request_response_information,
+                options.request_problem_information,
                 options
                     .user_properties
                     .iter()

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1170,6 +1170,17 @@ impl<
                     .raw
                     .recv_body::<SubackPacket<1, MAX_USER_PROPERTIES>>(&header)
                     .await?;
+
+                if !self.client_config.request_problem_information
+                    && (suback.reason_string.is_some() || !suback.user_properties.is_empty())
+                {
+                    error!(
+                        "server sent reason string or user properties when request problem information was false"
+                    );
+                    self.raw.close_with(Some(ReasonCode::ProtocolError));
+                    return Err(MqttError::Server);
+                }
+
                 let pid = suback.packet_identifier;
 
                 if Self::remove_packet_identifier_if_exists(&mut self.pending_suback, pid) {
@@ -1204,6 +1215,17 @@ impl<
                     .raw
                     .recv_body::<UnsubackPacket<1, MAX_USER_PROPERTIES>>(&header)
                     .await?;
+
+                if !self.client_config.request_problem_information
+                    && (unsuback.reason_string.is_some() || !unsuback.user_properties.is_empty())
+                {
+                    error!(
+                        "server sent reason string or user properties when request problem information was false"
+                    );
+                    self.raw.close_with(Some(ReasonCode::ProtocolError));
+                    return Err(MqttError::Server);
+                }
+
                 let pid = unsuback.packet_identifier;
 
                 if Self::remove_packet_identifier_if_exists(&mut self.pending_unsuback, pid) {
@@ -1332,6 +1354,17 @@ impl<
                     .raw
                     .recv_body::<PubackPacket<MAX_USER_PROPERTIES>>(&header)
                     .await?;
+
+                if !self.client_config.request_problem_information
+                    && (puback.reason_string.is_some() || !puback.user_properties.is_empty())
+                {
+                    error!(
+                        "server sent reason string or user properties when request problem information was false"
+                    );
+                    self.raw.close_with(Some(ReasonCode::ProtocolError));
+                    return Err(MqttError::Server);
+                }
+
                 let pid = puback.packet_identifier;
                 let reason_code = puback.reason_code;
 
@@ -1374,6 +1407,17 @@ impl<
                     .raw
                     .recv_body::<PubrecPacket<MAX_USER_PROPERTIES>>(&header)
                     .await?;
+
+                if !self.client_config.request_problem_information
+                    && (pubrec.reason_string.is_some() || !pubrec.user_properties.is_empty())
+                {
+                    error!(
+                        "server sent reason string or user properties when request problem information was false"
+                    );
+                    self.raw.close_with(Some(ReasonCode::ProtocolError));
+                    return Err(MqttError::Server);
+                }
+
                 let pid = pubrec.packet_identifier;
                 let reason_code = pubrec.reason_code;
 
@@ -1444,6 +1488,17 @@ impl<
                     .raw
                     .recv_body::<PubrelPacket<MAX_USER_PROPERTIES>>(&header)
                     .await?;
+
+                if !self.client_config.request_problem_information
+                    && (pubrel.reason_string.is_some() || !pubrel.user_properties.is_empty())
+                {
+                    error!(
+                        "server sent reason string or user properties when request problem information was false"
+                    );
+                    self.raw.close_with(Some(ReasonCode::ProtocolError));
+                    return Err(MqttError::Server);
+                }
+
                 let pid = pubrel.packet_identifier;
                 let reason_code = pubrel.reason_code;
 
@@ -1489,6 +1544,17 @@ impl<
                     .raw
                     .recv_body::<PubcompPacket<MAX_USER_PROPERTIES>>(&header)
                     .await?;
+
+                if !self.client_config.request_problem_information
+                    && (pubcomp.reason_string.is_some() || !pubcomp.user_properties.is_empty())
+                {
+                    error!(
+                        "server sent reason string or user properties when request problem information was false"
+                    );
+                    self.raw.close_with(Some(ReasonCode::ProtocolError));
+                    return Err(MqttError::Server);
+                }
+
                 let pid = pubcomp.packet_identifier;
                 let reason_code = pubcomp.reason_code;
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1174,6 +1174,7 @@ impl<
 
                     Event::Suback(Suback {
                         packet_identifier: pid,
+                        reason_string: suback.reason_string.map(Property::into_inner),
                         user_properties: suback
                             .user_properties
                             .into_iter()
@@ -1206,6 +1207,7 @@ impl<
 
                     Event::Unsuback(Suback {
                         packet_identifier: pid,
+                        reason_string: unsuback.reason_string.map(Property::into_inner),
                         user_properties: unsuback
                             .user_properties
                             .into_iter()

--- a/src/client/options/connect.rs
+++ b/src/client/options/connect.rs
@@ -113,7 +113,8 @@ impl<'c> Options<'c> {
         self
     }
     /// Sets the request problem information property to true allowing the server to send
-    /// user properties and reason strings on all packets instead of only
+    /// user properties and reason strings on all packets instead of only PUBLISH,
+    /// CONNACK and DISCONNECT.
     #[must_use]
     pub const fn request_problem_information(mut self) -> Self {
         self.request_problem_information = true;

--- a/src/client/options/connect.rs
+++ b/src/client/options/connect.rs
@@ -8,24 +8,37 @@ use crate::{
     types::{MqttBinary, MqttString, MqttStringPair},
 };
 
-/// Options for a connection.
+/// Clientside options for establishing a connection to a broker.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Options<'c> {
-    /// If set to true, a new session is started. If set to false, an existing session is continued.
+    /// If set to true, a new session is started. If set to false and the server has an existing session,
+    /// it is continued.
     pub clean_start: bool,
 
     /// The setting of the keep alive the client wishes. Can be set to a different value by the server.
     pub keep_alive: KeepAlive,
 
-    /// The setting of the session expiry interval the server wishes. Can be set to a different value by the server.
+    /// The setting of the session expiry interval the client wishes. This setting can be overriden by
+    /// the server. If set to [`SessionExpiryInterval::EndOnDisconnect`], the session expiry interval
+    /// property is omitted on the network.
     pub session_expiry_interval: SessionExpiryInterval,
 
-    /// The maximum packet size that the client is willing to accept
+    /// The maximum packet size that the client is willing to accept. If set to
+    /// [`MaximumPacketSize::Unlimited`], the maximum packet size property is omitted on the network.
     pub maximum_packet_size: MaximumPacketSize,
 
-    /// When set to true, the broker may return response information used to construct response topics.
+    /// When set to true, the server may return response information used to construct response topics.
+    /// If set to false, the server must not return response information and the request response
+    /// information property is omitted on the network.
     pub request_response_information: bool,
+
+    /// When set to false, the server must not send a reason string or user properties on any packet
+    /// other than PUBLISH, CONNACK, or DISCONNECT.
+    /// If set to true, the server is allowed to send reason strings and user properties on any packet
+    /// that specifies these properties and the request problem information property is omitted on the
+    /// network.
+    pub request_problem_information: bool,
 
     /// Arbitrary key-value pairs of strings sent as the user property entries of the CONNECT packet.
     /// Note that this slice's length must be less than [`crate::client::Client`]'s const generic
@@ -49,7 +62,9 @@ impl Default for Options<'_> {
 
 impl<'c> Options<'c> {
     /// Creates new connect options with no clean start, infinite keep alive and session
-    /// expiry immediately after disconnecting.
+    /// expiry immediately after disconnecting. Request problem information is false
+    /// disallowing the server from sending user properties or reason strings in PUBACK,
+    /// PUBREC, PUBREL, PUBCOMP, SUBACK and UNSUBACK packets.
     #[must_use]
     pub const fn new() -> Self {
         Self {
@@ -58,6 +73,7 @@ impl<'c> Options<'c> {
             session_expiry_interval: SessionExpiryInterval::EndOnDisconnect,
             maximum_packet_size: MaximumPacketSize::Unlimited,
             request_response_information: false,
+            request_problem_information: false,
             user_properties: &[],
             user_name: None,
             password: None,
@@ -94,6 +110,13 @@ impl<'c> Options<'c> {
     #[must_use]
     pub const fn request_response_information(mut self) -> Self {
         self.request_response_information = true;
+        self
+    }
+    /// Sets the request problem information property to true allowing the server to send
+    /// user properties and reason strings on all packets instead of only
+    #[must_use]
+    pub const fn request_problem_information(mut self) -> Self {
+        self.request_problem_information = true;
         self
     }
     /// Sets the user properties. Note that this slice's length must be less than

--- a/src/client/options/disconnect.rs
+++ b/src/client/options/disconnect.rs
@@ -1,10 +1,14 @@
 use crate::{config::SessionExpiryInterval, types::MqttStringPair};
 
+#[allow(unused_imports)]
+use crate::types::ReasonCode;
+
 /// Options for a disconnection to the server with a DISCONNECT packet.
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Options<'d> {
-    /// If set to true, the server publishes the will message.
+    /// If set to true, the client uses [`ReasonCode::DisconnectWithWillMessage`] in and
+    /// the server publishes the will message.
     pub publish_will: bool,
 
     /// The session expiry interval property. Not allowed to be set to a non-zero value

--- a/src/client/options/disconnect.rs
+++ b/src/client/options/disconnect.rs
@@ -7,8 +7,8 @@ use crate::types::ReasonCode;
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Options<'d> {
-    /// If set to true, the client uses [`ReasonCode::DisconnectWithWillMessage`] in and
-    /// the server publishes the will message.
+    /// If set to true, the client uses [`ReasonCode::DisconnectWithWillMessage`] in the
+    /// DISCONNECT packet and the server publishes the will message.
     pub publish_will: bool,
 
     /// The session expiry interval property. Not allowed to be set to a non-zero value

--- a/src/config/client.rs
+++ b/src/config/client.rs
@@ -16,10 +16,23 @@ pub struct Config {
     /// This value is configured when calling [`crate::client::Client::connect`]
     /// from the value in [`crate::client::options::ConnectOptions`]
     pub maximum_accepted_remaining_length: u32,
+
+    /// Whether reason string and user properties are sent (by the server) in case
+    /// of failures. In reality, this depends a lot on the specific server implementation
+    /// and only follows this rule:
+    ///
+    /// Whether the server is allowed to send reason strings or user properties on
+    /// packets other than PUBLISH, CONNACK or DISCONNECT (PUBACK, PUBREC, PUBREL,
+    /// PUBCOMP, SUBACK, UNSUBACK, AUTH).
+    ///
+    /// [MQTTv5.0 3.1.2.11.7](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901053)
+    ///
+    /// This value is configured when calling [`crate::client::Client::connect`]
+    /// from the value in [`crate::client::options::ConnectOptions`]
+    pub request_problem_information: bool,
     // receive_maximum
     // topic_alias_maximum
     // request_response_information this requests a response_information property in the CONNACK
-    // request_problem_information indicates to the server that it may include reason strings and user properties
 }
 
 impl Default for Config {
@@ -27,6 +40,7 @@ impl Default for Config {
         Self {
             session_expiry_interval: SessionExpiryInterval::default(),
             maximum_accepted_remaining_length: VarByteInt::MAX_ENCODABLE,
+            request_problem_information: false,
         }
     }
 }

--- a/src/v5/packet/connack.rs
+++ b/src/v5/packet/connack.rs
@@ -157,10 +157,10 @@ impl<'p, const MAX_USER_PROPERTIES: usize> RxPacket<'p> for ConnackPacket<'p, MA
 
                     // Safety: `!Vec::is_full` guarantees there is space
                     unsafe { user_properties.push_unchecked(user_property) };
-                },
+                }
                 PropertyType::UserProperty => {
                     UserProperty::skip(r).await?;
-                },
+                }
                 PropertyType::WildcardSubscriptionAvailable => wildcard_subscription_available.try_set(r).await?,
                 PropertyType::SubscriptionIdentifierAvailable => subscription_identifier_available.try_set(r).await?,
                 PropertyType::SharedSubscriptionAvailable => shared_subscription_available.try_set(r).await?,
@@ -173,19 +173,19 @@ impl<'p, const MAX_USER_PROPERTIES: usize> RxPacket<'p> for ConnackPacket<'p, MA
                     let len = u16::read(r).await? as usize;
                     verbose!("skipping authentication method ({} bytes)", len);
                     r.skip(len).await?;
-                },
+                }
                 PropertyType::AuthenticationData if seen_authentication_data => return Err(RxError::ProtocolError),
                 PropertyType::AuthenticationData => {
                     seen_authentication_data = true;
                     let len = u16::read(r).await? as usize;
                     verbose!("skipping authentication data ({} bytes)", len);
                     r.skip(len).await?;
-                },
+                }
                 p => {
                     // Malformed packet according to <https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901029>
                     trace!("invalid CONNACK property: {:?}", p);
-                    return Err(RxError::MalformedPacket)
-                },
+                    return Err(RxError::MalformedPacket);
+                }
             };
         }
 

--- a/src/v5/packet/connect.rs
+++ b/src/v5/packet/connect.rs
@@ -1,4 +1,4 @@
-use core::num::NonZero;
+use core::{num::NonZero, ops::Not};
 
 use heapless::Vec;
 
@@ -136,6 +136,7 @@ impl<'p, const MAX_USER_PROPERTIES: usize> ConnectPacket<'p, MAX_USER_PROPERTIES
         session_expiry_interval: SessionExpiryInterval,
         receive_maximum: NonZero<u16>,
         request_response_information: bool,
+        request_problem_information: bool,
         user_properties: Vec<UserProperty<'p>, MAX_USER_PROPERTIES>,
     ) -> Self {
         Self {
@@ -150,7 +151,10 @@ impl<'p, const MAX_USER_PROPERTIES: usize> ConnectPacket<'p, MAX_USER_PROPERTIES
             request_response_information: request_response_information
                 .then_some(true)
                 .map(Into::into),
-            request_problem_information: None,
+            request_problem_information: request_problem_information
+                .not()
+                .then_some(false)
+                .map(Into::into),
             user_properties,
             authentication_method: None,
             authentication_data: None,
@@ -246,6 +250,7 @@ mod unit {
             SessionExpiryInterval::EndOnDisconnect,
             NonZero::new(u16::MAX).unwrap(),
             false,
+            true,
             Vec::new(),
         );
 
@@ -281,6 +286,7 @@ mod unit {
             SessionExpiryInterval::Seconds(8136391),
             NonZero::new(63543).unwrap(),
             true,
+            false,
             [
                 UserProperty(MqttStringPair::new(
                     MqttString::from_str("triple 1").unwrap(),
@@ -301,7 +307,7 @@ mod unit {
         #[rustfmt::skip]
         encode!(packet, [
             0x10,       //
-            0x52,       // remaining length
+            0x54,       // remaining length
             0x00,       // ---
             0x04,       //
             b'M',       //
@@ -312,7 +318,7 @@ mod unit {
             0b00000000, // Connect flags
             0x00,       // Keep alive MSB
             0x00,       // Keep alive LSB
-            0x44,       // Property length
+            0x46,       // Property length
 
             0x11,       // Session expiry interval
             0x00, 0x7C, 0x26, 0xC7,
@@ -325,6 +331,9 @@ mod unit {
 
             0x19,       // Request response information
             0x01,
+
+            0x17,       // Request problem information
+            0x00,
 
             0x26,       // User property
             0x00, 0x08, b't', b'r', b'i', b'p', b'l', b'e', b' ', b'1', 
@@ -353,6 +362,7 @@ mod unit {
             SessionExpiryInterval::EndOnDisconnect,
             NonZero::new(u16::MAX).unwrap(),
             false,
+            true,
             Vec::new(),
         );
 
@@ -415,6 +425,7 @@ mod unit {
             MaximumPacketSize::Unlimited,
             SessionExpiryInterval::Seconds(893475),
             NonZero::new(u16::MAX).unwrap(),
+            true,
             true,
             Vec::new(),
         );

--- a/src/v5/packet/disconnect.rs
+++ b/src/v5/packet/disconnect.rs
@@ -127,7 +127,6 @@ impl<'p, const MAX_USER_PROPERTIES: usize> RxPacket<'p>
                 property_type,
                 r.remaining_len()
             );
-            #[rustfmt::skip]
             match property_type {
                 // Protocol error according to [MQTT-3.14.2-2]
                 PropertyType::SessionExpiryInterval => return Err(RxError::ProtocolError),
@@ -137,16 +136,16 @@ impl<'p, const MAX_USER_PROPERTIES: usize> RxPacket<'p>
 
                     // Safety: `!Vec::is_full` guarantees there is space
                     unsafe { user_properties.push_unchecked(user_property) };
-                },
+                }
                 PropertyType::UserProperty => {
                     UserProperty::skip(r).await?;
-                },
+                }
                 PropertyType::ServerReference => server_reference.try_set(r).await?,
                 // Malformed packet according to <https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901029>
                 p => {
                     trace!("invalid DISCONNECT property: {:?}", p);
-                    return Err(RxError::MalformedPacket)
-                },
+                    return Err(RxError::MalformedPacket);
+                }
             };
         }
 

--- a/src/v5/packet/pubacks/mod.rs
+++ b/src/v5/packet/pubacks/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     types::{PacketIdentifier, ReasonCode, VarByteInt},
     v5::{
         packet::pubacks::types::{Ack, Comp, PubackPacketType, Rec, Rel},
-        property::{PropertyType, UserProperty},
+        property::{AtMostOnceProperty, PropertyType, ReasonString, UserProperty},
     },
 };
 
@@ -39,8 +39,8 @@ pub type PubcompPacket<'p, const MAX_USER_PROPERTIES: usize> =
 pub struct GenericPubackPacket<'p, T, const MAX_USER_PROPERTIES: usize> {
     pub packet_identifier: PacketIdentifier,
     pub reason_code: ReasonCode,
-    // reason string is currently unused and does not have to be read into memory.
-    // reason_string: Option<ReasonString<'p>>,
+
+    pub reason_string: Option<ReasonString<'p>>,
     pub user_properties: Vec<UserProperty<'p>, MAX_USER_PROPERTIES>,
     _phantom_data: PhantomData<&'p T>,
 }
@@ -102,7 +102,7 @@ impl<'p, T: PubackPacketType, const MAX_USER_PROPERTIES: usize> RxPacket<'p>
             return Err(RxError::MalformedPacket);
         }
 
-        let mut seen_reason_string = false;
+        let mut reason_string = None;
         let mut user_properties = Vec::new();
 
         while r.remaining_len() > 0 {
@@ -119,13 +119,7 @@ impl<'p, T: PubackPacketType, const MAX_USER_PROPERTIES: usize> RxPacket<'p>
             );
             #[rustfmt::skip]
             match property_type {
-                PropertyType::ReasonString if seen_reason_string => return Err(RxError::ProtocolError),
-                PropertyType::ReasonString => {
-                    seen_reason_string = true;
-                    let len = u16::read(r).await? as usize;
-                    verbose!("skipping reason string ({} bytes)", len);
-                    r.skip(len).await?;
-                },
+                PropertyType::ReasonString => reason_string.try_set(r).await?,
                 PropertyType::UserProperty if !user_properties.is_full() => {
                     let user_property = UserProperty::read(r).await?;
 
@@ -146,6 +140,7 @@ impl<'p, T: PubackPacketType, const MAX_USER_PROPERTIES: usize> RxPacket<'p>
         Ok(Self {
             packet_identifier,
             reason_code,
+            reason_string,
             user_properties,
             _phantom_data: PhantomData,
         })
@@ -180,23 +175,10 @@ impl<T: PubackPacketType, const MAX_USER_PROPERTIES: usize> TxPacket
         self.packet_identifier.write(write).await?;
         self.reason_code.write(write).await?;
 
-        // FIXME(reason string)
-        // match &self.reason_string {
-        //     // Invariant: reason string length 65537 <= VarByteInt::MAX_ENCODABLE
-        //     Some(r) => {
-        //         VarByteInt::new_unchecked(r.written_len() as u32)
-        //             .write(write)
-        //             .await?;
-        //         r.write(write).await?;
-        //     }
-        //     // Invariant: 0 <= VarByteInt::MAX_ENCODABLE
-        //     None => VarByteInt::new_unchecked(0).write(write).await?,
-        // }
+        let properties_length = self.properties_length();
+        properties_length.write(write).await?;
 
-        // FIXME(reason string)
-        // write empty property length
-        // Invariant: 0 <= VarByteInt::MAX_ENCODABLE
-        VarByteInt::new_unchecked(0).write(write).await?;
+        self.reason_string.write(write).await?;
 
         for user_property in &self.user_properties {
             user_property.write(write).await?;
@@ -213,6 +195,7 @@ impl<T: PubackPacketType, const MAX_USER_PROPERTIES: usize>
         Self {
             packet_identifier,
             reason_code,
+            reason_string: None,
             user_properties: Vec::new(),
             _phantom_data: PhantomData,
         }
@@ -221,9 +204,11 @@ impl<T: PubackPacketType, const MAX_USER_PROPERTIES: usize>
     fn properties_length(&self) -> VarByteInt {
         let len: usize = self.user_properties.iter().map(Writable::written_len).sum();
 
-        // FIXME(user property): No support for outgoing user properties yet, therefore the
-        // encoded length of user properties is 0
-        // Invariant: Max length = 0 <= VarByteInt::MAX_ENCODABLE
+        // max length = MAX_USER_PROPERTIES * 131077 + 65538
+        // Invariant: MAX_USER_PROPERTIES <= 2047 => max length <= VarByteInt::MAX_ENCODABLE
+        //
+        // reason string: 65538
+        // user properties: MAX_USER_PROPERTIES * 131077
         VarByteInt::new_unchecked(len as u32)
     }
 }
@@ -236,7 +221,10 @@ mod unit {
         use crate::{
             test::{rx::decode, tx::encode},
             types::{MqttString, MqttStringPair, PacketIdentifier, ReasonCode},
-            v5::{packet::PubackPacket, property::UserProperty},
+            v5::{
+                packet::PubackPacket,
+                property::{ReasonString, UserProperty},
+            },
         };
 
         #[tokio::test]
@@ -266,7 +254,7 @@ mod unit {
                 PacketIdentifier::new(NonZero::new(9769).unwrap())
             );
             assert_eq!(packet.reason_code, ReasonCode::NoMatchingSubscribers);
-            // assert!(packet.reason_string.is_none());
+            assert!(packet.reason_string.is_none());
             assert!(packet.user_properties.is_empty());
         }
 
@@ -280,7 +268,7 @@ mod unit {
                 PacketIdentifier::new(NonZero::new(29017).unwrap())
             );
             assert_eq!(packet.reason_code, ReasonCode::UnspecifiedError);
-            // assert!(packet.reason_string.is_none());
+            assert!(packet.reason_string.is_none());
             assert!(packet.user_properties.is_empty());
         }
 
@@ -294,7 +282,7 @@ mod unit {
                 PacketIdentifier::new(NonZero::new(35125).unwrap())
             );
             assert_eq!(packet.reason_code, ReasonCode::Success);
-            // assert!(packet.reason_string.is_none());
+            assert!(packet.reason_string.is_none());
             assert!(packet.user_properties.is_empty());
         }
 
@@ -319,10 +307,10 @@ mod unit {
                 PacketIdentifier::new(NonZero::new(4660).unwrap())
             );
             assert_eq!(packet.reason_code, ReasonCode::PayloadFormatInvalid);
-            // assert_eq!(
-            //     packet.reason_string,
-            //     Some(ReasonString(MqttString::try_from("test reason").unwrap()))
-            // );
+            assert_eq!(
+                packet.reason_string,
+                Some(ReasonString(MqttString::try_from("test reason").unwrap()))
+            );
 
             assert_eq!(packet.user_properties.len(), 1);
             assert_eq!(
@@ -379,7 +367,10 @@ mod unit {
         use crate::{
             test::{rx::decode, tx::encode},
             types::{MqttString, MqttStringPair, PacketIdentifier, ReasonCode},
-            v5::{packet::PubrecPacket, property::UserProperty},
+            v5::{
+                packet::PubrecPacket,
+                property::{ReasonString, UserProperty},
+            },
         };
 
         #[tokio::test]
@@ -409,7 +400,7 @@ mod unit {
                 PacketIdentifier::new(NonZero::new(9876).unwrap())
             );
             assert_eq!(packet.reason_code, ReasonCode::PacketIdentifierInUse);
-            // assert!(packet.reason_string.is_none());
+            assert!(packet.reason_string.is_none());
             assert!(packet.user_properties.is_empty());
         }
 
@@ -423,7 +414,7 @@ mod unit {
                 PacketIdentifier::new(NonZero::new(17865).unwrap())
             );
             assert_eq!(packet.reason_code, ReasonCode::ImplementationSpecificError);
-            // assert!(packet.reason_string.is_none());
+            assert!(packet.reason_string.is_none());
             assert!(packet.user_properties.is_empty());
         }
 
@@ -437,7 +428,7 @@ mod unit {
                 PacketIdentifier::new(NonZero::new(23487).unwrap())
             );
             assert_eq!(packet.reason_code, ReasonCode::Success);
-            // assert!(packet.reason_string.is_none());
+            assert!(packet.reason_string.is_none());
             assert!(packet.user_properties.is_empty());
         }
 
@@ -465,10 +456,10 @@ mod unit {
                 PacketIdentifier::new(NonZero::new(9786).unwrap())
             );
             assert_eq!(packet.reason_code, ReasonCode::TopicNameInvalid);
-            // assert_eq!(
-            //     packet.reason_string,
-            //     Some(ReasonString(MqttString::try_from("test reason").unwrap()))
-            // );
+            assert_eq!(
+                packet.reason_string,
+                Some(ReasonString(MqttString::try_from("test reason").unwrap()))
+            );
 
             assert_eq!(packet.user_properties.len(), 1);
             assert_eq!(
@@ -519,7 +510,10 @@ mod unit {
         use crate::{
             test::{rx::decode, tx::encode},
             types::{MqttString, MqttStringPair, PacketIdentifier, ReasonCode},
-            v5::{packet::PubrelPacket, property::UserProperty},
+            v5::{
+                packet::PubrelPacket,
+                property::{ReasonString, UserProperty},
+            },
         };
 
         #[tokio::test]
@@ -549,7 +543,7 @@ mod unit {
                 PacketIdentifier::new(NonZero::new(9876).unwrap())
             );
             assert_eq!(packet.reason_code, ReasonCode::Success);
-            // assert!(packet.reason_string.is_none());
+            assert!(packet.reason_string.is_none());
             assert!(packet.user_properties.is_empty());
         }
 
@@ -563,7 +557,7 @@ mod unit {
                 PacketIdentifier::new(NonZero::new(17865).unwrap())
             );
             assert_eq!(packet.reason_code, ReasonCode::PacketIdentifierNotFound);
-            // assert!(packet.reason_string.is_none());
+            assert!(packet.reason_string.is_none());
             assert!(packet.user_properties.is_empty());
         }
 
@@ -577,7 +571,7 @@ mod unit {
                 PacketIdentifier::new(NonZero::new(23487).unwrap())
             );
             assert_eq!(packet.reason_code, ReasonCode::Success);
-            // assert!(packet.reason_string.is_none());
+            assert!(packet.reason_string.is_none());
             assert!(packet.user_properties.is_empty());
         }
 
@@ -612,10 +606,10 @@ mod unit {
                 PacketIdentifier::new(NonZero::new(9786).unwrap())
             );
             assert_eq!(packet.reason_code, ReasonCode::PacketIdentifierNotFound);
-            // assert_eq!(
-            //     packet.reason_string,
-            //     Some(ReasonString(MqttString::try_from("test reason").unwrap()))
-            // );
+            assert_eq!(
+                packet.reason_string,
+                Some(ReasonString(MqttString::try_from("test reason").unwrap()))
+            );
 
             assert_eq!(packet.user_properties.len(), 1);
             assert_eq!(
@@ -666,7 +660,10 @@ mod unit {
         use crate::{
             test::{rx::decode, tx::encode},
             types::{MqttString, MqttStringPair, PacketIdentifier, ReasonCode},
-            v5::{packet::PubcompPacket, property::UserProperty},
+            v5::{
+                packet::PubcompPacket,
+                property::{ReasonString, UserProperty},
+            },
         };
 
         #[tokio::test]
@@ -696,7 +693,7 @@ mod unit {
                 PacketIdentifier::new(NonZero::new(9876).unwrap())
             );
             assert_eq!(packet.reason_code, ReasonCode::Success);
-            // assert!(packet.reason_string.is_none());
+            assert!(packet.reason_string.is_none());
             assert!(packet.user_properties.is_empty());
         }
 
@@ -710,7 +707,7 @@ mod unit {
                 PacketIdentifier::new(NonZero::new(17865).unwrap())
             );
             assert_eq!(packet.reason_code, ReasonCode::PacketIdentifierNotFound);
-            // assert!(packet.reason_string.is_none());
+            assert!(packet.reason_string.is_none());
             assert!(packet.user_properties.is_empty());
         }
 
@@ -724,7 +721,7 @@ mod unit {
                 PacketIdentifier::new(NonZero::new(23487).unwrap())
             );
             assert_eq!(packet.reason_code, ReasonCode::Success);
-            // assert!(packet.reason_string.is_none());
+            assert!(packet.reason_string.is_none());
             assert!(packet.user_properties.is_empty());
         }
 
@@ -753,10 +750,10 @@ mod unit {
                 PacketIdentifier::new(NonZero::new(9786).unwrap())
             );
             assert_eq!(packet.reason_code, ReasonCode::PacketIdentifierNotFound);
-            // assert_eq!(
-            //     packet.reason_string,
-            //     Some(ReasonString(MqttString::try_from("test reason").unwrap()))
-            // );
+            assert_eq!(
+                packet.reason_string,
+                Some(ReasonString(MqttString::try_from("test reason").unwrap()))
+            );
 
             assert_eq!(packet.user_properties.len(), 1);
             assert_eq!(

--- a/src/v5/packet/pubacks/mod.rs
+++ b/src/v5/packet/pubacks/mod.rs
@@ -117,7 +117,6 @@ impl<'p, T: PubackPacketType, const MAX_USER_PROPERTIES: usize> RxPacket<'p>
                 property_type,
                 r.remaining_len()
             );
-            #[rustfmt::skip]
             match property_type {
                 PropertyType::ReasonString => reason_string.try_set(r).await?,
                 PropertyType::UserProperty if !user_properties.is_full() => {
@@ -125,15 +124,15 @@ impl<'p, T: PubackPacketType, const MAX_USER_PROPERTIES: usize> RxPacket<'p>
 
                     // Safety: `!Vec::is_full` guarantees there is space
                     unsafe { user_properties.push_unchecked(user_property) };
-                },
+                }
                 PropertyType::UserProperty => {
                     UserProperty::skip(r).await?;
-                },
+                }
                 p => {
                     // Malformed packet according to <https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901029>
                     trace!("invalid packet {:?} property: {:?}", T::PACKET_TYPE, p);
-                    return Err(RxError::MalformedPacket)
-                },
+                    return Err(RxError::MalformedPacket);
+                }
             };
         }
 

--- a/src/v5/packet/pubacks/mod.rs
+++ b/src/v5/packet/pubacks/mod.rs
@@ -6,6 +6,8 @@ use core::marker::PhantomData;
 
 use heapless::Vec;
 
+#[cfg(test)]
+use crate::types::{MqttString, MqttStringPair};
 use crate::{
     buffer::BufferProvider,
     eio::{Read, Write},
@@ -187,8 +189,8 @@ impl<T: PubackPacketType, const MAX_USER_PROPERTIES: usize> TxPacket
     }
 }
 
-impl<T: PubackPacketType, const MAX_USER_PROPERTIES: usize>
-    GenericPubackPacket<'_, T, MAX_USER_PROPERTIES>
+impl<'p, T: PubackPacketType, const MAX_USER_PROPERTIES: usize>
+    GenericPubackPacket<'p, T, MAX_USER_PROPERTIES>
 {
     pub const fn new(packet_identifier: PacketIdentifier, reason_code: ReasonCode) -> Self {
         Self {
@@ -198,6 +200,17 @@ impl<T: PubackPacketType, const MAX_USER_PROPERTIES: usize>
             user_properties: Vec::new(),
             _phantom_data: PhantomData,
         }
+    }
+
+    #[cfg(test)]
+    pub fn add_reason_string(&mut self, reason_string: MqttString<'p>) {
+        self.reason_string = Some(reason_string.into());
+    }
+    #[cfg(test)]
+    pub fn add_user_property(&mut self, user_property: MqttStringPair<'p>) {
+        self.user_properties
+            .push(UserProperty(user_property))
+            .unwrap();
     }
 
     fn properties_length(&self) -> VarByteInt {
@@ -244,6 +257,45 @@ mod unit {
                     0x0F, // Packet identifier LSB
                     0x87, // Reason Code
                     0x00, // Property length
+                ]
+            );
+        }
+
+        #[tokio::test]
+        #[test_log::test]
+        async fn encode_properties() {
+            let mut packet = PubackPacket::<16>::new(
+                PacketIdentifier::new(NonZero::new(23485).unwrap()),
+                ReasonCode::TopicNameInvalid,
+            );
+            packet.add_reason_string(MqttString::from_str("invalid topic name!").unwrap());
+            packet.add_user_property(MqttStringPair::new(
+                MqttString::from_str("topic name").unwrap(),
+                MqttString::from_str("invalid").unwrap(),
+            ));
+            packet.add_user_property(MqttStringPair::new(
+                MqttString::from_str("accepted").unwrap(),
+                MqttString::from_str("negative").unwrap(),
+            ));
+
+            #[rustfmt::skip]
+            encode!(
+                packet,
+                [
+                    0x40,
+                    0x45,
+                    0x5B, // Packet identifier MSB
+                    0xBD, // Packet identifier LSB
+                    0x90, // Reason Code
+                    0x41, // Property length
+                    // Reason String
+                    0x1F, 0x00, 0x13, b'i', b'n', b'v', b'a', b'l', b'i', b'd', b' ', b't', b'o', b'p', b'i', b'c', b' ', b'n', b'a', b'm', b'e', b'!',
+                    // User Property
+                    0x26, 0x00, 0x0A, b't', b'o', b'p', b'i', b'c', b' ', b'n', b'a', b'm', b'e',
+                          0x00, 0x07, b'i', b'n', b'v', b'a', b'l', b'i', b'd',
+                    // User Property
+                    0x26, 0x00, 0x08, b'a', b'c', b'c', b'e', b'p', b't', b'e', b'd',
+                          0x00, 0x08, b'n', b'e', b'g', b'a', b't', b'i', b'v', b'e',
                 ]
             );
         }
@@ -396,6 +448,45 @@ mod unit {
 
         #[tokio::test]
         #[test_log::test]
+        async fn encode_properties() {
+            let mut packet = PubrecPacket::<16>::new(
+                PacketIdentifier::new(NonZero::new(23895).unwrap()),
+                ReasonCode::ImplementationSpecificError,
+            );
+            packet.add_reason_string(MqttString::from_str("I crashed :(").unwrap());
+            packet.add_user_property(MqttStringPair::new(
+                MqttString::from_str("me").unwrap(),
+                MqttString::from_str("somewhere over the rainbow").unwrap(),
+            ));
+            packet.add_user_property(MqttStringPair::new(
+                MqttString::from_str("problem").unwrap(),
+                MqttString::from_str("yours").unwrap(),
+            ));
+
+            #[rustfmt::skip]
+            encode!(
+                packet,
+                [
+                    0x50,
+                    0x45,
+                    0x5D, // Packet identifier MSB
+                    0x57, // Packet identifier LSB
+                    0x83, // Reason Code
+                    0x41, // Property length
+                    // Reason String
+                    0x1F, 0x00, 0x0C, b'I', b' ', b'c', b'r', b'a', b's', b'h', b'e', b'd', b' ', b':', b'(',
+                    // User Property
+                    0x26, 0x00, 0x02, b'm', b'e',
+                          0x00, 0x1A, b's', b'o', b'm', b'e', b'w', b'h', b'e', b'r', b'e', b' ', b'o', b'v', b'e', b'r', b' ', b't', b'h', b'e', b' ', b'r', b'a', b'i', b'n', b'b', b'o', b'w',
+                    // User Property
+                    0x26, 0x00, 0x07, b'p', b'r', b'o', b'b', b'l', b'e', b'm',
+                          0x00, 0x05, b'y', b'o', b'u', b'r', b's',
+                ]
+            );
+        }
+
+        #[tokio::test]
+        #[test_log::test]
         async fn decode_simple() {
             let packet = decode!(PubrecPacket<2>, 4, [0x50, 0x04, 0x26, 0x94, 0x91, 0x00]);
 
@@ -539,6 +630,38 @@ mod unit {
 
         #[tokio::test]
         #[test_log::test]
+        async fn encode_properties() {
+            let mut packet = PubrelPacket::<16>::new(
+                PacketIdentifier::new(NonZero::new(9786).unwrap()),
+                ReasonCode::PacketIdentifierNotFound,
+            );
+            packet.add_reason_string(MqttString::try_from("test reason").unwrap());
+            packet.add_user_property(MqttStringPair::new(
+                MqttString::try_from("test-name").unwrap(),
+                MqttString::try_from("test-value").unwrap(),
+            ));
+
+            #[rustfmt::skip]
+            encode!(
+                packet,
+                [
+                    0x62,
+                    0x2A,
+                    0x26,   // Packet identifier MSB
+                    0x3A,   // Packet identifier LSB
+                    0x92,   // Reason Code
+                    0x26,   // Property length
+                    // Reason String
+                    0x1F, 0x00, 0x0B, b't', b'e', b's', b't', b' ', b'r', b'e', b'a', b's', b'o', b'n',
+                    // User Property
+                    0x26, 0x00, 0x09, b't', b'e', b's', b't', b'-', b'n', b'a', b'm', b'e',
+                          0x00, 0x0A, b't', b'e', b's', b't', b'-', b'v', b'a', b'l', b'u', b'e',
+                ]
+            );
+        }
+
+        #[tokio::test]
+        #[test_log::test]
         async fn decode_simple() {
             let packet = decode!(PubrelPacket<2>, 4, [0x62, 0x04, 0x26, 0x94, 0x00, 0x00]);
 
@@ -589,7 +712,7 @@ mod unit {
                 [
                     0x62,
                     0x2A, 
-                    
+
                     0x26, 0x3A, // Packet Identifier
                     0x92,       // Reason Code
 
@@ -598,7 +721,7 @@ mod unit {
                     // Reason String
                     0x1F, 0x00, 0x0B,
                           b't', b'e', b's', b't', b' ', b'r', b'e', b'a', b's', b'o', b'n', 
-                    
+
                     // User Property
                     0x26, 0x00, 0x09, b't', b'e', b's', b't', b'-', b'n', b'a', b'm', b'e', 
                           0x00, 0x0A, b't', b'e', b's', b't', b'-', b'v', b'a', b'l', b'u', b'e',
@@ -683,6 +806,40 @@ mod unit {
                     0x6C, // Packet identifier LSB
                     0x92, // Reason Code
                     0x00, // Property length
+                ]
+            );
+        }
+
+        #[tokio::test]
+        #[test_log::test]
+        async fn encode_properties() {
+            let mut packet = PubcompPacket::<16>::new(
+                PacketIdentifier::new(NonZero::new(9786).unwrap()),
+                ReasonCode::PacketIdentifierNotFound,
+            );
+            packet.add_reason_string(MqttString::try_from("test reason").unwrap());
+            packet.add_user_property(MqttStringPair::new(
+                MqttString::try_from("test-name").unwrap(),
+                MqttString::try_from("test-value").unwrap(),
+            ));
+
+            #[rustfmt::skip]
+            encode!(
+                packet,
+                [
+                    0x70,
+                    0x2A,
+                    0x26,   // Packet identifier MSB
+                    0x3A,   // Packet identifier LSB
+                    0x92,   // Reason Code
+                    0x26,   // Property length
+
+                    // Reason String
+                    0x1F, 0x00, 0x0B, b't', b'e', b's', b't', b' ', b'r', b'e', b'a', b's', b'o', b'n',
+
+                    // User Property
+                    0x26, 0x00, 0x09, b't', b'e', b's', b't', b'-', b'n', b'a', b'm', b'e',
+                          0x00, 0x0A, b't', b'e', b's', b't', b'-', b'v', b'a', b'l', b'u', b'e',
                 ]
             );
         }

--- a/src/v5/packet/pubacks/mod.rs
+++ b/src/v5/packet/pubacks/mod.rs
@@ -201,7 +201,12 @@ impl<T: PubackPacketType, const MAX_USER_PROPERTIES: usize>
     }
 
     fn properties_length(&self) -> VarByteInt {
-        let len: usize = self.user_properties.iter().map(Writable::written_len).sum();
+        let len = self.reason_string.written_len()
+            + self
+                .user_properties
+                .iter()
+                .map(Writable::written_len)
+                .sum::<usize>();
 
         // max length = MAX_USER_PROPERTIES * 131077 + 65538
         // Invariant: MAX_USER_PROPERTIES <= 2047 => max length <= VarByteInt::MAX_ENCODABLE

--- a/src/v5/packet/subacks/mod.rs
+++ b/src/v5/packet/subacks/mod.rs
@@ -106,14 +106,13 @@ impl<'p, T: SubackPacketType, const MAX_TOPIC_FILTERS: usize, const MAX_USER_PRO
                 r.remaining_len()
             );
 
-            #[rustfmt::skip]
             match property_type {
                 PropertyType::ReasonString => {
                     reason_string.try_set(r).await?;
                     properties_length = properties_length
                         .checked_sub(reason_string.as_ref().unwrap().0.written_len())
                         .ok_or(RxError::MalformedPacket)?;
-                },
+                }
                 PropertyType::UserProperty if !user_properties.is_full() => {
                     let user_property = UserProperty::read(r).await?;
 
@@ -133,8 +132,8 @@ impl<'p, T: SubackPacketType, const MAX_TOPIC_FILTERS: usize, const MAX_USER_PRO
                 p => {
                     // Malformed packet according to <https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901029>
                     trace!("invalid {:?} property: {:?}", T::PACKET_TYPE, p);
-                    return Err(RxError::MalformedPacket)
-                },
+                    return Err(RxError::MalformedPacket);
+                }
             };
         }
 

--- a/src/v5/packet/subacks/mod.rs
+++ b/src/v5/packet/subacks/mod.rs
@@ -9,13 +9,13 @@ use crate::{
     header::{FixedHeader, PacketType},
     io::{
         read::{BodyReader, Readable},
-        write::{Writable, wlen},
+        write::Writable,
     },
     packet::{Packet, RxError, RxPacket},
     types::{PacketIdentifier, ReasonCode, VarByteInt},
     v5::{
         packet::subacks::types::{Suback, SubackPacketType, Unsuback},
-        property::{PropertyType, UserProperty},
+        property::{AtMostOnceProperty, PropertyType, ReasonString, UserProperty},
     },
 };
 
@@ -36,8 +36,7 @@ pub struct GenericSubackPacket<
 > {
     pub packet_identifier: PacketIdentifier,
 
-    // reason string is currently unused and does not have to be read into memory.
-    // reason_string: Option<ReasonString<'p>>,
+    pub reason_string: Option<ReasonString<'p>>,
     pub user_properties: Vec<UserProperty<'p>, MAX_USER_PROPERTIES>,
 
     pub reason_codes: Vec<ReasonCode, MAX_TOPIC_FILTERS>,
@@ -88,7 +87,7 @@ impl<'p, T: SubackPacketType, const MAX_TOPIC_FILTERS: usize, const MAX_USER_PRO
             return Err(RxError::ProtocolError);
         }
 
-        let mut seen_reason_string = false;
+        let mut reason_string: Option<ReasonString<'_>> = None;
         let mut user_properties = Vec::new();
 
         while properties_length > 0 {
@@ -109,14 +108,10 @@ impl<'p, T: SubackPacketType, const MAX_TOPIC_FILTERS: usize, const MAX_USER_PRO
 
             #[rustfmt::skip]
             match property_type {
-                PropertyType::ReasonString if seen_reason_string => return Err(RxError::ProtocolError),
                 PropertyType::ReasonString => {
-                    seen_reason_string = true;
-                    let len = u16::read(r).await? as usize;
-                    verbose!("skipping reason string ({} bytes)", len);
-                    r.skip(len).await?;
+                    reason_string.try_set(r).await?;
                     properties_length = properties_length
-                        .checked_sub(wlen!(u16) + len)
+                        .checked_sub(reason_string.as_ref().unwrap().0.written_len())
                         .ok_or(RxError::MalformedPacket)?;
                 },
                 PropertyType::UserProperty if !user_properties.is_full() => {
@@ -141,8 +136,6 @@ impl<'p, T: SubackPacketType, const MAX_TOPIC_FILTERS: usize, const MAX_USER_PRO
                     return Err(RxError::MalformedPacket)
                 },
             };
-
-            let _ = seen_reason_string;
         }
 
         let mut reason_codes = Vec::new();
@@ -170,6 +163,7 @@ impl<'p, T: SubackPacketType, const MAX_TOPIC_FILTERS: usize, const MAX_USER_PRO
 
         Ok(Self {
             packet_identifier,
+            reason_string,
             user_properties,
             reason_codes,
             _phantom_data: PhantomData,
@@ -187,7 +181,10 @@ mod unit {
         use crate::{
             test::rx::decode,
             types::{MqttString, MqttStringPair, PacketIdentifier, ReasonCode},
-            v5::{packet::SubackPacket, property::UserProperty},
+            v5::{
+                packet::SubackPacket,
+                property::{ReasonString, UserProperty},
+            },
         };
 
         #[tokio::test]
@@ -213,7 +210,7 @@ mod unit {
                 packet.packet_identifier,
                 PacketIdentifier::new(NonZero::new(6025).unwrap())
             );
-            // assert!(packet.reason_string.is_none());
+            assert!(packet.reason_string.is_none());
             assert!(packet.user_properties.is_empty());
 
             let reason_codes: Vec<_, 12> = [
@@ -266,10 +263,10 @@ mod unit {
                 packet.packet_identifier,
                 PacketIdentifier::new(NonZero::new(5620).unwrap())
             );
-            // assert_eq!(
-            //     packet.reason_string,
-            //     Some(ReasonString(MqttString::try_from("crazy things").unwrap()))
-            // );
+            assert_eq!(
+                packet.reason_string,
+                Some(ReasonString(MqttString::try_from("crazy things").unwrap()))
+            );
             assert_eq!(
                 packet.user_properties,
                 [
@@ -337,7 +334,10 @@ mod unit {
         use crate::{
             test::rx::decode,
             types::{MqttString, MqttStringPair, PacketIdentifier, ReasonCode},
-            v5::{packet::UnsubackPacket, property::UserProperty},
+            v5::{
+                packet::UnsubackPacket,
+                property::{ReasonString, UserProperty},
+            },
         };
 
         #[tokio::test]
@@ -362,7 +362,7 @@ mod unit {
                 packet.packet_identifier,
                 PacketIdentifier::new(NonZero::new(41972).unwrap())
             );
-            // assert!(packet.reason_string.is_none());
+            assert!(packet.reason_string.is_none());
             assert!(packet.user_properties.is_empty());
 
             let reason_codes: Vec<_, 7> = [
@@ -414,10 +414,12 @@ mod unit {
                 packet.packet_identifier,
                 PacketIdentifier::new(NonZero::new(9756).unwrap())
             );
-            // assert_eq!(
-            //     packet.reason_string,
-            //     Some(ReasonString(MqttString::try_from("get outta here").unwrap()))
-            // );
+            assert_eq!(
+                packet.reason_string,
+                Some(ReasonString(
+                    MqttString::try_from("get outta here").unwrap()
+                ))
+            );
             assert_eq!(
                 packet.user_properties,
                 [

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -36,6 +36,7 @@ pub const NO_SESSION_CONNECT_OPTIONS: &ConnectOptions<'static> = &ConnectOptions
     maximum_packet_size: MaximumPacketSize::Unlimited,
     session_expiry_interval: SessionExpiryInterval::EndOnDisconnect,
     request_response_information: false,
+    request_problem_information: true,
     user_properties: &[],
     user_name: Some(USERNAME),
     password: Some(PASSWORD),

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -130,6 +130,7 @@ pub async fn subscribe<'c>(
         match warn_inspect!(client.poll().await, "Client::poll() failed")? {
             Event::Suback(Suback {
                 packet_identifier,
+                reason_string: _,
                 user_properties: _,
                 reason_code,
             }) if packet_identifier == pid => {
@@ -143,6 +144,7 @@ pub async fn subscribe<'c>(
             }
             Event::Suback(Suback {
                 packet_identifier,
+                reason_string: _,
                 user_properties: _,
                 reason_code: _,
             }) => {
@@ -171,6 +173,7 @@ pub async fn unsubscribe<'c>(
         match warn_inspect!(client.poll().await, "Client::poll() failed")? {
             Event::Unsuback(Suback {
                 packet_identifier,
+                reason_string: _,
                 user_properties: _,
                 reason_code,
             }) if packet_identifier == pid => {
@@ -179,6 +182,7 @@ pub async fn unsubscribe<'c>(
             }
             Event::Unsuback(Suback {
                 packet_identifier,
+                reason_string: _,
                 user_properties: _,
                 reason_code: _,
             }) => {

--- a/tests/integration/message_retry.rs
+++ b/tests/integration/message_retry.rs
@@ -82,6 +82,7 @@ async fn outgoing_qos1_retry() {
                         Event::PublishAcknowledged(Puback {
                             packet_identifier,
                             reason_code: _,
+                            reason_string: _,
                             user_properties: _,
                         }) if packet_identifier == pid => break,
                         _ => {}
@@ -169,6 +170,7 @@ async fn outgoing_qos2_retry_publish() {
                         Event::PublishComplete(Puback {
                             packet_identifier,
                             reason_code: _,
+                            reason_string: _,
                             user_properties: _,
                         }) if packet_identifier == pid => break,
                         _ => {}
@@ -234,6 +236,7 @@ async fn outgoing_qos2_retry_pubrel() {
                         Event::PublishReceived(Puback {
                             packet_identifier,
                             reason_code: _,
+                            reason_string: _,
                             user_properties: _,
                         }) if packet_identifier == pid => break,
                         _ => {}
@@ -269,6 +272,7 @@ async fn outgoing_qos2_retry_pubrel() {
                         Event::PublishComplete(Puback {
                             packet_identifier,
                             reason_code: _,
+                            reason_string: _,
                             user_properties: _,
                         }) if packet_identifier == pid => break,
                         _ => {}
@@ -369,6 +373,7 @@ async fn incoming_qos2_retry_pubcomp() {
                         Event::PublishReleased(Puback {
                             packet_identifier,
                             reason_code: _,
+                            reason_string: _,
                             user_properties: _,
                         }) if packet_identifier == pid => {
                             break;
@@ -447,6 +452,7 @@ async fn outgoing_qos1_write_fail_retry() {
                         Event::PublishAcknowledged(Puback {
                             packet_identifier,
                             reason_code: _,
+                            reason_string: _,
                             user_properties: _,
                         }) if pid == packet_identifier => {}
                         _ => panic!("Should only receive a PUBACK"),
@@ -491,6 +497,7 @@ async fn outgoing_qos1_write_fail_retry() {
                     Event::PublishAcknowledged(Puback {
                         packet_identifier,
                         reason_code: _,
+                        reason_string: _,
                         user_properties: _,
                     }) if pid == packet_identifier => {}
                     _ => panic!("Should only receive a PUBACK"),
@@ -562,6 +569,7 @@ async fn outgoing_qos1_read_fail_retry() {
                         Ok(Event::PublishAcknowledged(Puback {
                             packet_identifier,
                             reason_code: _,
+                            reason_string: _,
                             user_properties: _,
                         })) if pid == packet_identifier => {}
                         Ok(_) => panic!("Should only receive a PUBACK"),
@@ -600,6 +608,7 @@ async fn outgoing_qos1_read_fail_retry() {
                     Event::PublishAcknowledged(Puback {
                         packet_identifier,
                         reason_code: _,
+                        reason_string: _,
                         user_properties: _,
                     }) if pid == packet_identifier => {}
                     _ => panic!("Should only receive a PUBACK"),
@@ -674,6 +683,7 @@ async fn outgoing_qos2_write_fail_retry() {
                         Ok(Event::PublishReceived(Puback {
                             packet_identifier,
                             reason_code: _,
+                            reason_string: _,
                             user_properties: _,
                         })) if pid == packet_identifier => {}
                         Ok(_) => panic!("Should only receive a PUBREC"),
@@ -688,6 +698,7 @@ async fn outgoing_qos2_write_fail_retry() {
                         Event::PublishComplete(Puback {
                             packet_identifier,
                             reason_code: _,
+                            reason_string: _,
                             user_properties: _,
                         }) if pid == packet_identifier => {}
                         _ => panic!("Should only receive a PUBCOMP"),
@@ -744,6 +755,7 @@ async fn outgoing_qos2_write_fail_retry() {
                         Event::PublishReceived(Puback {
                             packet_identifier,
                             reason_code: _,
+                            reason_string: _,
                             user_properties: _,
                         }) if pid == packet_identifier => {}
                         _ => panic!("Should only receive a PUBREC"),
@@ -754,6 +766,7 @@ async fn outgoing_qos2_write_fail_retry() {
                     Event::PublishComplete(Puback {
                         packet_identifier,
                         reason_code: _,
+                        reason_string: _,
                         user_properties: _,
                     }) if pid == packet_identifier => {}
                     _ => panic!("Should only receive a PUBCOMP"),
@@ -824,6 +837,7 @@ async fn outgoing_qos2_read_fail_retry() {
                         Ok(Event::PublishReceived(Puback {
                             packet_identifier,
                             reason_code: _,
+                            reason_string: _,
                             user_properties: _,
                         })) if pid == packet_identifier => {}
                         Ok(_) => panic!("Should only receive a PUBREC"),
@@ -837,6 +851,7 @@ async fn outgoing_qos2_read_fail_retry() {
                         Ok(Event::PublishComplete(Puback {
                             packet_identifier,
                             reason_code: _,
+                            reason_string: _,
                             user_properties: _,
                         })) if pid == packet_identifier => {}
                         Ok(_) => panic!("Should only receive a PUBCOMP"),
@@ -897,6 +912,7 @@ async fn outgoing_qos2_read_fail_retry() {
                         Event::PublishReceived(Puback {
                             packet_identifier,
                             reason_code: _,
+                            reason_string: _,
                             user_properties: _,
                         }) if pid == packet_identifier => {}
                         _ => panic!("Should only receive a PUBREC"),
@@ -907,6 +923,7 @@ async fn outgoing_qos2_read_fail_retry() {
                     Event::PublishComplete(Puback {
                         packet_identifier,
                         reason_code: _,
+                        reason_string: _,
                         user_properties: _,
                     }) if pid == packet_identifier => {}
                     _ => panic!("Should only receive a PUBCOMP"),
@@ -1006,6 +1023,7 @@ async fn incoming_qos1_write_fail_retry() {
                     match assert_ok!(rx.poll().await) {
                         Event::Suback(Suback {
                             packet_identifier,
+                            reason_string: _,
                             user_properties: _,
                             reason_code: _,
                         }) if pid == packet_identifier => {}
@@ -1116,6 +1134,7 @@ async fn incoming_qos1_read_fail_retry() {
                     match rx.poll().await {
                         Ok(Event::Suback(Suback {
                             packet_identifier,
+                            reason_string: _,
                             user_properties: _,
                             reason_code: _,
                         })) if pid == packet_identifier => {}
@@ -1232,6 +1251,7 @@ async fn incoming_qos2_write_fail_retry() {
                     match assert_ok!(rx.poll().await) {
                         Event::Suback(Suback {
                             packet_identifier,
+                            reason_string: _,
                             user_properties: _,
                             reason_code: _,
                         }) if pid == packet_identifier => {}
@@ -1259,6 +1279,7 @@ async fn incoming_qos2_write_fail_retry() {
                         Ok(Event::PublishReleased(Puback {
                             packet_identifier,
                             reason_code: _,
+                            reason_string: _,
                             user_properties: _,
                         })) if packet_identifier == pid => {}
                         Ok(Event::PublishReleased(_)) => panic!("Received non-matching PUBREL"),
@@ -1294,6 +1315,7 @@ async fn incoming_qos2_write_fail_retry() {
                             Event::PublishReleased(Puback {
                                 packet_identifier,
                                 reason_code: _,
+                                reason_string: _,
                                 user_properties: _,
                             }) if packet_identifier == pid => break,
                             Event::PublishReleased(_) => panic!("Received non-matching PUBREL"),
@@ -1369,6 +1391,7 @@ async fn incoming_qos2_read_fail_retry() {
                     match rx.poll().await {
                         Ok(Event::Suback(Suback {
                             packet_identifier,
+                            reason_string: _,
                             user_properties: _,
                             reason_code: _,
                         })) if pid == packet_identifier => {}
@@ -1400,6 +1423,7 @@ async fn incoming_qos2_read_fail_retry() {
                         Ok(Event::PublishReleased(Puback {
                             packet_identifier,
                             reason_code: _,
+                            reason_string: _,
                             user_properties: _,
                         })) if packet_identifier == pid => {}
                         Ok(Event::PublishReleased(_)) => panic!("Received non-matching PUBREL"),
@@ -1435,6 +1459,7 @@ async fn incoming_qos2_read_fail_retry() {
                         Event::PublishReleased(Puback {
                             packet_identifier,
                             reason_code: _,
+                            reason_string: _,
                             user_properties: _,
                         }) if packet_identifier == pid.unwrap() => break 'complete,
                         Event::PublishReleased(_) => panic!("Received non-matching PUBREL"),
@@ -1451,6 +1476,7 @@ async fn incoming_qos2_read_fail_retry() {
                         Event::PublishReleased(Puback {
                             packet_identifier,
                             reason_code: _,
+                            reason_string: _,
                             user_properties: _,
                         }) if packet_identifier == pid => break 'complete,
                         Event::PublishReleased(_) => panic!("Received non-matching PUBREL"),


### PR DESCRIPTION
Addresses #89, but does not resolve it completely as reason string is still not controllable in outgoing PUBACK, PUBREC, PUBREL and PUBCOMP packets.

Adds a validation which checks that response information is not received in CONNACK when request response information in CONNECT is false.