### PR TITLE
Prevent no local shared subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add reason string to outgoing DISCONNECT packets
 - Use `NonZero<u32>` for `SessionExpiryInterval::Seconds`
 - Allow any valid reason code to be sent in DISCONNECT packets
+- Prevent protocol error on shared subscription with no local set to true
 
 ## 0.5.1 - 2026-04-10
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to rust-mqtt
+
+`rust-mqtt` welcomes contribution from everyone in the form of suggestions, bug reports, pull requests, and feedback. This document gives some guidance if you are thinking of helping us or just want to run the examples.
+
+## Setting up a broker
+
+For our examples and integration test suite, a MQTT broker is required. For local development, Mosquitto is recommended over HiveMQ because it's simpler to set up.
+
+To configure and run a broker for plain TCP connections (`demo`, `manual_ack`, integration tests) run the following commands:
+
+```bash
+cp .ci/mqtt_pass_plain.txt .ci/mqtt_pass_hashed.txt
+chmod 700 .ci/mqtt_pass_hashed.txt
+mosquitto_passwd -U .ci/mqtt_pass_hashed.txt
+mosquitto -c .ci/mosquitto.conf -v
+```
+
+Set up the broker for `tls` by running Mosquitto with the TLS configuration file. The required PKI files have been generated using `.ci/pki/generate.sh` script.
+
+```bash
+mosquitto -c .ci/mosquitto-tls.conf -v
+```
+
+## Examples
+
+- 'demo' is a showcase of rust-mqtt's features over TCP. Note that the example usage is very strict and not really a good way of using the client.
+- 'tls' connects the client to a broker over TLS with client certificate authentication and server certificate verification using [embedded-tls](https://github.com/drogue-iot/embedded-tls).
+- 'manual_ack' shows the client's capabilities of manual acknowledgements by rudimentarily implementing the optional payload format check (see [MQTTv5, 3.3.2.3.2 Payload Format Indicator](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901111))
+
+Set up the broker for 'demo' and 'manual_ack' by installing, configuring and running Mosquitto using the CI configuration:
+
+```bash
+cp .ci/mqtt_pass_plain.txt .ci/mqtt_pass_hashed.txt
+chmod 700 .ci/mqtt_pass_hashed.txt
+mosquitto_passwd -U .ci/mqtt_pass_hashed.txt
+mosquitto -c .ci/mosquitto.conf -v
+```
+
+Set up the broker for 'tls' by running Mosquitto with the tls config file. The required PKI files have been generated using the `.ci/pki/generate.sh` script.
+
+```bash
+mosquitto -c .ci/mosquitto-tls.conf -v
+```
+
+Then you can run the examples with different logging configs and the bump/alloc features:
+
+```bash
+RUST_LOG=info cargo run --example demo
+RUST_LOG=info cargo run --example tls
+RUST_LOG=trace cargo run --example manual_ack --no-default-features --features "v5 log bump log-level-trace"
+```
+
+## Tests
+
+The CI pipeline run unit, integration and doc tests as well as linting and other checks thoroughly. However, you should still run these tests locally.
+
+### Unit
+
+Unit tests should be ran using both the `alloc` and `bump` features.
+
+```bash
+cargo test unit
+cargo test unit --no-default-features --features "v5 bump"
+```
+
+### Integration
+
+Set up the mosquitto broker as used in the CI pipeline (described above). You should restart the broker after every run of the integration test suite as it carries non-idempotent state that will impact the tests. Integration tests can only be run with the `alloc` feature for simplicity.
+
+```bash
+cargo test integration
+```
+
+Because the test suite is quite comprehensive, some test cases are ignored because they may fail with the currently used release of a broker. However, these cases also follow a naming convention to be able to run them despite being ignored by default. To run these tests on the relevant broker that does behave correctly, you can run the following commands.
+
+```bash
+cargo test mosquitto_only -- --ignored
+cargo test hive_only -- --ignored
+```
+
+### Debugging
+
+It can be helpful to see logging output when running tests. `rust-mqtt` supports detailed logging. At `log-level-trace`, the state machine logs all state transitions and at `log-verbose`, I/O traces when encoding and decoding the packets are also enabled.
+
+```bash
+RUST_LOG=trace cargo test unit --no-default-features --features "v5 bump log-verbose log" -- --show-output
+RUST_LOG=warn cargo test -- --show-output
+RUST_LOG=info cargo test integration --features "log" -- --show-output
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ RUST_LOG=trace cargo run --example manual_ack --no-default-features --features "
 
 ## Tests
 
-The CI pipeline run unit, integration and doc tests as well as linting and other checks thoroughly. However, you should still run these tests locally.
+The CI pipeline runs unit, integration and doc tests as well as linting and other checks thoroughly. However, you should still run these tests locally.
 
 ### Unit
 

--- a/README.md
+++ b/README.md
@@ -60,15 +60,17 @@ The design goal is a strict yet flexible and explicit API that leverages Rust's 
   - `log`: Enables logging via the `log` crate
   - `defmt`: Implements `defmt::Format` for crate items & enables logging via the `defmt` crate (version 1)
   - `log-level-*`: Enables logs at the selected level and more severe levels (error, warn, info, debug, trace). The trace log level also features detailed MQTT state machine logs.
-  - `log-verbose`: Enables high-overhead IO traces at the trace log level and enables `log-level-trace`
+  - `log-verbose`: Enables high-overhead I/O traces at the trace log level and enables `log-level-trace`
 
 ## Usage
 
 It is recommended to use a buffering `Write` implementation, as the current IO model makes fragmented `Write::write` calls. The client also calls `Read::read` frequently; if your underlying implementation involves expensive syscalls, consider using a buffering reader as well.
 
-### Illustrative API example
+### Quickstart
 
-Showing explicit session recovery and Quality of Service 2 retransmission after a network failure. The precise network and executor setup is omitted for brevity.
+The cargo examples in this repository require a broker with correct configuration. Refer to [the contributing guide](CONTRIBUTING.md) for further explanation and guidance.
+
+What follows is an illustrative API example showing explicit session recovery and Quality of Service 2 retransmission after a network failure. The precise network and executor setup is omitted for brevity.
 
 ```rust,ignore
 async fn main() {
@@ -143,75 +145,6 @@ async fn main() {
         Err(_) => panic!("Other error :("),
     }
 }
-```
-
-### Examples
-
-- 'demo' is a showcase of rust-mqtt's features over TCP. Note that the example usage is very strict and not really a good way of using the client.
-- 'tls' connects the client to a broker over TLS with client certificate authentication and server certificate verification using [embedded-tls](https://github.com/drogue-iot/embedded-tls).
-- 'manual_ack' shows the client's capabilities of manual acknowledgements by rudimentarily implementing the optional payload format check (see [MQTTv5, 3.3.2.3.2 Payload Format Indicator](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901111))
-
-Set up the broker for 'demo' and 'manual_ack' by installing, configuring and running Mosquitto using the CI configuration:
-
-```bash
-cp .ci/mqtt_pass_plain.txt .ci/mqtt_pass_hashed.txt
-chmod 700 .ci/mqtt_pass_hashed.txt
-mosquitto_passwd -U .ci/mqtt_pass_hashed.txt
-mosquitto -c .ci/mosquitto.conf -v
-```
-
-Set up the broker for 'tls' by running Mosquitto with the tls config file. The required PKI files have been generated using the `.ci/pki/generate.sh` script.
-
-```bash
-mosquitto -c .ci/mosquitto-tls.conf -v
-```
-
-Then you can run the examples with different logging configs and the bump/alloc features:
-
-```bash
-RUST_LOG=info cargo run --example demo
-RUST_LOG=info cargo run --example tls
-RUST_LOG=trace cargo run --example manual_ack --no-default-features --features "v5 log bump log-level-trace"
-```
-
-### Tests
-
-Unit tests should be ran using both the 'alloc' and 'bump' features.
-
-```bash
-cargo test unit
-cargo test unit --no-default-features --features "v5 bump"
-```
-
-For integration tests, you can set up the mosquitto broker as used in the CI pipeline.
-You should restart the broker after every run of the integration test suite as it
-carries non-idempotent state that will impact the tests.
-
-```bash
-cp .ci/mqtt_pass_plain.txt .ci/mqtt_pass_hashed.txt
-chmod 700 .ci/mqtt_pass_hashed.txt
-mosquitto_passwd -U .ci/mqtt_pass_hashed.txt
-mosquitto -c .ci/mosquitto.conf [-d]
-```
-
-Then you can run integration tests with the alloc feature.
-
-```bash
-cargo test integration
-```
-
-It can be helpful to see logging output when running tests.
-
-```bash
-RUST_LOG=trace cargo test unit --no-default-features --features "v5 bump log-verbose log" -- --show-output
-RUST_LOG=warn cargo test -- --show-output
-RUST_LOG=info cargo test integration --features "log" -- --show-output
-```
-
-The full test suite can run with the alloc feature, just make sure a fresh broker is up and running.
-
-```bash
-cargo test
 ```
 
 ## Acknowledgment

--- a/src/client/err.rs
+++ b/src/client/err.rs
@@ -223,6 +223,16 @@ pub enum Error<'e, const MAX_USER_PROPERTIES: usize> {
     /// Recoverable error. No action has been taken by the client.
     UnsupportedByServer,
 
+    /// A shared subscription with the no local flag set to [`true`] was attempted. This would cause a protocol
+    /// error.
+    ///
+    /// Recoverable error. No action has been taken by the client. Ensure that at max only one of
+    /// [`TopicFilter::is_shared`] and the `no_local` field in the [`SubscriptionOptions`] is [`true`].
+    ///
+    /// [`SubscriptionOptions`]: crate::client::options::SubscriptionOptions
+    /// [`TopicFilter::is_shared`]: crate::types::TopicFilter::is_shared
+    IllegalNoLocalSharedSubscription,
+
     /// A disconnect now with the given session expiry interval would cause a protocol error.
     ///
     /// A disconnection was attempted with a session expiry interval change where the session expiry interval in the
@@ -255,6 +265,7 @@ impl<const MAX_USER_PROPERTIES: usize> Error<'_, MAX_USER_PROPERTIES> {
                 | Self::SessionBuffer
                 | Self::SendQuotaExceeded
                 | Self::UnsupportedByServer
+                | Self::IllegalNoLocalSharedSubscription
                 | Self::IllegalDisconnectSessionExpiryInterval
         )
     }
@@ -295,6 +306,7 @@ impl<'e> Error<'e, 0> {
             Self::SessionBuffer => Error::SessionBuffer,
             Self::SendQuotaExceeded => Error::SendQuotaExceeded,
             Self::UnsupportedByServer => Error::UnsupportedByServer,
+            Self::IllegalNoLocalSharedSubscription => Error::IllegalNoLocalSharedSubscription,
             Self::IllegalDisconnectSessionExpiryInterval => {
                 Error::IllegalDisconnectSessionExpiryInterval
             }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     session::{Error as SmError, Event as SmEvent, LocalPublishState, Response, Session},
     types::{
         IdentifiedQoS, MqttBinary, MqttString, MqttStringPair, PacketIdentifier, QoS, ReasonCode,
-        SubscriptionFilter, TopicFilter, TopicName, VarByteInt,
+        NoLocalSharedSubscription, SubscriptionFilter, TopicFilter, TopicName, VarByteInt,
     },
     v5::{
         packet::{
@@ -731,6 +731,10 @@ impl<
             return Err(MqttError::UnsupportedByServer);
         }
 
+        let subscribe_filter = SubscriptionFilter::new(topic_filter, options)
+            .map_err(|NoLocalSharedSubscription| MqttError::IllegalNoLocalSharedSubscription)?;
+        let subscribe_filters = [subscribe_filter].into();
+
         let Some(handle) = self.session.free_handle() else {
             info!("no free packet identifier");
             return Err(MqttError::SessionBuffer);
@@ -742,9 +746,6 @@ impl<
             MqttError::SessionBuffer
         })?;
 
-        let subscribe_filter = SubscriptionFilter::new(topic_filter, options);
-
-        let subscribe_filters = [subscribe_filter].into();
         let packet = SubscribePacket::<1, MAX_USER_PROPERTIES>::new(
             pid,
             options.subscription_identifier.map(Into::into),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -20,8 +20,8 @@ use crate::{
     packet::{Packet, TxPacket},
     session::{Error as SmError, Event as SmEvent, LocalPublishState, Response, Session},
     types::{
-        IdentifiedQoS, MqttBinary, MqttString, MqttStringPair, PacketIdentifier, QoS, ReasonCode,
-        NoLocalSharedSubscription, SubscriptionFilter, TopicFilter, TopicName, VarByteInt,
+        IdentifiedQoS, MqttBinary, MqttString, MqttStringPair, NoLocalSharedSubscription,
+        PacketIdentifier, QoS, ReasonCode, SubscriptionFilter, TopicFilter, TopicName, VarByteInt,
     },
     v5::{
         packet::{

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -737,7 +737,7 @@ impl<
 
         let Some(handle) = self.session.free_handle() else {
             info!("no free packet identifier");
-            return Err(MqttError::SessionBuffer);
+            return Err(MqttError::AllPacketIdentifiersUsed);
         };
         let pid = handle.packet_identifier;
 
@@ -806,7 +806,7 @@ impl<
 
         let Some(handle) = self.session.free_handle() else {
             info!("no free packet identifier");
-            return Err(MqttError::SessionBuffer);
+            return Err(MqttError::AllPacketIdentifiersUsed);
         };
         let pid = handle.packet_identifier;
 

--- a/src/client/options/subscribe.rs
+++ b/src/client/options/subscribe.rs
@@ -17,7 +17,7 @@ pub struct Options<'s> {
     /// If set to true, the server does not forward any publications matching
     /// this subscription to connections with client identifiers the same as
     /// the client identifier of this connection.
-    /// If set to true on a shared subscription, a protocol error is triggered.
+    /// Can not be set to true for a shared subscription.
     pub no_local: bool,
 
     /// The maximum quality of service that the server is allowed to forward publications

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -9,7 +9,7 @@ mod string;
 mod topic;
 mod will;
 
-pub(crate) use topic::SubscriptionFilter;
+pub(crate) use topic::{NoLocalSharedSubscription, SubscriptionFilter};
 pub(crate) use will::Will;
 
 pub use binary::MqttBinary;

--- a/src/types/topic.rs
+++ b/src/types/topic.rs
@@ -305,6 +305,12 @@ pub struct SubscriptionFilter<'t> {
     subscription_options: u8,
 }
 
+/// The no local flag is set for a shared subscription, which is not allowed:
+///
+/// It is a Protocol Error to set the No Local bit to 1 on a Shared Subscription [MQTT-3.8.3-4].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NoLocalSharedSubscription;
+
 impl<const MAX_TOPIC_FILTERS: usize> Writable for Vec<SubscriptionFilter<'_>, MAX_TOPIC_FILTERS> {
     fn written_len(&self) -> usize {
         self.iter()
@@ -324,7 +330,14 @@ impl<const MAX_TOPIC_FILTERS: usize> Writable for Vec<SubscriptionFilter<'_>, MA
 }
 
 impl<'t> SubscriptionFilter<'t> {
-    pub const fn new(topic: TopicFilter<'t>, options: &SubscriptionOptions) -> Self {
+    pub fn new(
+        topic: TopicFilter<'t>,
+        options: &SubscriptionOptions,
+    ) -> Result<Self, NoLocalSharedSubscription> {
+        if options.no_local && topic.is_shared() {
+            return Err(NoLocalSharedSubscription);
+        }
+
         let retain_handling_bits = match options.retain_handling {
             RetainHandling::AlwaysSend => 0x00,
             RetainHandling::SendIfNotSubscribedBefore => 0x10,
@@ -346,10 +359,10 @@ impl<'t> SubscriptionFilter<'t> {
         let subscribe_options_bits =
             retain_handling_bits | retain_as_published_bit | no_local_bit | qos_bits;
 
-        Self {
+        Ok(Self {
             topic,
             subscription_options: subscribe_options_bits,
-        }
+        })
     }
 }
 

--- a/src/v5/packet/subscribe.rs
+++ b/src/v5/packet/subscribe.rs
@@ -152,14 +152,16 @@ mod unit {
             SubscriptionFilter::new(
                 TopicFilter::new(MqttString::try_from("test/hello").unwrap()).unwrap(),
                 &SubscriptionOptions::new().no_local(),
-            ),
+            )
+            .unwrap(),
             SubscriptionFilter::new(
                 TopicFilter::new(MqttString::try_from("asdfjklo/#").unwrap()).unwrap(),
                 &SubscriptionOptions::new()
                     .retain_handling(RetainHandling::NeverSend)
                     .retain_as_published()
                     .exactly_once(),
-            ),
+            )
+            .unwrap(),
         ];
         let packet: SubscribePacket<'_, 2, 0> = SubscribePacket::new(
             PacketIdentifier::new(NonZero::new(23197).unwrap()),
@@ -215,7 +217,8 @@ mod unit {
                 .retain_handling(RetainHandling::SendIfNotSubscribedBefore)
                 .retain_as_published()
                 .subscription_identifier(VarByteInt::from(23459u16)),
-        )];
+        )
+        .unwrap()];
 
         let user_properties = [
             UserProperty(MqttStringPair::new(


### PR DESCRIPTION
- Adds a check to prevent the client making a shared subscription when the `no_local` field in the `SubscriptionOptions` is set to true
- Splits CONTRIBUTING.md off of README.md for a tighter Github and crates.io/docs.rs appearance