### PR TITLE
Return network handle on disconnect/abort

### DIFF
--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -14,6 +14,9 @@ jobs:
       - name: Install toolchain
         run: rustup show
 
+      - name: Rust Cache
+        uses: swatinem/rust-cache@v2
+
       - name: Run clippy with alloc & log features
         run: cargo clippy --all-targets --features "log"
 

--- a/.github/workflows/doc_tests.yaml
+++ b/.github/workflows/doc_tests.yaml
@@ -11,5 +11,8 @@ jobs:
       - name: Install toolchain
         run: rustup show
 
+      - name: Rust Cache
+        uses: swatinem/rust-cache@v2
+
       - name: Run doc tests with alloc feature
         run: RUST_LOG=trace cargo test --doc --features "log" -- --show-output

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -11,6 +11,9 @@ jobs:
       - name: Install toolchain
         run: rustup show
 
+      - name: Rust Cache
+        uses: swatinem/rust-cache@v2
+
       - name: Install Mosquitto
         run: |
           sudo apt-get update
@@ -48,6 +51,9 @@ jobs:
 
       - name: Install toolchain
         run: rustup show
+
+      - name: Rust Cache
+        uses: swatinem/rust-cache@v2
 
       - name: Start HiveMQ
         run: |

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -66,28 +66,36 @@ jobs:
       - name: Rust Cache
         uses: swatinem/rust-cache@v2
 
-      - name: Start HiveMQ
+      - name: Prepare HiveMQ Configuration
         run: |
-          curl -LO https://github.com/hivemq/hivemq-community-edition/releases/download/2025.5/hivemq-ce-2025.5.zip
-          unzip hivemq-ce-2025.5.zip
           curl -LO https://github.com/hivemq/hivemq-file-rbac-extension/releases/download/4.6.8/hivemq-file-rbac-extension-4.6.8.zip
           unzip hivemq-file-rbac-extension-4.6.8.zip
-          mv hivemq-file-rbac-extension hivemq-ce-2025.5/extensions
-          cp .ci/hive_config.xml hivemq-ce-2025.5/conf/config.xml
-          cp .ci/hive_cred.xml hivemq-ce-2025.5/extensions/hivemq-file-rbac-extension/credentials.xml
-          cp .ci/hive_extension_config.xml hivemq-ce-2025.5/extensions/hivemq-file-rbac-extension/conf/config.xml
-          hivemq-ce-2025.5/bin/run.sh &
-          sleep 3
+          cp .ci/hive_cred.xml hivemq-file-rbac-extension/conf/credentials.xml
+          cp .ci/hive_extension_config.xml hivemq-file-rbac-extension/conf/config.xml
+
+      - name: Start HiveMQ
+        run: |
+          docker run -d \
+            --name hivemq \
+            -p 1883:1883 \
+            -v $PWD/.ci/hive_config.xml:/opt/hivemq/conf/config.xml \
+            -v $PWD/hivemq-file-rbac-extension:/opt/hivemq/extensions/hivemq-file-rbac-extension \
+            hivemq/hivemq-ce:2026.5
+          timeout 30s sh -c 'until docker logs hivemq 2>&1 | grep "Started HiveMQ in"; do sleep 0.1; done'
 
       - name: Run integration tests
         run: RUST_LOG=trace cargo test integration --features "log" -- --show-output
 
       - name: Restart HiveMQ
         run: |
-          pkill -f hivemq-ce || true
-          sleep 5
-          hivemq-ce-2025.5/bin/run.sh &
-          sleep 3
+          docker rm -f hivemq
+          docker run -d \
+            --name hivemq \
+            -p 1883:1883 \
+            -v $PWD/.ci/hive_config.xml:/opt/hivemq/conf/config.xml \
+            -v $PWD/hivemq-file-rbac-extension:/opt/hivemq/extensions/hivemq-file-rbac-extension \
+            hivemq/hivemq-ce:2026.5
+          timeout 30s sh -c 'until docker logs hivemq 2>&1 | grep "Started HiveMQ in"; do sleep 0.1; done'
 
       - name: Run hive-only integration tests
         run: RUST_LOG=trace cargo test hive_only --features "log" -- --show-output --ignored

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -14,31 +14,42 @@ jobs:
       - name: Rust Cache
         uses: swatinem/rust-cache@v2
 
-      - name: Install Mosquitto
-        run: |
-          sudo apt-get update
-          sudo add-apt-repository -y ppa:mosquitto-dev/mosquitto-ppa
-          sudo apt-get update
-          sudo apt install -y mosquitto
-          sudo service mosquitto stop
-
-      - name: Configure & Start Mosquitto
+      - name: Prepare Mosquitto Configuration
         run: |
           cp .ci/mqtt_pass_plain.txt .ci/mqtt_pass_hashed.txt
-          chmod 700 .ci/mqtt_pass_hashed.txt
-          mosquitto_passwd -U .ci/mqtt_pass_hashed.txt
-          mosquitto -c .ci/mosquitto.conf -d
-          sleep 1
+          sudo chown root:root .ci/mqtt_pass_hashed.txt
+          sudo chmod 600 .ci/mqtt_pass_hashed.txt
+
+          docker run --rm \
+            -v $PWD/.ci:/.ci \
+            eclipse-mosquitto:2.1.2-alpine \
+            mosquitto_passwd -U .ci/mqtt_pass_hashed.txt
+
+          sudo chown 1883:1883 .ci/mqtt_pass_hashed.txt
+
+      - name: Start Mosquitto
+        run: |
+          docker run -d \
+            --name mosquitto \
+            -p 1883:1883 \
+            -v $PWD/.ci:/.ci \
+            -v $PWD/.ci/mosquitto.conf:/mosquitto/config/mosquitto.conf \
+            eclipse-mosquitto:2.1.2-alpine
+          timeout 10s sh -c 'until docker logs mosquitto 2>&1 | grep "mosquitto version 2.1.2 running"; do sleep 0.1; done'
 
       - name: Run integration tests
         run: RUST_LOG=trace cargo test integration --features "log" -- --show-output
 
       - name: Restart Mosquitto
         run: |
