### PR TITLE
Make in-flight counters publicly available

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -311,12 +311,17 @@ impl<const SUBSCRIBE_MAXIMUM: usize, const RECEIVE_MAXIMUM: usize, const SEND_MA
             })
     }
 
-    fn active_inbound_publishes(&self) -> u16 {
+    /// Returns the amount of inbound, in-flight publications.
+    #[must_use]
+    pub fn active_inbound_publishes(&self) -> u16 {
         debug_assert!(u16::try_from(self.inbound_publishes.len()).is_ok());
 
         self.inbound_publishes.len() as u16
     }
-    pub(crate) fn active_outbound_publishes(&self) -> u16 {
+
+    /// Returns the amount of outbound, in-flight publications.
+    #[must_use]
+    pub fn active_outbound_publishes(&self) -> u16 {
         debug_assert!(u16::try_from(self.outbound_publishes.len()).is_ok());
 
         self.outbound_publishes.len() as u16


### PR DESCRIPTION
I would like to access these metrics, because I use them to manage my buffers and prioritize work (i.e. I build a caching wrapper around your crate and prioritize inbound/bound traffic).