-          pkill mosquitto || true
-          sleep 1
-          mosquitto -c .ci/mosquitto.conf -d
-          sleep 1
+          docker rm -f mosquitto
+          docker run -d \
+            --name mosquitto \
+            -p 1883:1883 \
+            -v $PWD/.ci:/.ci \
+            -v $PWD/.ci/mosquitto.conf:/mosquitto/config/mosquitto.conf \
+            eclipse-mosquitto:2.1.2-alpine
+          timeout 10s sh -c 'until docker logs mosquitto 2>&1 | grep "mosquitto version 2.1.2 running"; do sleep 0.1; done'
 
       - name: Run mosquitto-only integration tests
         run: RUST_LOG=trace cargo test mosquitto_only --features "log" -- --show-output --ignored

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -11,6 +11,9 @@ jobs:
       - name: Install toolchain
         run: rustup show
 
+      - name: Rust Cache
+        uses: swatinem/rust-cache@v2
+
       - name: Run unit tests with alloc feature
         run: RUST_LOG=trace cargo test unit --features "log" -- --show-output
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `NonZero<u32>` for `SessionExpiryInterval::Seconds`
 - Allow any valid reason code to be sent in DISCONNECT packets
 - Prevent protocol error on shared subscription with no local set to true
+- Disallow calls to `Client::abort` when the client is disconnected and has no available network connection
+- Return the `Transport` network handle after a successful disconnection / abortion
 
 ## 0.5.1 - 2026-04-10
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ async fn main() {
     }
 
     // An error has occured (e.g. network failure)
-    client.abort().await;
+    client.abort().await.unwrap();
 
     let transport = ...;    // Open a fresh connection
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -337,10 +337,16 @@ async fn main() {
     }
 
     match client.disconnect(&DisconnectOptions::new()).await {
-        Ok(()) => info!("Disconnected from server"),
+        Ok(_n) => {
+            // For a correct TCP disconnection, one should make sure the underlying TCP socket
+            // sends a FIN segment. However I could not get the tokio::TcpStream to behave that
+            // way, so we just do nothing here. It's fine for MQTT operability realistically,
+            // but for clean usage, the TCP should be closed properly.
+
+            info!("Disconnected from server")
+        }
         Err(e) => {
             error!("Failed to disconnect from server: {e:?}");
-            return;
         }
     }
 }

--- a/examples/manual_ack.rs
+++ b/examples/manual_ack.rs
@@ -216,5 +216,10 @@ async fn main() {
         };
     }
 
-    client.disconnect(&DisconnectOptions::new()).await.unwrap();
+    // For a correct TCP disconnection, one should make sure the underlying TCP socket
+    // sends a FIN segment. However I could not get the tokio::TcpStream to behave that
+    // way, so we just do nothing here. It's fine for MQTT operability realistically,
+    // but for clean usage, the TCP should be closed properly.
+
+    let _n = client.disconnect(&DisconnectOptions::new()).await.unwrap();
 }

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -1,5 +1,6 @@
 use std::{
     net::{Ipv4Addr, SocketAddr},
+    panic,
     time::{Duration, SystemTime},
 };
 
@@ -107,5 +108,8 @@ async fn main() {
 
     sleep(Duration::from_secs(5)).await;
 
-    client.disconnect(&DisconnectOptions::new()).await.unwrap();
+    let tls = client.disconnect(&DisconnectOptions::new()).await.unwrap();
+    let Ok(_) = tls.close().await else {
+        panic!();
+    };
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1712,9 +1712,10 @@ impl<
         self.raw.send(&packet).await?;
         self.raw.flush().await?;
 
+        self.raw.prepare_close();
+
         info!("disconnected from server");
 
-        self.raw.prepare_close();
         Ok(self.raw.abort().await.unwrap())
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -361,27 +361,31 @@ impl<
         self.raw.buffer_mut()
     }
 
-    /// Connect the client to an MQTT server on the other end of the `net` argument.
-    /// Sends a CONNECT message and awaits the CONNACK response by the server.
+    /// Establishes a connection to an MQTT server over the provided [`Transport`].
     ///
-    /// Only call this when
-    /// - the client is newly constructed.
-    /// - a non-recoverable error has occured and [`Self::abort`] has been called.
-    /// - [`Self::disconnect`] has been called.
+    /// Sends a CONNECT packet  and awaits the CONNACK response by the server. It initializes
+    /// the internal state of the client, including session information and negotiated server
+    /// capabilities.
     ///
-    /// The session expiry interval in [`ConnectOptions`] overrides the one in the session of the client.
+    /// This function must only be called if:
+    /// - The client is newly constructed and has not yet been connected.
+    /// - A previous connection was closed gracefully via [`Self::disconnect`].
+    /// - An unrecoverable error occurred and the error handling was performed with [`Self::abort`].
     ///
     /// Configuration that was negotiated with the server is stored in the `client_config`,
     /// `server_config`, `shared_config`, and `session` fields, which have getters
     /// ([`Self::client_config`], [`Self::server_config`], [`Self::shared_config`],
     /// [`Self::session`]).
     ///
-    /// If the server does not have a session present, the client's session is cleared. In case you would want
-    /// to keep the session state, you can call [`Self::session`] and clone the session before.
+    /// If the server indicates that no session is present (Session Present flag is 0), the
+    /// client's local session state is cleared. To persist state across connections,
+    /// call [`Self::session`] to clone the state before calling this method.
     ///
-    /// # Returns:
-    /// Information about the session/connection that the client does currently not use and therefore  not store
-    /// in its configuration fields.
+    /// # Returns
+    ///
+    /// - [`Ok(Connected)`]: Contains information from the CONNACK packet that is not persisted
+    ///   in the client's internal configuration fields.
+    /// - [`Err(MqttError)`]: If the connection attempt failed.
     ///
     /// # Errors
     ///
@@ -399,8 +403,12 @@ impl<
     /// # Panics
     ///
     /// This function panics if the length of the `user_properties` slice in the [`ConnectOptions`]
-    /// or the length of the `user_properties` slice in the will in [`ConnectOptions`] is greater
-    /// than `MAX_USER_PROPERTIES`.
+    /// or the length of the `user_properties` slice in the [`WillOptions`] in [`ConnectOptions`]
+    /// is greater than `MAX_USER_PROPERTIES`.
+    ///
+    /// [`Ok(Connected)`]: crate::client::event::Connected
+    /// [`Err(MqttError)`]: crate::client::MqttError
+    /// [`WillOptions`]: crate::client::options::WillOptions
     pub async fn connect<'d>(
         &mut self,
         net: N,
@@ -1541,17 +1549,40 @@ impl<
         Ok(())
     }
 
-    /// Disconnects from the server after an error occured in a situation-aware way by either:
-    /// - dropping the connection
-    /// - sending a DISCONNECT with the deposited reason code and dropping the connection.
+    /// Completes the disconnection from the server after an unrecoverable error in a
+    /// situation-aware way.
     ///
-    /// After an MQTT communication fails, usually either the client or the server closes the connection.
+    /// If the server caused the error, it sends a DISCONNECT with the deposited reason code.
+    /// Otherwise, it performs no network operations.
     ///
-    /// This is not cancel-safe but you can set a timeout if reconnecting later anyway or you don't reuse the client.
+    /// This function must only be called once after an unrecoverable error occurred and
+    /// only if [`Client::connect`] was called previously. If called on a healthy connection,
+    /// or if [`Client::connect`] was never called, it does nothing and the network
+    /// connection remains as is.
+    ///
+    /// # Returns
+    ///
+    /// - [`Ok(T)`]: The underlying network connection from the previous [`Client::connect`].
+    ///   The returned network should be used to close network connection.
+    /// - [`Err(AbortError::Connected`]: If the call was incorrect because the MQTT protocol
+    ///   connection and the transport connection is healthy. In debug builds, this will panic
+    ///   instead.
+    /// - [`Err(AbortError::Terminated)`]: If the call was incorrect because the client holds
+    ///   no underlying disconnection. In debug builds, this will panic instead.
+    ///
+    /// # Cancel Safety
+    ///
+    /// This future is not cancel-safe. If cancelled, it cannot be called again to retrieve
+    /// the network connection. However, the client logic for disconnection/abortion is
+    /// still completed, allowing for a subsequent [`Client::connect`].
     ///
     /// # Panics
     ///
-    /// This function may panic if the client has not returned an unrecoverable error before.
+    /// This function may panic if the client has not returned an unrecoverable error, or if called
+    /// twice without a [`Client::connect`] in-between.
+    ///
+    /// [`Err(AbortError::Connected)`]: crate::client::AbortError::Connected
+    /// [`Err(AbortError::Terminated)`]: crate::client::AbortError::Terminated
     #[inline]
     pub async fn abort(&mut self) -> Result<N, AbortError> {
         self.raw
@@ -1571,6 +1602,13 @@ impl<
     /// [`ReasonCode::PayloadFormatInvalid`]
     /// (Compare [Disconnect Reason Code](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901208), \[MQTT-3.14.2-1\]).
     ///
+    /// # Returns
+    ///
+    /// - [`Ok(N)`]: The underlying network connection from the previous [`Client::connect`]. The client is
+    ///   terminated; a subsequent call to [`Client::abort`] is incorrect.
+    /// - [`Err(MqttError)`]: If the disconnection failed. If the error is unrecoverable, a call to [`Client::abort`]
+    ///   is required to retrieve the network connection.
+    ///
     /// # Errors
     ///
     /// * [`MqttError::RecoveryRequired`] if an unrecoverable error occured previously
@@ -1586,6 +1624,8 @@ impl<
     ///
     /// This function panics if the length of the `user_properties` slice in the [`DisconnectOptions`]
     /// is greater than `MAX_USER_PROPERTIES`.
+    ///
+    /// [`Err(MqttError)`]: crate::client::MqttError
     pub async fn disconnect(
         &mut self,
         options: &DisconnectOptions<'_>,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -40,6 +40,7 @@ pub mod options;
 pub mod raw;
 
 pub use err::Error as MqttError;
+pub use raw::AbortError;
 
 /// An MQTT client.
 ///
@@ -519,12 +520,12 @@ impl<
             Ok(t) => {
                 error!("received unexpected {:?} packet header", t);
 
-                self.raw.close_with(Some(ReasonCode::ProtocolError));
+                self.raw.prepare_disconnect(ReasonCode::ProtocolError);
                 return Err(MqttError::Server);
             }
             Err(_) => {
                 error!("received invalid header {:?}", header);
-                self.raw.close_with(Some(ReasonCode::MalformedPacket));
+                self.raw.prepare_disconnect(ReasonCode::MalformedPacket);
                 return Err(MqttError::Server);
             }
         }
@@ -551,7 +552,7 @@ impl<
 
         if !options.request_response_information && response_information.is_some() {
             error!("server sent response information when request response information was false");
-            self.raw.close_with(Some(ReasonCode::ProtocolError));
+            self.raw.prepare_disconnect(ReasonCode::ProtocolError);
             return Err(MqttError::Server);
         }
 
@@ -563,14 +564,14 @@ impl<
                 .or(client_identifier)
                 .ok_or_else(|| {
                     error!("server did not assign a client identifier when it was required.");
-                    self.raw.close_with(Some(ReasonCode::ProtocolError));
+                    self.raw.prepare_disconnect(ReasonCode::ProtocolError);
                     MqttError::Server
                 })?;
 
             if session_present {
                 if options.clean_start {
                     error!("server set the session present flag when clean start was set");
-                    self.raw.close_with(Some(ReasonCode::ProtocolError));
+                    self.raw.prepare_disconnect(ReasonCode::ProtocolError);
                     return Err(MqttError::Server);
                 } else {
                     info!("connected to server and reconnected to session");
@@ -632,7 +633,7 @@ impl<
             debug!("CONNACK packet indicates rejection");
             info!("connection rejected by server (reason: {:?})", reason_code);
 
-            self.raw.close_with(None);
+            self.raw.prepare_close();
 
             info!("disconnected from server");
 
@@ -1552,11 +1553,12 @@ impl<
     ///
     /// This function may panic if the client has not returned an unrecoverable error before.
     #[inline]
-    pub async fn abort(&mut self) {
-        match self.raw.abort().await {
-            Ok(()) => info!("connection aborted"),
-            Err(e) => warn!("connection abort failed: {:?}", e),
-        }
+    pub async fn abort(&mut self) -> Result<N, AbortError> {
+        self.raw
+            .abort()
+            .await
+            .inspect(|_| info!("connection aborted"))
+            .inspect_err(|e| warn!("connection abort failed due to invalid state: {:?}", e))
     }
 
     /// Disconnects gracefully from the server by sending a DISCONNECT packet.
@@ -1587,7 +1589,7 @@ impl<
     pub async fn disconnect(
         &mut self,
         options: &DisconnectOptions<'_>,
-    ) -> Result<(), MqttError<'c, 0>> {
+    ) -> Result<N, MqttError<'c, 0>> {
         assert!(
             options.user_properties.len() <= MAX_USER_PROPERTIES,
             "attempted to send DISCONNECT with {} > {} (MAX_USER_PROPERTIES) properties",
@@ -1668,12 +1670,10 @@ impl<
         self.raw.send(&packet).await?;
         self.raw.flush().await?;
 
-        // Terminates (closes) the connection by dropping it
-        self.raw.close_with(None);
-
         info!("disconnected from server");
 
-        Ok(())
+        self.raw.prepare_close();
+        Ok(self.raw.abort().await.unwrap())
     }
 
     /// Combines [`Self::poll_header`] and [`Self::poll_body`].
@@ -1730,7 +1730,7 @@ impl<
             );
         } else {
             error!("received invalid header {:?}", header);
-            self.raw.close_with(Some(ReasonCode::MalformedPacket));
+            self.raw.prepare_disconnect(ReasonCode::MalformedPacket);
             return Err(MqttError::Server);
         }
 
@@ -1739,7 +1739,7 @@ impl<
                 "received a packet exceeding maximum packet size, remaining length={:?}",
                 header.remaining_len.value()
             );
-            self.raw.close_with(Some(ReasonCode::PacketTooLarge));
+            self.raw.prepare_disconnect(ReasonCode::PacketTooLarge);
             return Err(MqttError::Server);
         }
 
@@ -1799,7 +1799,7 @@ impl<
                     error!(
                         "server sent reason string or user properties when request problem information was false"
                     );
-                    self.raw.close_with(Some(ReasonCode::ProtocolError));
+                    self.raw.prepare_disconnect(ReasonCode::ProtocolError);
                     return Err(MqttError::Server);
                 }
 
@@ -1811,7 +1811,7 @@ impl<
                     // We only send SUBSCRIBE packets with exactly 1 topic
                     let [r] = suback.reason_codes.as_slice() else {
                         error!("received mismatched SUBACK");
-                        self.raw.close_with(Some(ReasonCode::ProtocolError));
+                        self.raw.prepare_disconnect(ReasonCode::ProtocolError);
                         return Err(MqttError::Server);
                     };
 
@@ -1845,7 +1845,7 @@ impl<
                     error!(
                         "server sent reason string or user properties when request problem information was false"
                     );
-                    self.raw.close_with(Some(ReasonCode::ProtocolError));
+                    self.raw.prepare_disconnect(ReasonCode::ProtocolError);
                     return Err(MqttError::Server);
                 }
 
@@ -1857,7 +1857,7 @@ impl<
                     // We only send UNSUBSCRIBE packets with exactly 1 topic
                     let [r] = unsuback.reason_codes.as_slice() else {
                         error!("received mismatched UNSUBACK");
-                        self.raw.close_with(Some(ReasonCode::ProtocolError));
+                        self.raw.prepare_disconnect(ReasonCode::ProtocolError);
                         return Err(MqttError::Server);
                     };
 
@@ -1887,7 +1887,7 @@ impl<
                 // Our topic alias maximum is always 0, the moment we receive a topic alias, this is an error.
                 let TopicReference::Name(topic) = publish.topic else {
                     error!("received disallowed topic alias");
-                    self.raw.close_with(Some(ReasonCode::TopicAliasInvalid));
+                    self.raw.prepare_disconnect(ReasonCode::TopicAliasInvalid);
                     return Err(MqttError::Server);
                 };
 
@@ -1966,7 +1966,7 @@ impl<
                     }
                     Response::Disconnect(reason_code) => {
                         error!("invalid PUBLISH packet rejected by state machine");
-                        self.raw.close_with(Some(reason_code));
+                        self.raw.prepare_disconnect(reason_code);
                     }
                 }
 
@@ -2002,7 +2002,7 @@ impl<
                     error!(
                         "server sent reason string or user properties when request problem information was false"
                     );
-                    self.raw.close_with(Some(ReasonCode::ProtocolError));
+                    self.raw.prepare_disconnect(ReasonCode::ProtocolError);
                     return Err(MqttError::Server);
                 }
 
@@ -2019,7 +2019,7 @@ impl<
                     Response::None => {}
                     Response::Disconnect(reason_code) => {
                         error!("invalid PUBACK packet rejected by state machine");
-                        self.raw.close_with(Some(reason_code));
+                        self.raw.prepare_disconnect(reason_code);
                     }
                 }
 
@@ -2051,7 +2051,7 @@ impl<
                     error!(
                         "server sent reason string or user properties when request problem information was false"
                     );
-                    self.raw.close_with(Some(ReasonCode::ProtocolError));
+                    self.raw.prepare_disconnect(ReasonCode::ProtocolError);
                     return Err(MqttError::Server);
                 }
 
@@ -2079,7 +2079,7 @@ impl<
                     }
                     Response::Disconnect(reason_code) => {
                         error!("invalid PUBREC packet rejected by state machine");
-                        self.raw.close_with(Some(reason_code));
+                        self.raw.prepare_disconnect(reason_code);
                     }
                 }
 
@@ -2109,7 +2109,7 @@ impl<
                     error!(
                         "server sent reason string or user properties when request problem information was false"
                     );
-                    self.raw.close_with(Some(ReasonCode::ProtocolError));
+                    self.raw.prepare_disconnect(ReasonCode::ProtocolError);
                     return Err(MqttError::Server);
                 }
 
@@ -2137,7 +2137,7 @@ impl<
                     }
                     Response::Disconnect(reason_code) => {
                         error!("invalid PUBREL packet rejected by state machine");
-                        self.raw.close_with(Some(reason_code));
+                        self.raw.prepare_disconnect(reason_code);
                     }
                 }
 
@@ -2167,7 +2167,7 @@ impl<
                     error!(
                         "server sent reason string or user properties when request problem information was false"
                     );
-                    self.raw.close_with(Some(ReasonCode::ProtocolError));
+                    self.raw.prepare_disconnect(ReasonCode::ProtocolError);
                     return Err(MqttError::Server);
                 }
 
@@ -2184,7 +2184,7 @@ impl<
                     Response::None => {}
                     Response::Disconnect(reason_code) => {
                         error!("invalid PUBCOMP packet rejected by state machine");
-                        self.raw.close_with(Some(reason_code));
+                        self.raw.prepare_disconnect(reason_code);
                     }
                 }
 
@@ -2212,7 +2212,7 @@ impl<
 
                 // The server initiated the disconnect. We must close the transport on our side
                 // as well so that subsequent error handling (e.g. `abort`) sees a non-Ok network state.
-                self.raw.close_with(None);
+                self.raw.prepare_close();
 
                 return Err(MqttError::Disconnect {
                     reason: disconnect.reason_code,
@@ -2234,13 +2234,13 @@ impl<
                     t
                 );
 
-                self.raw.close_with(Some(ReasonCode::ProtocolError));
+                self.raw.prepare_disconnect(ReasonCode::ProtocolError);
                 return Err(MqttError::Server);
             }
             PacketType::Connack => {
                 error!("received unexpected CONNACK packet");
 
-                self.raw.close_with(Some(ReasonCode::ProtocolError));
+                self.raw.prepare_disconnect(ReasonCode::ProtocolError);
                 return Err(MqttError::Server);
             }
             PacketType::Auth => {
@@ -2249,7 +2249,7 @@ impl<
                 // Receiving a AUTH packet is currently always a protocol error because we never send
                 // an Authentication Method property in the CONNECT packet.
                 // <https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901217>
-                self.raw.close_with(Some(ReasonCode::ProtocolError));
+                self.raw.prepare_disconnect(ReasonCode::ProtocolError);
                 return Err(MqttError::AuthPacketReceived);
             }
         };

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -51,7 +51,8 @@ pub use raw::AbortError;
 /// - `RECEIVE_MAXIMUM`: MQTT's control flow mechanism. The maximum amount of incoming [`QoS::AtLeastOnce`] and
 ///   [`QoS::ExactlyOnce`] publications (accumulated). Must not be 0 and must not be greater than 65535.
 /// - `SEND_MAXIMUM`: The maximum amount of outgoing [`QoS::AtLeastOnce`] and [`QoS::ExactlyOnce`] publications. The server
-///   can further limit this with its receive maximum. The client will use the minimum of this value and [`Self::server_config`].
+///   can further limit this with its receive maximum. The client will use the minimum of this value and the value in
+///   [`Client::server_config`].
 /// - `MAX_SUBSCRIPTION_IDENTIFIERS`: The maximum amount of subscription identifier properties the client can receive within a
 ///   single PUBLISH packet. If a packet with more subscription identifiers is received, the later identifers will be discarded.
 /// - `MAX_USER_PROPERTIES`: The maximum amount of user properties that the client can send and receive in one packet.
@@ -258,8 +259,9 @@ impl<
     /// Creates a new, disconnected MQTT client using a buffer provider to store
     /// dynamically sized fields of received packets.
     /// The session state is initialised as a new session. If you want to start the
-    /// client with an existing session, use [`Self::with_session`].
-    /// All publications and acknowledgements will be acknowledged automatically.
+    /// client with an existing session, use [`Client::with_session`].
+    /// All publications and acknowledgements will be acknowledged automatically by
+    /// default.
     pub fn new(buffer: &'c mut B) -> Self {
         const {
             const_assert!(
@@ -363,23 +365,24 @@ impl<
 
     /// Establishes a connection to an MQTT server over the provided [`Transport`].
     ///
-    /// Sends a CONNECT packet  and awaits the CONNACK response by the server. It initializes
+    /// Sends a CONNECT packet and awaits the CONNACK response by the server. It initializes
     /// the internal state of the client, including session information and negotiated server
     /// capabilities.
     ///
     /// This function must only be called if:
     /// - The client is newly constructed and has not yet been connected.
-    /// - A previous connection was closed gracefully via [`Self::disconnect`].
-    /// - An unrecoverable error occurred and the error handling was performed with [`Self::abort`].
+    /// - A previous connection was closed gracefully via [`Client::disconnect`].
+    /// - An unrecoverable error occurred and the error handling was performed with
+    ///   [`Client::abort`].
     ///
     /// Configuration that was negotiated with the server is stored in the `client_config`,
     /// `server_config`, `shared_config`, and `session` fields, which have getters
-    /// ([`Self::client_config`], [`Self::server_config`], [`Self::shared_config`],
-    /// [`Self::session`]).
+    /// ([`Client::client_config`], [`Client::server_config`], [`Client::shared_config`],
+    /// [`Client::session`]).
     ///
     /// If the server indicates that no session is present (Session Present flag is 0), the
     /// client's local session state is cleared. To persist state across connections,
-    /// call [`Self::session`] to clone the state before calling this method.
+    /// call [`Client::session`] to clone the state before calling this method.
     ///
     /// # Returns
     ///
@@ -1719,7 +1722,7 @@ impl<
         Ok(self.raw.abort().await.unwrap())
     }
 
-    /// Combines [`Self::poll_header`] and [`Self::poll_body`].
+    /// Combines [`Client::poll_header`] and [`Client::poll_body`].
     ///
     /// Polls the network for a full packet. Not cancel-safe.
     ///
@@ -1753,7 +1756,7 @@ impl<
     /// - The client did not return a non-recoverable Error before
     ///
     /// # Returns:
-    /// The received fixed header with a valid packet type. It can be used to call [`Self::poll_body`].
+    /// The received fixed header with a valid packet type. It can be used to call [`Client::poll_body`].
     ///
     /// # Errors
     ///

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1562,9 +1562,9 @@ impl<
     ///
     /// # Returns
     ///
-    /// - [`Ok(T)`]: The underlying network connection from the previous [`Client::connect`].
+    /// - [`Ok(N)`]: The underlying network connection from the previous [`Client::connect`].
     ///   The returned network should be used to close network connection.
-    /// - [`Err(AbortError::Connected`]: If the call was incorrect because the MQTT protocol
+    /// - [`Err(AbortError::Connected)`]: If the call was incorrect because the MQTT protocol
     ///   connection and the transport connection is healthy. In debug builds, this will panic
     ///   instead.
     /// - [`Err(AbortError::Terminated)`]: If the call was incorrect because the client holds
@@ -1581,6 +1581,7 @@ impl<
     /// This function may panic if the client has not returned an unrecoverable error, or if called
     /// twice without a [`Client::connect`] in-between.
     ///
+    /// [`Ok(N)`]: crate::io::Transport
     /// [`Err(AbortError::Connected)`]: crate::client::AbortError::Connected
     /// [`Err(AbortError::Terminated)`]: crate::client::AbortError::Terminated
     #[inline]
@@ -1625,6 +1626,7 @@ impl<
     /// This function panics if the length of the `user_properties` slice in the [`DisconnectOptions`]
     /// is greater than `MAX_USER_PROPERTIES`.
     ///
+    /// [`Ok(N)`]: crate::io::Transport
     /// [`Err(MqttError)`]: crate::client::MqttError
     pub async fn disconnect(
         &mut self,

--- a/src/client/raw/err.rs
+++ b/src/client/raw/err.rs
@@ -53,3 +53,30 @@ impl<B> From<NetStateError> for Error<B> {
         Self::Disconnected
     }
 }
+
+/// The reason why a call to [`Client::abort`] was incorrect.
+///
+/// [`Client::abort`]: crate::client::Client::abort
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum AbortError {
+    /// Both the transport and MQTT protocol connections are healthy.
+    ///
+    /// [`Client::abort`] must only be called after an unrecoverable error.
+    /// Use [`Client::disconnect`] for a graceful disconnection.
+    ///
+    /// [`Client::abort`]: crate::client::Client::abort
+    /// [`Client::disconnect`]: crate::client::Client::disconnect
+    Connected,
+
+    /// No network connection is available to the client.
+    ///
+    /// This occurs if [`Client::connect`] was never called, or if the
+    /// connection´was already finalized by a previous call to
+    /// [`Client::abort`] or [`Client::disconnect`].
+    ///
+    /// [`Client::abort`]: crate::client::Client::abort
+    /// [`Client::connect`]: crate::client::Client::connect
+    /// [`Client::disconnect`]: crate::client::Client::disconnect
+    Terminated,
+}

--- a/src/client/raw/mod.rs
+++ b/src/client/raw/mod.rs
@@ -69,7 +69,10 @@ impl<'b, N: Transport, B: BufferProvider<'b>> Raw<'b, N, B> {
     }
 
     pub fn prepare_disconnect(&mut self, reason_code: ReasonCode) {
-        debug_assert!(self.n.is_ok());
+        debug_assert!(
+            self.n.is_ok(),
+            "connection must be in a healthy state to transition into failed state."
+        );
 
         self.n.fail(reason_code);
     }
@@ -88,7 +91,7 @@ impl<'b, N: Transport, B: BufferProvider<'b>> Raw<'b, N, B> {
     /// This expects the network to be in neither `Ok(N)` nor `Terminated` state
     pub async fn abort(&mut self) -> Result<N, AbortError> {
         debug_assert!(
-            !self.n.is_terminated(),
+            !self.n.is_terminated() && !self.n.is_ok(),
             "network must be in DueDisconnect(N, ReasonCode) or Inactive(N) state to disconnect due to an error."
         );
 

--- a/src/client/raw/mod.rs
+++ b/src/client/raw/mod.rs
@@ -4,6 +4,9 @@ mod err;
 mod header;
 mod net;
 
+use core::matches;
+
+pub use err::AbortError;
 pub(crate) use err::Error as RawError;
 pub(crate) use net::Error as NetStateError;
 
@@ -54,10 +57,6 @@ impl<'b, N: Transport, B: BufferProvider<'b>> Raw<'b, N, B> {
     }
 
     pub fn set_net(&mut self, net: N) {
-        debug_assert!(
-            !self.n.is_ok(),
-            "network must not be in Ok() state to replace it."
-        );
         self.n.replace(net);
     }
 
@@ -69,49 +68,67 @@ impl<'b, N: Transport, B: BufferProvider<'b>> Raw<'b, N, B> {
         self.buf
     }
 
-    pub fn close_with(&mut self, reason_code: Option<ReasonCode>) {
-        match reason_code {
-            Some(r) => self.n.fail(r),
-            None => {
-                drop(self.n.terminate());
-                debug!("closed network connection");
-            }
-        }
+    pub fn prepare_disconnect(&mut self, reason_code: ReasonCode) {
+        debug_assert!(self.n.is_ok());
+
+        self.n.fail(reason_code);
+    }
+
+    pub fn prepare_close(&mut self) {
+        debug_assert!(
+            matches!(self.n, NetState::Ok(_) | NetState::DueDisconnect(_, _)),
+            "transport layer must be in a working state to close it."
+        );
+
+        self.n.deactivate();
     }
 
     /// Disconnect handler after an error occured.
     ///
-    /// This expects the network to not be in `Ok()` state
-    pub async fn abort(&mut self) -> Result<(), RawError<B::ProvisionError>> {
+    /// This expects the network to be in neither `Ok(N)` nor `Terminated` state
+    pub async fn abort(&mut self) -> Result<N, AbortError> {
         debug_assert!(
-            !self.n.is_ok(),
-            "network must not be in Ok() state to disconnect due to an error."
+            !self.n.is_terminated(),
+            "network must be in DueDisconnect(N, ReasonCode) or Inactive(N) state to disconnect due to an error."
         );
 
-        match &mut self.n {
-            NetState::Faulted(n, r) => {
-                let packet = DisconnectPacket::<0>::new(*r, None, None, Vec::new());
+        // We want to ensure correct operability (e.g. subsequent calls to `Client::connect`) even when this
+        // future is dropped. Therefore we remove the network from the client handle before any await point.
+        // In case of a healthy connection, we set the network connection back into our netstate before the
+        // first await point.
+        let n = self.n.terminate();
+
+        match n {
+            NetState::Ok(n) => {
+                warn!("abort() called during healthy MQTT connection");
+
+                self.n.replace(n);
+
+                Err(AbortError::Connected)
+            }
+            NetState::Terminated => {
+                warn!("abort() called when no network connection is present");
+
+                Err(AbortError::Terminated)
+            }
+            NetState::DueDisconnect(mut n, r) => {
+                let packet = DisconnectPacket::<0>::new(r, None, None, Vec::new());
 
                 debug!("sending DISCONNECT packet with reason code: {:?}", r);
 
                 // Don't check whether length exceeds servers maximum packet size because we don't
                 // add properties to the DISCONNECT packet -> length is always in the 4..=6 range in bytes.
                 // The server really shouldn't reject this.
-                let r = packet
-                    .send(n)
-                    .await
-                    .map_err(Into::into)
-                    .inspect_err(|e| error!("I/O error during send: {:?}", e));
+                if let Err(e) = packet.send(&mut n).await {
+                    error!(
+                        "I/O error during send: {:?}",
+                        <_ as Into<RawError<B::ProvisionError>>>::into(e)
+                    )
+                };
 
-                self.close_with(None);
-
-                r
+                Ok(n)
             }
-            NetState::Ok(_) => {
-                self.close_with(None);
-                Ok(())
-            }
-            NetState::Terminated => Ok(()),
+            NetState::Inactive(n) => Ok(n),
         }
     }
 
@@ -137,7 +154,10 @@ impl<'b, N: Transport, B: BufferProvider<'b>> Raw<'b, N, B> {
             RawError::Server => error!("server protocol violation"),
         }
 
-        self.close_with(r);
+        match r {
+            Some(reason_code) => self.prepare_disconnect(reason_code),
+            None => self.n.deactivate(),
+        }
 
         e
     }
@@ -173,9 +193,8 @@ impl<'b, N: Transport, B: BufferProvider<'b>> Raw<'b, N, B> {
             }
         }
 
-        // Terminate right away because if send fails, sending another (DISCONNECT) packet doesn't make sense
-        drop(self.n.terminate());
-        debug!("closed network connection");
+        // Deactivate right away because if send fails, sending a (DISCONNECT) packet doesn't make sense
+        self.n.deactivate();
 
         e
     }
@@ -185,6 +204,9 @@ impl<'b, N: Transport, B: BufferProvider<'b>> Raw<'b, N, B> {
         let net = self.n.get().inspect_err(|e| match e {
             NetStateError::Faulted => {
                 warn!("attempted to receive from a faulted mqtt connection")
+            }
+            NetStateError::Inactive => {
+                warn!("attempted to receive from a faulted mqtt/network connection")
             }
             NetStateError::Terminated => {
                 warn!("attempted to receive from a closed network connection")
@@ -213,6 +235,9 @@ impl<'b, N: Transport, B: BufferProvider<'b>> Raw<'b, N, B> {
     ) -> Result<P, RawError<B::ProvisionError>> {
         let net = self.n.get().inspect_err(|e| match e {
             NetStateError::Faulted => warn!("attempted to receive from a faulted mqtt connection"),
+            NetStateError::Inactive => {
+                warn!("attempted to receive from a faulted mqtt/network connection")
+            }
             NetStateError::Terminated => {
                 warn!("attempted to receive from a closed network connection")
             }
@@ -224,26 +249,15 @@ impl<'b, N: Transport, B: BufferProvider<'b>> Raw<'b, N, B> {
             .map_err(|e| self.handle_rx(e))
     }
 
-    // pub async fn recv_full<P: RxPacket<'b>>(&mut self) -> Result<P, RawError<B::ProvisionError>> {
-    //     let header = self.recv_header().await?;
-    //     let packet_type = header.packet_type().map_err(|_r| {
-    //         self.close_with(Some(ReasonCode::MalformedPacket));
-    //         RawError::Server
-    //     })?;
-    //     if packet_type != P::PACKET_TYPE {
-    //         self.close_with(Some(ReasonCode::ImplementationSpecificError));
-    //         return Err(RawError::UnexpectedPacketType);
-    //     }
-
-    //     self.recv_body(&header).await
-    // }
-
     pub async fn send<P: TxPacket>(
         &mut self,
         packet: &P,
     ) -> Result<(), RawError<B::ProvisionError>> {
         let net = self.n.get().inspect_err(|e| match e {
             NetStateError::Faulted => warn!("attempted to send on a faulted mqtt connection"),
+            NetStateError::Inactive => {
+                warn!("attempted to send on a faulted mqtt/network connection")
+            }
             NetStateError::Terminated => warn!("attempted to send on a closed network connection"),
         })?;
         packet.send(net).await.map_err(|e| self.handle_tx(e))
@@ -253,6 +267,9 @@ impl<'b, N: Transport, B: BufferProvider<'b>> Raw<'b, N, B> {
     pub async fn flush(&mut self) -> Result<(), RawError<B::ProvisionError>> {
         let net = self.n.get().inspect_err(|e| match e {
             NetStateError::Faulted => warn!("attempted to flush a faulted mqtt connection"),
+            NetStateError::Inactive => {
+                warn!("attempted to flush a faulted mqtt/network connection")
+            }
             NetStateError::Terminated => warn!("attempted to flush a closed network connection"),
         })?;
 

--- a/src/client/raw/net.rs
+++ b/src/client/raw/net.rs
@@ -1,61 +1,92 @@
-use core::mem;
+use core::{matches, mem};
 
-use crate::{io::Transport, types::ReasonCode};
+use crate::{fmt::debug_assert, io::Transport, types::ReasonCode};
 
-/// Represents a network connection with different variants for handling failures in the connection gracefully.
+/// Represents the state of a network connection, including mechanisms for handling failures gracefully.
 #[derive(Debug, Default)]
 pub(crate) enum NetState<N: Transport> {
-    /// The connection and dialogue with the server is ok
+    /// Both the transport layer and the MQTT protocol-level connection are healthy.
     Ok(N),
 
-    /// The connection is ok but some protocol specific error (e.g. `MalformedPacket` or `ProtocolError` occured)
-    ///
-    /// Sending messages can be considered, but the session should ultimately be closed according to spec
-    Faulted(N, ReasonCode),
+    /// The transport layer is healthy, but a protocol error (e.g. `MalformedPacket`) has occurred. A
+    /// `DISCONNECT` packet must be sent with the provided [`ReasonCode`] before closing the connection.
+    DueDisconnect(N, ReasonCode),
 
-    /// The connection is closed
+    /// The connection is inactive. This occurs if a protocol failure does not require a `DISCONNECT`,
+    /// or if the transport itself encountered an error. The transport is retained so the user can close
+    /// it gracefully or reuse it.
+    Inactive(N),
+
+    /// No network connection is available.
     #[default]
     Terminated,
 }
 
-/// A network connection state related error.
 pub enum Error {
-    /// An error has occurred in the application MQTT communication.
-    /// The underlying network is still open and should be used for sending a DISCONNECT packet.
     Faulted,
-
-    /// An error has occurred in the application MQTT communication.
-    /// The underlying network has already been closed because either a DISCONNECT packet has already been sent or shouldn't be sent at all.
+    Inactive,
     Terminated,
 }
 
 impl<N: Transport> NetState<N> {
-    pub fn is_ok(&self) -> bool {
+    /// Returns `true` if the net state is [`Ok`].
+    ///
+    /// [`Ok`]: NetState::Ok
+    #[must_use]
+    pub(crate) fn is_ok(&self) -> bool {
         matches!(self, Self::Ok(_))
     }
+    /// Returns `true` if the net state is [`Terminated`].
+    ///
+    /// [`Terminated`]: NetState::Terminated
+    #[must_use]
+    pub(crate) fn is_terminated(&self) -> bool {
+        matches!(self, Self::Terminated)
+    }
+
     pub fn replace(&mut self, net: N) {
+        debug_assert!(
+            self.is_terminated(),
+            "network must be in Terminated state to replace it",
+        );
+
         *self = Self::Ok(net);
     }
     pub fn get(&mut self) -> Result<&mut N, Error> {
         match self {
             Self::Ok(n) => Ok(n),
-            Self::Faulted(_, _) => Err(Error::Faulted),
+            Self::DueDisconnect(_, _) => Err(Error::Faulted),
+            Self::Inactive(_) => Err(Error::Inactive),
             Self::Terminated => Err(Error::Terminated),
         }
     }
 
     pub fn fail(&mut self, reason_code: ReasonCode) {
+        debug_assert!(
+            matches!(self, Self::Ok(_)),
+            "network must be in Ok(N) state to fail."
+        );
+
         *self = match mem::take(self) {
-            Self::Ok(n) | Self::Faulted(n, _) => Self::Faulted(n, reason_code),
+            Self::Ok(n) | Self::DueDisconnect(n, _) => Self::DueDisconnect(n, reason_code),
+            Self::Inactive(n) => Self::Inactive(n),
             Self::Terminated => Self::Terminated,
         }
     }
 
-    pub fn terminate(&mut self) -> Option<N> {
-        match mem::take(self) {
-            Self::Ok(n) => Some(n),
-            Self::Faulted(n, _) => Some(n),
-            Self::Terminated => None,
+    pub fn deactivate(&mut self) {
+        debug_assert!(
+            matches!(self, Self::Ok(_) | Self::DueDisconnect(_, _)),
+            "network must be in Ok(N) or DueDisconnect(N, ReasonCode) state to be deactivated."
+        );
+
+        *self = match mem::take(self) {
+            Self::Ok(n) | Self::DueDisconnect(n, _) | Self::Inactive(n) => Self::Inactive(n),
+            Self::Terminated => Self::Terminated,
         }
+    }
+
+    pub fn terminate(&mut self) -> Self {
+        mem::take(self)
     }
 }

--- a/tests/common/utils.rs
+++ b/tests/common/utils.rs
@@ -22,6 +22,7 @@ use tokio::net::TcpStream;
 
 use crate::common::{
     FailingClient, TestClient,
+    assert::assert_ok,
     failing::{ByteLimit, FailingTcp},
     fmt::warn_inspect,
 };
@@ -106,10 +107,7 @@ pub async fn connected_failing_client(
 }
 
 pub async fn disconnect(client: &mut TestClient<'_>, options: &DisconnectOptions<'_>) {
-    let _ = warn_inspect!(
-        client.disconnect(options).await,
-        "Client::disconnect() failed"
-    );
+    assert_ok!(client.disconnect(options).await);
 }
 
 pub async fn subscribe<'c>(

--- a/tests/integration/connect_options.rs
+++ b/tests/integration/connect_options.rs
@@ -601,8 +601,9 @@ async fn keep_alive_not_kept_alive_idle_network() {
         } | MqttError::Network(_)
     ));
 
-    // A non-recoverable poll error should always allow calling abort without panicking.
-    c.abort().await;
+    // A non-recoverable poll error should always allow calling abort without panicking
+    // and return the network.
+    assert_ok!(c.abort().await);
 }
 
 #[tokio::test]
@@ -656,8 +657,9 @@ async fn keep_alive_not_kept_alive_incoming_qos0() {
             .await,
             "expected to be disconnected"
         );
-        // A non-recoverable poll error should always allow calling abort without panicking.
-        rx.abort().await;
+        // A non-recoverable poll error should always allow calling abort without panicking
+        // and return the network.
+        assert_ok!(rx.abort().await);
     };
 
     join!(receiver, publisher);
@@ -709,8 +711,9 @@ async fn keep_alive_not_kept_alive_will_timing() {
             server_reference: _,
         } | MqttError::Network(_)
     ));
-    // A non-recoverable poll error should always allow calling abort without panicking.
-    tx.abort().await;
+    // A non-recoverable poll error should always allow calling abort without panicking
+    // and return the network.
+    assert_ok!(tx.abort().await);
 
     disconnect(&mut rx, DEFAULT_DC_OPTIONS).await;
 }

--- a/tests/integration/disconnect_options.rs
+++ b/tests/integration/disconnect_options.rs
@@ -1,11 +1,10 @@
-use std::{assert_eq, format, num::NonZero};
+use std::{assert_eq, format, num::NonZero, panic};
 
 use rust_mqtt::{
     client::{MqttError, options::DisconnectOptions},
     config::SessionExpiryInterval,
     types::{MqttString, MqttStringPair},
 };
-use tokio_test::assert_err;
 
 use crate::common::{
     BROKER_ADDRESS, DEFAULT_DC_OPTIONS, NO_SESSION_CONNECT_OPTIONS,
@@ -21,13 +20,17 @@ async fn connect_session_expiry_zero_disconnect_session_expiry_non_zero() {
 
     let options = DisconnectOptions::new().session_expiry_interval(SessionExpiryInterval::NeverEnd);
 
-    let e = assert_err!(c.disconnect(&options).await);
+    let Err(e) = c.disconnect(&options).await else {
+        panic!();
+    };
     assert_eq!(e, MqttError::IllegalDisconnectSessionExpiryInterval);
 
     let options = DisconnectOptions::new()
         .session_expiry_interval(SessionExpiryInterval::Seconds(NonZero::new(1).unwrap()));
 
-    let e = assert_err!(c.disconnect(&options).await);
+    let Err(e) = c.disconnect(&options).await else {
+        panic!();
+    };
     assert_eq!(e, MqttError::IllegalDisconnectSessionExpiryInterval);
 
     disconnect(&mut c, DEFAULT_DC_OPTIONS).await;
@@ -158,14 +161,17 @@ async fn server_maximum_packet_size_exceeded_by_disconnect_hive_only() {
     let mut c =
         assert_ok!(connected_client(BROKER_ADDRESS, NO_SESSION_CONNECT_OPTIONS, None).await);
 
-    let e = assert_err!(
-        c.disconnect(
+    let Err(e) = c
+        .disconnect(
             &DisconnectOptions::new()
                 .user_properties(&user_properties)
-                .reason_string(reason_string)
+                .reason_string(reason_string),
         )
         .await
-    );
+    else {
+        panic!()
+    };
+
     assert_eq!(e, MqttError::ServerMaximumPacketSizeExceeded);
 
     disconnect(&mut c, DEFAULT_DC_OPTIONS).await;


### PR DESCRIPTION
- Closes #112 by changing return types of `Client::disconnect` and `Client::abort` to return the network handle in the success case; allowing the user to close the network connection as required by MQTT
- Improves CI by adding rust-cache for faster dependency resolving and compilation
- Improves CI integration tests by using Mosquitto and HiveMQ in Docker containers, avoiding stalling `apt` steps