### PR TITLE
Enhanced authentication

### DIFF
--- a/.ci/emqx.conf
+++ b/.ci/emqx.conf
@@ -1,0 +1,15 @@
+node {
+  cookie = "emqx50elixir"
+  data_dir = "data"
+}
+
+mqtt {
+  max_packet_size = "2000000B"
+}
+
+authentication = [
+  {
+    mechanism = "password_based"
+    backend = "built_in_database"
+  }
+]

--- a/.ci/emqx.conf
+++ b/.ci/emqx.conf
@@ -7,9 +7,22 @@ mqtt {
   max_packet_size = "2000000B"
 }
 
+# EMQX requires a really high max_heap_size value in order to
+# not run out of memory if debug logs are enabled (~1000MB).
+# For this reason, just disable shutdown completely.
+force_shutdown {
+  enable = false
+}
+
 authentication = [
   {
     mechanism = "password_based"
     backend = "built_in_database"
+  }
+  {
+    mechanism = "scram"
+    backend = "built_in_database"
+    algorithm = "sha256"
+    iteration_count = 4096
   }
 ]

--- a/.ci/emqx_users.csv
+++ b/.ci/emqx_users.csv
@@ -1,0 +1,2 @@
+user_id,password,is_superuser
+test,testPass,true

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -99,3 +99,42 @@ jobs:
 
       - name: Run hive-only integration tests
         run: RUST_LOG=trace cargo test hive_only --features "log" -- --show-output --ignored
+
+  integration_tests_emqx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install toolchain
+        run: rustup show
+
+      - name: Rust Cache
+        uses: swatinem/rust-cache@v2
+
+      - name: Start EMQX
+        run: |
+          docker run -d \
+            --name emqx \
+            -p 1883:1883 \
+            -v $PWD/.ci/emqx.conf:/opt/emqx/etc/emqx.conf \
+            -v $PWD/.ci/emqx_users.csv:/opt/emqx/etc/auth-built-in-db-bootstrap.csv \
+            emqx/emqx:6.2.2
+          timeout 30s sh -c 'until docker logs emqx 2>&1 | grep "EMQX Enterprise 6.2.2 is running now!"; do sleep 0.1; done'
+
+      - name: Run integration tests
+        run: RUST_LOG=trace cargo test integration --features "log" -- --show-output
+
+      - name: Restart EMQX
+        run: |
+          docker rm -f emqx
+          docker run -d \
+            --name emqx \
+            -p 1883:1883 \
+            -v $PWD/.ci/emqx.conf:/opt/emqx/etc/emqx.conf \
+            -v $PWD/.ci/emqx_users.csv:/opt/emqx/etc/auth-built-in-db-bootstrap.csv \
+            emqx/emqx:6.2.2
+          timeout 30s sh -c 'until docker logs emqx 2>&1 | grep "EMQX Enterprise 6.2.2 is running now!"; do sleep 0.1; done'
+
+      - name: Run emqx-only integration tests
+        run: RUST_LOG=trace cargo test emqx_only --features "log" -- --show-output --ignored

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -112,29 +112,46 @@ jobs:
       - name: Rust Cache
         uses: swatinem/rust-cache@v2
 
-      - name: Start EMQX
+      - name: Start & Configure EMQX
         run: |
           docker run -d \
             --name emqx \
             -p 1883:1883 \
+            -p 18083:18083 \
             -v $PWD/.ci/emqx.conf:/opt/emqx/etc/emqx.conf \
             -v $PWD/.ci/emqx_users.csv:/opt/emqx/etc/auth-built-in-db-bootstrap.csv \
             emqx/emqx:6.2.2
           timeout 30s sh -c 'until docker logs emqx 2>&1 | grep "EMQX Enterprise 6.2.2 is running now!"; do sleep 0.1; done'
 
+          API_JSON=$(docker exec emqx emqx ctl api_keys add --api-secret abcdefghijklmnopqrstuvwxyz0123456789 --name admin)
+          API_KEY=$(echo $API_JSON | grep -o '"api_key" : "[^"]*"' | cut -d'"' -f4)
+          curl -s --user "${API_KEY}:abcdefghijklmnopqrstuvwxyz0123456789" \
+              -X POST "http://localhost:18083/api/v5/authentication/scram:built_in_database/users" \
+              -H "Content-Type: application/json" \
+              -d "{\"user_id\": \"test\",\"password\": \"testPass\"}"
+
       - name: Run integration tests
         run: RUST_LOG=trace cargo test integration --features "log" -- --show-output
 
-      - name: Restart EMQX
+      - name: Restart & Configure  EMQX
         run: |
           docker rm -f emqx
           docker run -d \
             --name emqx \
             -p 1883:1883 \
+            -p 18083:18083 \
             -v $PWD/.ci/emqx.conf:/opt/emqx/etc/emqx.conf \
             -v $PWD/.ci/emqx_users.csv:/opt/emqx/etc/auth-built-in-db-bootstrap.csv \
             emqx/emqx:6.2.2
           timeout 30s sh -c 'until docker logs emqx 2>&1 | grep "EMQX Enterprise 6.2.2 is running now!"; do sleep 0.1; done'
+
+          API_JSON=$(docker exec emqx emqx ctl api_keys add --api-secret abcdefghijklmnopqrstuvwxyz0123456789 --name admin)
+          API_KEY=$(echo $API_JSON | grep -o '"api_key" : "[^"]*"' | cut -d'"' -f4)
+          curl -s --user "${API_KEY}:abcdefghijklmnopqrstuvwxyz0123456789" \
+              -X POST "http://localhost:18083/api/v5/authentication/scram:built_in_database/users" \
+              -H "Content-Type: application/json" \
+              -d "{\"user_id\": \"test\",\"password\": \"testPass\"}"
+
 
       - name: Run emqx-only integration tests
         run: RUST_LOG=trace cargo test emqx_only --features "log" -- --show-output --ignored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent protocol error on shared subscription with no local set to true
 - Disallow calls to `Client::abort` when the client is disconnected and has no available network connection
 - Return the `Transport` network handle after a successful disconnection / abortion
+- Add enhanced authentication with `Client::connect_enhanced` and re-authentication with `Client::reauthenticate`
+- Add generic paramater to `MqttError` defaulting to `Infallible` for errors during enhanced authentication
 
 ## 0.5.1 - 2026-04-10
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ mosquitto -c .ci/mosquitto-tls.conf -v
 - 'demo' is a showcase of rust-mqtt's features over TCP. Note that the example usage is very strict and not really a good way of using the client.
 - 'tls' connects the client to a broker over TLS with client certificate authentication and server certificate verification using [embedded-tls](https://github.com/drogue-iot/embedded-tls).
 - 'manual_ack' shows the client's capabilities of manual acknowledgements by rudimentarily implementing the optional payload format check (see [MQTTv5, 3.3.2.3.2 Payload Format Indicator](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901111))
+- 'auth' showcases MQTTv5's enhanced/extended authentication and re-authentication using the SCRAM-SHA-256 algorithm
 
 Set up the broker for 'demo' and 'manual_ack' by installing, configuring and running Mosquitto using the CI configuration:
 
@@ -42,12 +43,15 @@ Set up the broker for 'tls' by running Mosquitto with the tls config file. The r
 mosquitto -c .ci/mosquitto-tls.conf -v
 ```
 
+For 'auth', a broker that supports enhanced authentication is required. Unfortunately this does not come with Mosquitto out of the box. If you intend to run this example, you can set up an EMQX instance as in the integration test CI job.
+
 Then you can run the examples with different logging configs and the bump/alloc features:
 
 ```bash
 RUST_LOG=info cargo run --example demo
 RUST_LOG=info cargo run --example tls
 RUST_LOG=trace cargo run --example manual_ack --no-default-features --features "v5 log bump log-level-trace"
+RUST_LOG=debug cargo run --example auth     # 'auth' requires the alloc feature
 ```
 
 ## Tests
@@ -71,11 +75,12 @@ Set up the mosquitto broker as used in the CI pipeline (described above). You sh
 cargo test integration
 ```
 
-Because the test suite is quite comprehensive, some test cases are ignored because they may fail with the currently used release of a broker. However, these cases also follow a naming convention to be able to run them despite being ignored by default. To run these tests on the relevant broker that does behave correctly, you can run the following commands.
+Because the test suite is quite comprehensive, some test cases are ignored because they may fail with the currently used release of a broker. However, these cases also follow a naming convention to be able to run them despite being ignored by default. To run these tests on the relevant broker that does behave correctly, you can run the following commands. For EMQX-only tests, set up an instance as in the integration test CI job.
 
 ```bash
 cargo test mosquitto_only -- --ignored
 cargo test hive_only -- --ignored
+cargo test emqx_only -- --ignored
 ```
 
 ### Debugging

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,11 @@ pem-parser = "0.1.1"
 signature = "2.2.0"
 p256 = "0.13.2"
 
+hmac = "0.13.0"
+sha2 = "0.11.0"
+pbkdf2 = "0.13.0"
+base64 = "0.23.1"
+
 
 [features]
 default = ["v5", "alloc", "log-level-info"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,9 @@ log-verbose = ["log-level-trace"]
 
 
 [[example]]
+name = "auth"
+
+[[example]]
 name = "demo"
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ log-verbose = ["log-level-trace"]
 
 [[example]]
 name = "auth"
+required-features = ["alloc"]
 
 [[example]]
 name = "demo"

--- a/README.md
+++ b/README.md
@@ -36,11 +36,10 @@ The design goal is a strict yet flexible and explicit API that leverages Rust's 
 - Request Problem Information
 - Reason String
 - User Property
+- Enhanced/Extended authentication and re-authentication
 
 ### Currently unsupported MQTT features & limitations
 
-- AUTH packet
-- Properties: Authentication Method, Authentication Data
 - Subscribing to multiple topics in a single packet
 - Topic alias in incoming publications
 

--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -1,0 +1,328 @@
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    panic,
+    str::from_utf8,
+};
+
+use base64::{Engine, engine::general_purpose::STANDARD};
+use embedded_io_adapters::tokio_1::FromTokio;
+use hmac::{Hmac, KeyInit, Mac};
+use log::{debug, error, info};
+use pbkdf2::pbkdf2_hmac;
+use rand::{Rng, distributions::Alphanumeric};
+use rust_mqtt::{
+    auth::{AuthMechanism, AuthOptions},
+    buffer::*,
+    client::{
+        Client,
+        event::{Auth, Event},
+        options::{ConnectOptions, DisconnectOptions, ReAuthOptions},
+    },
+    types::{MqttBinary, MqttString, ReasonCode},
+};
+use sha2::{Digest, Sha256};
+use tokio::net::TcpStream;
+use tokio_test::assert_ok;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let mut buffer = AllocBuffer;
+
+    let mut client = Client::<'_, '_, _, _, 1, 1, 1, 1, 16>::new(&mut buffer);
+
+    let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1883);
+    let connection = TcpStream::connect(addr).await.unwrap();
+    let connection = FromTokio::new(connection);
+
+    // ENHANCED AUTHENTICATION ON CONNECT
+
+    let (mut scram, connect_authentication_data) = ScramSha256::new("test", "testPass");
+
+    match client
+        .connect_enhanced(
+            connection,
+            &ConnectOptions::new()
+                .clean_start()
+                .authentication_data(connect_authentication_data),
+            None,
+            MqttString::from_str("SCRAM-SHA-256").unwrap(),
+            &mut scram,
+        )
+        .await
+    {
+        Ok(c) => {
+            info!("Connected to server: {c:?}");
+            info!("{:?}", client.client_config());
+            info!("{:?}", client.server_config());
+            info!("{:?}", client.shared_config());
+            info!("{:?}", client.session());
+        }
+        Err(e) => {
+            error!("Failed to connect to server: {e:?}");
+            return;
+        }
+    }
+
+    // (ENHANCED) RE-AUTHENTICATION
+
+    let (mut scram, authentication_data) = ScramSha256::new("test", "testPass");
+
+    assert_ok!(
+        client
+            .reauthenticate(&ReAuthOptions::new().authentication_data(authentication_data))
+            .await
+    );
+
+    match assert_ok!(client.poll().await) {
+        Event::Auth(auth) if auth.reason_code == ReasonCode::ContinueAuthentication => {
+            let Ok(r) = scram.kontinue(&auth) else {
+                assert_ok!(
+                    client
+                        .disconnect(
+                            &DisconnectOptions::new().reason_code(ReasonCode::ProtocolError)
+                        )
+                        .await
+                );
+                return;
+            };
+
+            let mut options = ReAuthOptions::new();
+            options.authentication_data = r.authentication_data;
+
+            assert_ok!(client.reauthenticate(&options).await);
+        }
+        Event::Auth(_) => {
+            panic!("server skipped server first data step");
+        }
+        e => info!("Received event {e:?}"),
+    }
+
+    match assert_ok!(client.poll().await) {
+        Event::Auth(auth)
+            if auth.reason_code == ReasonCode::Success && scram.success(&auth).is_ok() =>
+        {
+            info!("re-authentication complete");
+        }
+        Event::Auth(_) => {
+            panic!("server didn't complete re-authentication as expected");
+        }
+        e => info!("Received event {e:?}"),
+    }
+
+    match client.disconnect(&DisconnectOptions::new()).await {
+        Ok(_n) => {
+            // For a correct TCP disconnection, one should make sure the underlying TCP socket
+            // sends a FIN segment. However I could not get the tokio::TcpStream to behave that
+            // way, so we just do nothing here. It's fine for MQTT operability realistically,
+            // but for clean usage, the TCP should be closed properly.
+
+            info!("Disconnected from server")
+        }
+        Err(e) => {
+            error!("Failed to disconnect from server: {e:?}");
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ScramError {
+    ProtocolError(&'static str),
+    CryptoError,
+    AuthFailed,
+}
+
+#[derive(Debug, Clone)]
+enum State {
+    AwaitServerFirst {
+        client_nonce: String,
+        client_first_bare: String,
+    },
+    AwaitServerFinal {
+        server_signature: Vec<u8>,
+    },
+    Complete,
+}
+
+#[derive(Debug, Clone)]
+struct ScramSha256 {
+    password: String,
+    state: State,
+}
+
+impl ScramSha256 {
+    pub fn new(username: &str, password: impl Into<String>) -> (Self, MqttBinary<'static>) {
+        let username = username.replace('=', "=2D").replace(',', "=2C"); // RFC 5802 escaping
+        let client_nonce = rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(24)
+            .map(char::from)
+            .collect();
+        let client_first_bare = format!("n={},r={}", username, client_nonce);
+        let client_first = format!("n,,{}", client_first_bare);
+
+        (
+            Self {
+                password: password.into(),
+                state: State::AwaitServerFirst {
+                    client_nonce,
+                    client_first_bare,
+                },
+            },
+            MqttBinary::try_from(client_first.into_bytes()).unwrap(),
+        )
+    }
+}
+
+impl<const MAX_USER_PROPERTIES: usize> AuthMechanism<MAX_USER_PROPERTIES> for ScramSha256 {
+    type Error = ScramError;
+
+    fn kontinue(
+        &mut self,
+        auth: &Auth<'_, MAX_USER_PROPERTIES>,
+    ) -> Result<AuthOptions<'_, MAX_USER_PROPERTIES>, (Self::Error, Option<ReasonCode>)> {
+        let State::AwaitServerFirst {
+            client_nonce,
+            client_first_bare,
+        } = &self.state
+        else {
+            return Err((
+                ScramError::ProtocolError("Invalid state"),
+                Some(ReasonCode::ProtocolError),
+            ));
+        };
+
+        let server_first = auth
+            .authentication_data
+            .as_ref()
+            .and_then(|d| from_utf8(d.as_bytes()).ok())
+            .ok_or((
+                ScramError::ProtocolError("Invalid server challenge"),
+                Some(ReasonCode::ProtocolError),
+            ))?;
+
+        let full_nonce =
+            get_attr(server_first, "r=").map_err(|e| (e, Some(ReasonCode::ProtocolError)))?;
+        let salt = STANDARD
+            .decode(get_attr(server_first, "s=").map_err(|e| (e, Some(ReasonCode::ProtocolError)))?)
+            .map_err(|_| (ScramError::CryptoError, Some(ReasonCode::ProtocolError)))?;
+        let iter = get_attr(server_first, "i=")
+            .map_err(|e| (e, Some(ReasonCode::ProtocolError)))?
+            .parse::<u32>()
+            .map_err(|_| {
+                (
+                    ScramError::ProtocolError("Invalid iter"),
+                    Some(ReasonCode::ProtocolError),
+                )
+            })?;
+
+        debug!(
+            "full_nonce={}, salt={:?}, iterations={}",
+            full_nonce, salt, iter
+        );
+
+        if !full_nonce.starts_with(client_nonce) {
+            error!(
+                "server nonce (={}) does not start with client nonce (={})",
+                full_nonce, client_nonce
+            );
+
+            return Err((
+                ScramError::ProtocolError("Invalid state"),
+                Some(ReasonCode::ProtocolError),
+            ));
+        }
+
+        let mut salted_password = [0u8; 32];
+        pbkdf2_hmac::<Sha256>(self.password.as_bytes(), &salt, iter, &mut salted_password);
+
+        let client_key = hmac(&salted_password, b"Client Key");
+        let stored_key = Sha256::digest(client_key);
+        let server_key = hmac(&salted_password, b"Server Key");
+
+        let client_final_no_proof = format!("c=biws,r={}", full_nonce);
+        let auth_msg = format!(
+            "{},{},{}",
+            client_first_bare, server_first, client_final_no_proof
+        );
+
+        let client_sig = hmac(&stored_key, auth_msg.as_bytes());
+        let client_proof: Vec<u8> = client_key
+            .iter()
+            .zip(client_sig.iter())
+            .map(|(a, b)| a ^ b)
+            .collect();
+
+        self.state = State::AwaitServerFinal {
+            server_signature: hmac(&server_key, auth_msg.as_bytes()).to_vec(),
+        };
+
+        let response = format!(
+            "{},p={}",
+            client_final_no_proof,
+            STANDARD.encode(client_proof)
+        );
+
+        debug!("client_final={}", response);
+
+        Ok(AuthOptions {
+            authentication_data: Some(MqttBinary::try_from(response.into_bytes()).unwrap()),
+            ..Default::default()
+        })
+    }
+
+    fn success(
+        &mut self,
+        auth: &Auth<'_, MAX_USER_PROPERTIES>,
+    ) -> Result<(), (Self::Error, Option<ReasonCode>)> {
+        let State::AwaitServerFinal { server_signature } = &self.state else {
+            return Err((
+                ScramError::ProtocolError("Out of order"),
+                Some(ReasonCode::ProtocolError),
+            ));
+        };
+
+        let data = auth.authentication_data.as_ref().ok_or((
+            ScramError::ProtocolError("No data"),
+            Some(ReasonCode::ProtocolError),
+        ))?;
+        let server_final = from_utf8(data.as_bytes()).map_err(|_| {
+            (
+                ScramError::ProtocolError("UTF-8"),
+                Some(ReasonCode::ProtocolError),
+            )
+        })?;
+
+        debug!("server_final={}", server_final);
+
+        let verifier = server_final.strip_prefix("v=").ok_or((
+            ScramError::ProtocolError("Invalid verifier format"),
+            Some(ReasonCode::ProtocolError),
+        ))?;
+
+        if STANDARD
+            .decode(verifier)
+            .map_err(|_| (ScramError::CryptoError, Some(ReasonCode::ProtocolError)))?
+            == *server_signature
+        {
+            self.state = State::Complete;
+            Ok(())
+        } else {
+            Err((ScramError::AuthFailed, Some(ReasonCode::ProtocolError)))
+        }
+    }
+}
+
+fn get_attr<'a>(input: &'a str, tag: &str) -> Result<&'a str, ScramError> {
+    input
+        .split(',')
+        .find_map(|s| s.strip_prefix(tag))
+        .ok_or(ScramError::ProtocolError("Missing attribute"))
+}
+
+fn hmac(key: &[u8], data: &[u8]) -> [u8; 32] {
+    let mut h = Hmac::<Sha256>::new_from_slice(key).expect("HMAC size");
+    h.update(data);
+    h.finalize().into_bytes().into()
+}

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -33,7 +33,7 @@ async fn main() {
     #[cfg(feature = "bump")]
     let mut buffer = BumpBuffer::new(&mut buffer);
 
-    let mut client = Client::<'_, _, _, 1, 1, 1, 1, 16>::new(&mut buffer);
+    let mut client = Client::<'_, '_, _, _, 1, 1, 1, 1, 16>::new(&mut buffer);
 
     let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1883);
     let connection = TcpStream::connect(addr).await.unwrap();
@@ -269,7 +269,7 @@ async fn main() {
     let mut buffer = BumpBuffer::new(&mut buffer);
 
     // Continue the previous session
-    let mut client = Client::<'_, _, _, 1, 1, 1, 1, 16>::with_session(session, &mut buffer);
+    let mut client = Client::<'_, '_, _, _, 1, 1, 1, 1, 16>::with_session(session, &mut buffer);
 
     let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1883);
     let connection = TcpStream::connect(addr).await.unwrap();

--- a/examples/manual_ack.rs
+++ b/examples/manual_ack.rs
@@ -45,7 +45,7 @@ async fn main() {
     #[cfg(feature = "bump")]
     let mut buffer = BumpBuffer::new(&mut buffer);
 
-    let mut client = Client::<'_, _, _, 1, 3, 3, 0, 16>::new(&mut buffer);
+    let mut client = Client::<'_, '_, _, _, 1, 3, 3, 0, 16>::new(&mut buffer);
 
     // Acknowledge all packets manually which have a payload format indicator property with a value of
     // true (claiming that the payload is UTF-8). We intentionally leave the check for actual UTF-8

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -68,7 +68,7 @@ async fn main() {
     #[cfg(feature = "bump")]
     let mut buffer = BumpBuffer::new(&mut buffer);
 
-    let mut client = Client::<'_, _, _, 1, 1, 1, 0, 1>::new(&mut buffer);
+    let mut client = Client::<'_, '_, _, _, 1, 1, 1, 0, 1>::new(&mut buffer);
 
     let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8883);
     let connection = TcpStream::connect(addr).await.unwrap();

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -7,6 +7,14 @@ use crate::{
     types::{MqttBinary, MqttString, MqttStringPair, ReasonCode},
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub(crate) enum ReAuthState {
+    Inactive,
+    AwaitAuth,
+    DueAuth,
+}
+
 /// Options for enhanced authentication for the AUTH packet.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -33,7 +33,7 @@ pub struct AuthOptions<'a, const MAX_USER_PROPERTIES: usize> {
 /// An enhanced authentication mechanism for use in MQTTv5's extended/enhanced
 /// authentication. [`Client`] only requires this for enhanced authentication
 /// used in [`Client::connect_enhanced`], but typically this can be reused for
-/// enhanced re-authentication. Note that this trait only provides methods
+/// enhanced re-authentication. Note that this trait only provides methods for
 /// handling a received authentication exchange (received AUTH or CONNACK
 /// packet). If authentication data is required for the first step of the
 /// authentication exchange, which is always sent by the client (in the CONNECT
@@ -55,8 +55,8 @@ pub trait AuthMechanism<const MAX_USER_PROPERTIES: usize> {
     type Error;
 
     /// An AUTH packet with [`ReasonCode::ContinueAuthentication`] was received.
-    /// The [`AuthMechanism`] executes it checks and produces the next step
-    /// (which is an AUTH packet) of the authentication exchange.
+    /// The [`AuthMechanism`] executes its checks and produces the next step
+    /// (which in turn is an AUTH packet) of the authentication exchange.
     ///
     /// # Returns
     ///

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,118 @@
+//! Contains traits and types for MQTTv5's enhanced authentication.
+
+use heapless::Vec;
+
+use crate::{
+    client::event::Auth,
+    types::{MqttBinary, MqttString, MqttStringPair, ReasonCode},
+};
+
+/// Options for enhanced authentication for the AUTH packet.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct AuthOptions<'a, const MAX_USER_PROPERTIES: usize> {
+    /// The authentication data property of the AUTH packet.
+    pub authentication_data: Option<MqttBinary<'a>>,
+
+    /// The reason string property of the AUTH packet.
+    pub reason_string: Option<MqttString<'a>>,
+
+    /// Arbitrary key-value pairs of strings sent as the user property entries
+    /// of the AUTH packet.
+    pub user_properties: Vec<MqttStringPair<'a>, MAX_USER_PROPERTIES>,
+}
+
+/// An enhanced authentication mechanism for use in MQTTv5's extended/enhanced
+/// authentication. [`Client`] only requires this for enhanced authentication
+/// used in [`Client::connect_enhanced`], but typically this can be reused for
+/// enhanced re-authentication. Note that this trait only provides methods
+/// handling a received authentication exchange (received AUTH or CONNACK
+/// packet). If authentication data is required for the first step of the
+/// authentication exchange, which is always sent by the client (in the CONNECT
+/// packet, in case of re-authentication this is a AUTH packet sent with
+/// [`Client::reauthenticate`]), this data must be created by the user
+/// beforehand.
+///
+/// [`Client`]: crate::client::Client
+/// [`Client::connect_enhanced`]: crate::client::Client::connect_enhanced
+/// [`Client::reauthenticate`]: crate::client::Client::reauthenticate
+pub trait AuthMechanism<const MAX_USER_PROPERTIES: usize> {
+    /// The authentication mechanism may detect formatting errors, hit errors
+    /// within cryptographic implementations or fail to authenticate the server
+    /// in case of mutual authentication (such as the SCRAM-SHA family). After
+    /// handling the failed authentication by disconnecting, this error is
+    /// wrapped in [`MqttError::EnhancedAuthFailed`] and returned.
+    ///
+    /// [`MqttError::EnhancedAuthFailed`]: crate::client::MqttError::EnhancedAuthFailed
+    type Error;
+
+    /// An AUTH packet with [`ReasonCode::ContinueAuthentication`] was received.
+    /// The [`AuthMechanism`] executes it checks and produces the next step
+    /// (which is an AUTH packet) of the authentication exchange.
+    ///
+    /// # Returns
+    ///
+    /// - [`Err((Self::Error, None))`] if an error occured and the client should
+    ///   disconnect without a DISCONNECT packet, i.e. close the network
+    ///   connection. The contained [`AuthMechanism::Error`] is wrapped in
+    ///   [`MqttError::EnhancedAuthFailed`] and returned.
+    /// - [`Err((Self::Error, Some(ReasonCode)))`] if an error occured and the
+    ///   client should disconnect with a DISCONNECT packet. This DISCONNECT
+    ///   packet is scheduled to be sent with [`Client::abort`]. The
+    ///   [`ReasonCode`] must be a valid Disconnect Reason Code (compare
+    ///   [`Client::disconnect`]). The contained [`AuthMechanism::Error`] is
+    ///   wrapped in [`MqttError::EnhancedAuthFailed`] and returned.
+    /// - [`Ok(Auth)`] if the authentication continues regularly. The contained
+    ///   [`Auth`] is converted into an AUTH packet with
+    ///   [`ReasonCode::ContinueAuthentication`] and sent to the server.
+    ///
+    /// [`ReasonCode::ContinueAuthentication`]: crate::types::ReasonCode::ContinueAuthentication
+    /// [`Err((Self::Error, None))`]: core::result::Result::Err
+    /// [`MqttError::EnhancedAuthFailed`]: crate::client::MqttError::EnhancedAuthFailed
+    /// [`Err((Self::Error, Some(ReasonCode)))`]: core::result::Result::Err
+    /// [`Client::abort`]: crate::client::Client::abort
+    /// [`Client::disconnect`]: crate::client::Client::disconnect
+    /// [`Ok(Auth)`]: core::result::Result::Ok
+    fn kontinue(
+        &mut self,
+        auth: &Auth<'_, MAX_USER_PROPERTIES>,
+    ) -> Result<AuthOptions<'_, MAX_USER_PROPERTIES>, (Self::Error, Option<ReasonCode>)>;
+
+    /// A CONNACK packet with [`ReasonCode::Success`] was received. The
+    /// properties of this CONNACK packet have been mapped to the fields of the
+    /// [`Auth`] parameter.
+    ///
+    /// In case this trait is used for enhanced re-authentication, this method
+    /// typically corresponds to the receival of an AUTH packet with
+    /// [`ReasonCode::Success`].
+    ///
+    /// There are no more steps within this authentication exchange. This method
+    /// validates the data in the CONNACK (or AUTH) packet if required. It may
+    /// be a no-op otherwise if no such validation is part of the authentication
+    /// mechanism or if no such data is present.
+    ///
+    /// # Returns
+    ///
+    /// - [`Err((Self::Error, None))`] if an error occured and the client should
+    ///   disconnect without a DISCONNECT packet, i.e. close the network
+    ///   connection. The contained [`AuthMechanism::Error`] is wrapped in
+    ///   [`MqttError::EnhancedAuthFailed`] and returned.
+    /// - [`Err((Self::Error, Some(ReasonCode)))`] if an error occured and
+    ///   the client should disconnect with a DISCONNECT packet. This DISCONNECT
+    ///   packet is scheduled to be sent with [`Client::abort`]. The
+    ///   [`ReasonCode`] must be a valid Disconnect Reason Code (compare
+    ///   [`Client::disconnect`]). The contained [`AuthMechanism::Error`] is
+    ///   wrapped in [`MqttError::EnhancedAuthFailed`] and returned.
+    /// - [`Ok`] if the authentication was successful.
+    ///
+    /// [`ReasonCode::Success`]: crate::types::ReasonCode::Success
+    /// [`Err((Self::Error, None))`]: core::result::Result::Err
+    /// [`Err((Self::Error, Some(ReasonCode)))`]: core::result::Result::Err
+    /// [`MqttError::EnhancedAuthFailed`]: crate::client::MqttError::EnhancedAuthFailed
+    /// [`Client::abort`]: crate::client::Client::abort
+    /// [`Client::disconnect`]: crate::client::Client::disconnect
+    fn success(
+        &mut self,
+        auth: &Auth<'_, MAX_USER_PROPERTIES>,
+    ) -> Result<(), (Self::Error, Option<ReasonCode>)>;
+}

--- a/src/client/err.rs
+++ b/src/client/err.rs
@@ -1,4 +1,4 @@
-use core::matches;
+use core::{convert::Infallible, matches};
 
 use heapless::Vec;
 
@@ -26,7 +26,7 @@ use crate::{
 /// [`Client::connect`]: crate::client::Client::connect
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum Error<'e, const MAX_USER_PROPERTIES: usize> {
+pub enum Error<'e, const MAX_USER_PROPERTIES: usize, A = Infallible> {
     /// An underlying Read/Write method returned an error.
     ///
     /// Unrecoverable error. [`Client::abort`] should be called.
@@ -81,6 +81,16 @@ pub enum Error<'e, const MAX_USER_PROPERTIES: usize> {
         /// a server reference. Identifies another server which can be used.
         server_reference: Option<MqttString<'e>>,
     },
+
+    /// An error occured in the [`AuthMechanism`] implementation or was detected by the [`AuthMechanism`]
+    /// during an enhanced authentication exchange in [`Client::connect_enhanced`].
+    ///
+    /// Unrecoverable error. [`Client::abort`] should be called.
+    ///
+    /// [`AuthMechanism`]: crate::auth::AuthMechanism
+    /// [`Client::connect_enhanced`]: crate::client::Client::connect_enhanced
+    /// [`Client::abort`]: crate::client::Client::abort
+    EnhancedAuthFailed(A),
 
     /// Another unrecoverable error has been returned earlier. The underlying connection is in a state,
     /// in which it refuses/is not able to perform regular communication.
@@ -248,7 +258,7 @@ pub enum Error<'e, const MAX_USER_PROPERTIES: usize> {
     IllegalDisconnectSessionExpiryInterval,
 }
 
-impl<const MAX_USER_PROPERTIES: usize> Error<'_, MAX_USER_PROPERTIES> {
+impl<const MAX_USER_PROPERTIES: usize, A> Error<'_, MAX_USER_PROPERTIES, A> {
     /// Returns whether the client can recover from this error without closing the network connection.
     #[must_use]
     pub fn is_recoverable(&self) -> bool {
@@ -270,14 +280,14 @@ impl<const MAX_USER_PROPERTIES: usize> Error<'_, MAX_USER_PROPERTIES> {
         )
     }
 }
-impl<'e> Error<'e, 0> {
+impl<'e, A> Error<'e, 0, A> {
     /// Converts an [`Error<0>`] into an [`Error<N>`] with any N.
     ///
     /// This cannot be a [`From`] implementation because `From<Error<0>> for Error<N>` would
     /// collide with the blanket implementation `From<T> for T`. The reason this function is
     /// only implemented for `MAX_USER_PROPERTIES` = 0 is to prevent potentially surprisng
     /// panics when converting from more user properties to less.
-    pub fn inflate<const MAX_USER_PROPERTIES: usize>(self) -> Error<'e, MAX_USER_PROPERTIES> {
+    pub fn inflate<const MAX_USER_PROPERTIES: usize>(self) -> Error<'e, MAX_USER_PROPERTIES, A> {
         match self {
             Self::Network(error_kind) => Error::Network(error_kind),
             Self::Server => Error::Server,
@@ -292,6 +302,48 @@ impl<'e> Error<'e, 0> {
                 reason,
                 reason_string,
                 user_properties: user_properties.into_iter().collect(),
+                server_reference,
+            },
+            Self::EnhancedAuthFailed(a) => Error::EnhancedAuthFailed(a),
+            Self::RecoveryRequired => Error::RecoveryRequired,
+            Self::PacketIdentifierNotInFlight => Error::PacketIdentifierNotInFlight,
+            Self::AllPacketIdentifiersUsed => Error::AllPacketIdentifiersUsed,
+            Self::ManualAckNotAllowed => Error::ManualAckNotAllowed,
+            Self::QoSMismatched => Error::QoSMismatched,
+            Self::HandshakeStateMismatched => Error::HandshakeStateMismatched,
+            Self::IllegalReasonCode => Error::IllegalReasonCode,
+            Self::PacketMaximumLengthExceeded => Error::PacketMaximumLengthExceeded,
+            Self::ServerMaximumPacketSizeExceeded => Error::ServerMaximumPacketSizeExceeded,
+            Self::SessionBuffer => Error::SessionBuffer,
+            Self::SendQuotaExceeded => Error::SendQuotaExceeded,
+            Self::UnsupportedByServer => Error::UnsupportedByServer,
+            Self::IllegalNoLocalSharedSubscription => Error::IllegalNoLocalSharedSubscription,
+            Self::IllegalDisconnectSessionExpiryInterval => {
+                Error::IllegalDisconnectSessionExpiryInterval
+            }
+        }
+    }
+}
+impl<'e, const MAX_USER_PROPERTIES: usize> Error<'e, MAX_USER_PROPERTIES> {
+    /// Converts an [`Error<A = Infallible>`] into an [`Error<A>`] with any A.
+    ///
+    /// This cannot be a [`From`] implementation because `From<Error<A>> for Error<A>` would
+    /// collide with the blanket implementation `From<T> for T`.
+    pub fn into_fallible<A>(self) -> Error<'e, MAX_USER_PROPERTIES, A> {
+        match self {
+            Self::Network(error_kind) => Error::Network(error_kind),
+            Self::Server => Error::Server,
+            Self::Alloc => Error::Alloc,
+            Self::AuthPacketReceived => Error::AuthPacketReceived,
+            Self::Disconnect {
+                reason,
+                reason_string,
+                user_properties,
+                server_reference,
+            } => Error::Disconnect {
+                reason,
+                reason_string,
+                user_properties,
                 server_reference,
             },
             Self::RecoveryRequired => Error::RecoveryRequired,
@@ -314,13 +366,15 @@ impl<'e> Error<'e, 0> {
     }
 }
 
-impl<const MAX_USER_PROPERTIES: usize> From<Reserved> for Error<'_, MAX_USER_PROPERTIES> {
+impl<const MAX_USER_PROPERTIES: usize, A> From<Reserved> for Error<'_, MAX_USER_PROPERTIES, A> {
     fn from(_: Reserved) -> Self {
         Self::Server
     }
 }
 
-impl<B, const MAX_USER_PROPERTIES: usize> From<RawError<B>> for Error<'_, MAX_USER_PROPERTIES> {
+impl<B, const MAX_USER_PROPERTIES: usize, A> From<RawError<B>>
+    for Error<'_, MAX_USER_PROPERTIES, A>
+{
     fn from(e: RawError<B>) -> Self {
         match e {
             RawError::Disconnected => Self::RecoveryRequired,
@@ -331,7 +385,9 @@ impl<B, const MAX_USER_PROPERTIES: usize> From<RawError<B>> for Error<'_, MAX_US
     }
 }
 
-impl<const MAX_USER_PROPERTIES: usize> From<TooLargeToEncode> for Error<'_, MAX_USER_PROPERTIES> {
+impl<const MAX_USER_PROPERTIES: usize, A> From<TooLargeToEncode>
+    for Error<'_, MAX_USER_PROPERTIES, A>
+{
     fn from(_: TooLargeToEncode) -> Self {
         Self::PacketMaximumLengthExceeded
     }

--- a/src/client/err.rs
+++ b/src/client/err.rs
@@ -134,8 +134,8 @@ pub enum Error<'e, const MAX_USER_PROPERTIES: usize, A = Infallible> {
 
     /// The requested operation of a publication flow is not allowed at this stage of its quality of
     /// service specific handshake and would result in a protocol violation if carried out. For the exact
-    /// rules of manual acknowledgements, refer to TODO. An exemplary list of cases (potentially missing
-    /// some) when this applies is as follows:
+    /// rules of manual acknowledgements, refer to [`Client`]. An exemplary list of cases (potentially
+    /// missing some) when this applies is as follows:
     /// - Automatic acknowledgements:
     ///   - A republish of a packet whose corresponding PUBREL packet has already been sent was
     ///     attempted.
@@ -159,6 +159,8 @@ pub enum Error<'e, const MAX_USER_PROPERTIES: usize, A = Infallible> {
     ///   - A manual PUBCOMP was attempted despite not having received a PUBREL yet.
     ///
     /// Recoverable error. No action has been taken by the client.
+    ///
+    /// [`Client`]: crate::client::Client
     HandshakeStateMismatched,
 
     /// A reason code not allowed for the requested operation was supplied. Refer to the

--- a/src/client/err.rs
+++ b/src/client/err.rs
@@ -50,15 +50,6 @@ pub enum Error<'e, const MAX_USER_PROPERTIES: usize, A = Infallible> {
     /// [`Client::abort`]: crate::client::Client::abort
     Alloc,
 
-    /// An AUTH packet header has been received by the client. AUTH packets are not supported by the client.
-    /// The client has scheduled a DISCONNECT packet with [`ReasonCode::ImplementationSpecificError`].
-    /// The packet body has not been decoded.
-    ///
-    /// Unrecoverable error. [`Client::abort`] should be called.
-    ///
-    /// [`Client::abort`]: crate::client::Client::abort
-    AuthPacketReceived,
-
     /// The client could not connect to the broker or the broker has sent a DISCONNECT packet.
     ///
     /// Unrecoverable error. [`Client::abort`] should be called.
@@ -243,6 +234,28 @@ pub enum Error<'e, const MAX_USER_PROPERTIES: usize, A = Infallible> {
     /// [`TopicFilter::is_shared`]: crate::types::TopicFilter::is_shared
     IllegalNoLocalSharedSubscription,
 
+    /// Sending an AUTH packet in this network connection is not allowed because no authentication method was
+    /// specified in the CONNECT packet, as the connection was established with [`Client::connect`], which
+    /// doesn't provide this functionality.
+    ///
+    /// Recoverable error. No action has been taken by the client. [`Client::reauthenticate`] can be called in
+    /// a network/protocol connection established with [`Client::connect_enhanced`].
+    ///
+    /// [`Client::connect`]: crate::client::Client::connect
+    /// [`Client::reauthenticate`]: crate::client::Client::reauthenticate
+    /// [`Client::connect_enhanced`]: crate::client::Client::connect_enhanced
+    NoEnhancedAuthentication,
+
+    /// Sending an AUTH packet now is not possible because the client has not yet received the server's AUTH
+    /// packet of an ongoing authentication exchange.
+    ///
+    /// Recoverable error. No action has been taken by the client. Try again after an [`Event::Auth`] has been
+    /// emitted. This indicates that the authentication is either complete ([`ReasonCode::Success`]) or moved
+    /// to the next state, leaving the client to send the next AUTH packet.
+    ///
+    /// [`Event::Auth`]: crate::client::event::Event::Auth
+    ReauthenticationHandshakeStateMismatched,
+
     /// A disconnect now with the given session expiry interval would cause a protocol error.
     ///
     /// A disconnection was attempted with a session expiry interval change where the session expiry interval in the
@@ -276,6 +289,8 @@ impl<const MAX_USER_PROPERTIES: usize, A> Error<'_, MAX_USER_PROPERTIES, A> {
                 | Self::SendQuotaExceeded
                 | Self::UnsupportedByServer
                 | Self::IllegalNoLocalSharedSubscription
+                | Self::NoEnhancedAuthentication
+                | Self::ReauthenticationHandshakeStateMismatched
                 | Self::IllegalDisconnectSessionExpiryInterval
         )
     }
@@ -292,7 +307,6 @@ impl<'e, A> Error<'e, 0, A> {
             Self::Network(error_kind) => Error::Network(error_kind),
             Self::Server => Error::Server,
             Self::Alloc => Error::Alloc,
-            Self::AuthPacketReceived => Error::AuthPacketReceived,
             Self::Disconnect {
                 reason,
                 reason_string,
@@ -318,6 +332,10 @@ impl<'e, A> Error<'e, 0, A> {
             Self::SendQuotaExceeded => Error::SendQuotaExceeded,
             Self::UnsupportedByServer => Error::UnsupportedByServer,
             Self::IllegalNoLocalSharedSubscription => Error::IllegalNoLocalSharedSubscription,
+            Self::NoEnhancedAuthentication => Error::NoEnhancedAuthentication,
+            Self::ReauthenticationHandshakeStateMismatched => {
+                Error::ReauthenticationHandshakeStateMismatched
+            }
             Self::IllegalDisconnectSessionExpiryInterval => {
                 Error::IllegalDisconnectSessionExpiryInterval
             }
@@ -334,7 +352,6 @@ impl<'e, const MAX_USER_PROPERTIES: usize> Error<'e, MAX_USER_PROPERTIES> {
             Self::Network(error_kind) => Error::Network(error_kind),
             Self::Server => Error::Server,
             Self::Alloc => Error::Alloc,
-            Self::AuthPacketReceived => Error::AuthPacketReceived,
             Self::Disconnect {
                 reason,
                 reason_string,
@@ -359,6 +376,10 @@ impl<'e, const MAX_USER_PROPERTIES: usize> Error<'e, MAX_USER_PROPERTIES> {
             Self::SendQuotaExceeded => Error::SendQuotaExceeded,
             Self::UnsupportedByServer => Error::UnsupportedByServer,
             Self::IllegalNoLocalSharedSubscription => Error::IllegalNoLocalSharedSubscription,
+            Self::NoEnhancedAuthentication => Error::NoEnhancedAuthentication,
+            Self::ReauthenticationHandshakeStateMismatched => {
+                Error::ReauthenticationHandshakeStateMismatched
+            }
             Self::IllegalDisconnectSessionExpiryInterval => {
                 Error::IllegalDisconnectSessionExpiryInterval
             }

--- a/src/client/event.rs
+++ b/src/client/event.rs
@@ -37,6 +37,9 @@ pub struct Connected<'i, const MAX_USER_PROPERTIES: usize> {
 
     /// Another server which can be used.
     pub server_reference: Option<MqttString<'i>>,
+
+    /// The authentication data in the CONNACK packet.
+    pub authentication_data: Option<MqttBinary<'i>>,
 }
 
 /// Events emitted by the client when receiving an MQTT packet.

--- a/src/client/event.rs
+++ b/src/client/event.rs
@@ -194,6 +194,14 @@ pub enum Event<'e, const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER_PRO
     /// [`QoS::ExactlyOnce`]: crate::types::QoS::ExactlyOnce
     /// [`Client::ack_manually_when`]: crate::client::Client::ack_manually_when
     Duplicate(Publish<'e, MAX_SUBSCRIPTION_IDENTIFIERS, MAX_USER_PROPERTIES>),
+
+    /// The server sent an AUTH packet. This event is only emitted if
+    /// [`Client::connect_enhanced`] was used for the current network connection. Consequently,
+    /// if the connection was established with [`Client::connect`], this event is never emitted.
+    ///
+    /// [`Client::connect_enhanced`]: crate::client::Client::connect_enhanced
+    /// [`Client::connect`]: crate::client::Client::connect
+    Auth(Auth<'e, MAX_USER_PROPERTIES>),
 }
 
 /// Content of [`Event::Suback`].

--- a/src/client/event.rs
+++ b/src/client/event.rs
@@ -17,6 +17,12 @@ use crate::{
 ///
 /// Does not include the [`ReasonCode`] as it is always [`ReasonCode::Success`]
 /// (0x00) if this event is returned.
+/// Does not include the authentication method, as it is always the same as the client's
+/// authentication method when enhanced authentication ([`Client::connect_enhanced`]) is used
+/// or not present otherwise ([`Client::connect`]).
+///
+/// [`Client::connect_enhanced`]: crate::client::Client::connect_enhanced
+/// [`Client::connect`]: crate::client::Client::connect
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Connected<'i, const MAX_USER_PROPERTIES: usize> {
@@ -368,15 +374,15 @@ impl<'p, T, const MAX_USER_PROPERTIES: usize> From<GenericPubackPacket<'p, T, MA
 }
 
 /// Content of [`Event::Auth`]. The authentication method
-/// is not included as it is always the value that configured
-/// when calling [`Client::connect_enhanced`].
+/// is not included as it is always the value that was
+/// configured when calling [`Client::connect_enhanced`].
 ///
 /// [`Client::connect_enhanced`]: crate::client::Client::connect_enhanced
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Auth<'a, const MAX_USER_PROPERTIES: usize> {
-    /// Reason code of the AUTH packet. When this is [`ReasonCode::Success`],
-    /// the authentication exchange is complete.
+    /// The reason code of the AUTH packet. When this is
+    /// [`ReasonCode::Success`], the authentication exchange is complete.
     pub reason_code: ReasonCode,
     /// The authentication data of the AUTH packet.
     pub authentication_data: Option<MqttBinary<'a>>,

--- a/src/client/event.rs
+++ b/src/client/event.rs
@@ -356,3 +356,23 @@ impl<'p, T, const MAX_USER_PROPERTIES: usize> From<GenericPubackPacket<'p, T, MA
         }
     }
 }
+
+/// Content of [`Event::Auth`]. The authentication method
+/// is not included as it is always the value that configured
+/// when calling [`Client::connect_enhanced`].
+///
+/// [`Client::connect_enhanced`]: crate::client::Client::connect_enhanced
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Auth<'a, const MAX_USER_PROPERTIES: usize> {
+    /// Reason code of the AUTH packet. When this is [`ReasonCode::Success`],
+    /// the authentication exchange is complete.
+    pub reason_code: ReasonCode,
+    /// The authentication data of the AUTH packet.
+    pub authentication_data: Option<MqttBinary<'a>>,
+    /// The reason string of the AUTH packet.
+    pub reason_string: Option<MqttString<'a>>,
+    /// The user property entries in the AUTH packet.
+    /// If the vector is full, this list might not be exhaustive.
+    pub user_properties: Vec<MqttStringPair<'a>, MAX_USER_PROPERTIES>,
+}

--- a/src/client/event.rs
+++ b/src/client/event.rs
@@ -61,7 +61,6 @@ pub enum Event<'e, const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER_PRO
     /// - [`QoS::AtMostOnce`]: No action
     /// - [`QoS::AtLeastOnce`] and [`Publish::ack_mode`] is [`AckMode::Automatic`]: A PUBACK packet has been sent to the server.
     /// - [`QoS::AtLeastOnce`] and [`Publish::ack_mode`] is [`AckMode::Manual`]: No action, the PUBACK must be sent manually by the user with [`Client::manual_acknowledge`].
-    /// - [`QoS::ExactlyOnce`]: A PUBREC packet has been sent to the server.
     /// - [`QoS::ExactlyOnce`] and [`Publish::ack_mode`] is [`AckMode::Automatic`]: A PUBREC packet has been sent to the server.
     /// - [`QoS::ExactlyOnce`] and [`Publish::ack_mode`] is [`AckMode::Manual`]: No action, the PUBREC must be sent manually by the user with [`Client::manual_receive`].
     ///

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -990,14 +990,14 @@ impl<
         if let Some(handle) = handle {
             // Treat the packet as sent before successfully sending. In case of a network error,
             // we have tracked the packet as in flight and can republish it.
-            if let Err(e) = handle.outbound_publish(options.qos, options.ack_mode) {
-                match e {
-                    SmError::NoCapacity => return Err(MqttError::SessionBuffer),
+            handle
+                .outbound_publish(options.qos, options.ack_mode)
+                .map_err(|e| match e {
+                    SmError::NoCapacity => MqttError::SessionBuffer,
                     SmError::PacketIdentifierUnused
                     | SmError::QoSMismatched
                     | SmError::HandshakeStateMismatched => unreachable!(),
-                }
-            }
+                })?;
         }
 
         match identified_qos.packet_identifier() {
@@ -1137,22 +1137,16 @@ impl<
             return Err(MqttError::ServerMaximumPacketSizeExceeded);
         }
 
-        if let Err(e) = self.session.outbound_republish(identified_qos) {
-            match e {
+        self.session
+            .outbound_republish(identified_qos)
+            .map_err(|e| match e {
                 SmError::NoCapacity => {
                     unreachable!("a republish can not fail due to missing capacity")
                 }
-                SmError::PacketIdentifierUnused => {
-                    return Err(MqttError::PacketIdentifierNotInFlight);
-                }
-                SmError::QoSMismatched => {
-                    return Err(MqttError::QoSMismatched);
-                }
-                SmError::HandshakeStateMismatched => {
-                    return Err(MqttError::HandshakeStateMismatched);
-                }
-            }
-        }
+                SmError::PacketIdentifierUnused => MqttError::PacketIdentifierNotInFlight,
+                SmError::QoSMismatched => MqttError::QoSMismatched,
+                SmError::HandshakeStateMismatched => MqttError::HandshakeStateMismatched,
+            })?;
 
         debug!(
             "resending PUBLISH packet with packet identifier {}",
@@ -2017,7 +2011,8 @@ impl<
                 }
 
                 match event {
-                    SmEvent::Aborted
+                    SmEvent::Ignored
+                    | SmEvent::Aborted
                     | SmEvent::Rejected
                     | SmEvent::Acknowledged
                     | SmEvent::Received(_)
@@ -2032,7 +2027,6 @@ impl<
                         };
                         Event::Duplicate(publish)
                     }
-                    SmEvent::Ignored => Event::Ignored,
                     SmEvent::ServerError => return Err(MqttError::Server),
                 }
             }
@@ -2238,7 +2232,6 @@ impl<
                     SmEvent::Publish
                     | SmEvent::Duplicate(_)
                     | SmEvent::Aborted
-                    | SmEvent::Rejected
                     | SmEvent::Acknowledged
                     | SmEvent::Received(_)
                     | SmEvent::Released(_) => unreachable!(),
@@ -2247,6 +2240,7 @@ impl<
                     SmEvent::Completed => {
                         Event::PublishComplete(Puback::new(pubcomp, AckMode::default()))
                     }
+                    SmEvent::Rejected => Event::PublishRejected(Pubrej::from(pubcomp)),
                     SmEvent::ServerError => return Err(MqttError::Server),
                 }
             }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -664,8 +664,7 @@ impl<
     /// [`Client::session`]).
     ///
     /// If the server indicates that no session is present (Session Present flag is 0), the
-    /// client's local session state is cleared. To persist state across connections,
-    /// call [`Client::session`] to clone the state before calling this method.
+    /// client's local session state is cleared.
     ///
     /// # Returns
     ///
@@ -757,8 +756,8 @@ impl<
     /// CONNACK packet, [`AuthMechanism::success`] is called. The [`AuthMechanism`] may
     /// detect an error in the authentication process or experience an internal error. In
     /// this case, the exchange is interrupted, [`MqttError::EnhancedAuthFailed`] is returned
-    /// an optional DISCONNECT packet is scheduled to be sent with [`Client::abort`],
-    /// depending on the returned [`ReasonCode`] by the [`AuthMechanism`].
+    /// and depending on the returned [`ReasonCode`] by the [`AuthMechanism`], an optional
+    /// DISCONNECT packet is scheduled to be sent with [`Client::abort`].
     ///
     /// The internal state of the client, including session information and negotiated server
     /// capabilities is initialized.
@@ -775,8 +774,7 @@ impl<
     /// [`Client::session`]).
     ///
     /// If the server indicates that no session is present (Session Present flag is 0), the
-    /// client's local session state is cleared. To persist state across connections,
-    /// call [`Client::session`] to clone the state before calling this method.
+    /// client's local session state is cleared.
     ///
     /// # Returns
     ///

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -148,6 +148,7 @@ pub use raw::AbortError;
 ///   packets with unused packet identifiers that require a responding packet are received (PUBREC and PUBREL), no session entry
 ///   is created and the responding packet (PUBREL and PUBCOMP) is sent automatically by the client.
 pub struct Client<
+    'a,
     'c,
     N: Transport,
     B: BufferProvider<'c>,
@@ -157,7 +158,7 @@ pub struct Client<
     const MAX_SUBSCRIPTION_IDENTIFIERS: usize,
     const MAX_USER_PROPERTIES: usize,
 > {
-    client_config: ClientConfig,
+    client_config: ClientConfig<'a>,
     shared_config: SharedConfig,
     server_config: ServerConfig,
     session: Session<SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>,
@@ -179,6 +180,7 @@ impl<
     const MAX_USER_PROPERTIES: usize,
 > core::fmt::Debug
     for Client<
+        '_,
         'c,
         N,
         B,
@@ -212,7 +214,8 @@ impl<
     const MAX_USER_PROPERTIES: usize,
 > defmt::Format
     for Client<
-        'c,
+        '_,
+        '_,
         N,
         B,
         SUBSCRIBE_MAXIMUM,
@@ -236,6 +239,7 @@ impl<
 }
 
 impl<
+    'a,
     'c,
     N: Transport,
     B: BufferProvider<'c>,
@@ -246,6 +250,7 @@ impl<
     const MAX_USER_PROPERTIES: usize,
 >
     Client<
+        'a,
         'c,
         N,
         B,
@@ -327,7 +332,7 @@ impl<
 
     /// Returns configuration for this client.
     #[inline]
-    pub fn client_config(&self) -> &ClientConfig {
+    pub fn client_config(&self) -> &ClientConfig<'a> {
         &self.client_config
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -10,7 +10,7 @@ use crate::{
         event::{Auth, Connected, Event, Puback, Publish, Pubrej, Suback},
         options::{
             AckMode, AckOptions, ConnectOptions, DisconnectOptions, PublicationOptions,
-            SubscriptionOptions, TopicReference, UnsubscriptionOptions,
+            ReAuthOptions, SubscriptionOptions, TopicReference, UnsubscriptionOptions,
         },
         raw::Raw,
     },
@@ -1877,6 +1877,91 @@ impl<
         Ok(())
     }
 
+    /// Initiates or continues a re-authentication by sending an AUTH packet.
+    ///
+    /// The client internally tracks the re-authentication state and determines the
+    /// [`ReasonCode`] to use. If no re-authentication is currently in progress
+    /// because none has been initialized since establishing the connection or the last
+    /// re-authentication exchange has been completed with an AUTH packet with
+    /// [`ReasonCode::Success`] sent by the server, [`ReasonCode::ReAuthenticate`] is
+    /// used. If a re-authentication is in progress and this method hasn't been called
+    /// since the last [`Event::Auth`], [`ReasonCode::ContinueAuthentication`] is used.
+    /// Otherwise, no AUTH packet may be sent.
+    ///
+    /// # Errors
+    ///
+    /// * [`MqttError::RecoveryRequired`] if an unrecoverable error occured previously
+    /// * [`MqttError::Network`] if the underlying [`Transport`] returned an error
+    /// * [`MqttError::ServerMaximumPacketSizeExceeded`] if the server's maximum packet
+    ///   size would be exceeded by sending this PUBCOMP packet
+    /// * [`MqttError::NoEnhancedAuthentication`] if enhanced authentication is not
+    ///   possible in this network connection because no authentication method has been
+    ///   specified in the CONNECT packet. [`Client::connect`] has been used to
+    ///   establish the connection instead of the required [`Client::connect_enhanced`].
+    /// * [`MqttError::ReauthenticationHandshakeStateMismatched`] if a re-authentication
+    ///   exchange is currently in progress, but the server has not yet sent an AUTH
+    ///   packet in response to the client's last AUTH packet.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the length of the `user_properties` slice in the
+    /// [`ReAuthOptions`] is greater than `MAX_USER_PROPERTIES`.
+    pub async fn reauthenticate(
+        &mut self,
+        options: &ReAuthOptions<'_>,
+    ) -> Result<(), MqttError<'c, 0>> {
+        let Some(authentication_method) = self
+            .client_config
+            .authentication_method
+            .as_ref()
+            .map(MqttString::as_borrowed)
+        else {
+            return Err(MqttError::NoEnhancedAuthentication);
+        };
+
+        let reason_code = match self.reauth_state {
+            ReAuthState::Inactive => ReasonCode::ReAuthenticate,
+            ReAuthState::AwaitAuth => {
+                return Err(MqttError::ReauthenticationHandshakeStateMismatched);
+            }
+            ReAuthState::DueAuth => ReasonCode::ContinueAuthentication,
+        };
+
+        let packet = AuthPacket::<MAX_USER_PROPERTIES>::new(
+            reason_code,
+            authentication_method.into(),
+            options
+                .authentication_data
+                .as_ref()
+                .map(MqttBinary::as_borrowed)
+                .map(Into::into),
+            options
+                .reason_string
+                .as_ref()
+                .map(MqttString::as_borrowed)
+                .map(Into::into),
+            options
+                .user_properties
+                .iter()
+                .map(MqttStringPair::as_borrowed)
+                .map(Into::into)
+                .collect(),
+        );
+
+        if self.server_config.maximum_packet_size.as_u32() < packet.encoded_len() as u32 {
+            return Err(MqttError::ServerMaximumPacketSizeExceeded);
+        }
+
+        self.reauth_state = ReAuthState::AwaitAuth;
+
+        debug!("sending AUTH packet");
+
+        self.raw.send(&packet).await?;
+        self.raw.flush().await?;
+
+        Ok(())
+    }
+
     /// Completes the disconnection from the server after an unrecoverable error in a
     /// situation-aware way.
     ///
@@ -2142,7 +2227,6 @@ impl<
     ///     the client expects for this packet identifier from its session state
     ///   * the fixed header has the packet type CONNECT/SUBSCRIBE/UNSUBSCRIBE/PINGREQ
     /// * [`MqttError::Disconnect`] if a DISCONNECT packet is received
-    /// * [`MqttError::AuthPacketReceived`] if the fixed header has the packet type AUTH
     pub async fn poll_body(
         &mut self,
         header: FixedHeader,
@@ -2615,13 +2699,44 @@ impl<
                 return Err(MqttError::Server);
             }
             PacketType::Auth => {
-                error!("received unexpected AUTH packet");
+                // We don't have to check whether we sent an authentication method because
+                // when no authentication method was set at the time of the connection,
+                // the re-authentication state remains `ReauthState::Inactive`
+                if self.reauth_state != ReAuthState::AwaitAuth {
+                    error!("received unexpected AUTH packet");
+                    self.raw.prepare_disconnect(ReasonCode::ProtocolError);
+                    return Err(MqttError::Server);
+                }
 
-                // Receiving a AUTH packet is currently always a protocol error because we never send
-                // an Authentication Method property in the CONNECT packet.
-                // <https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901217>
-                self.raw.prepare_disconnect(ReasonCode::ProtocolError);
-                return Err(MqttError::AuthPacketReceived);
+                let auth = self
+                    .raw
+                    .recv_body::<AuthPacket<MAX_USER_PROPERTIES>>(&header)
+                    .await?;
+
+                // Must be a match statement instead of a match expression because
+                // attributes on expressions are experimental
+                #[expect(clippy::wildcard_in_or_patterns)]
+                #[expect(unreachable_patterns)]
+                match auth.reason_code {
+                    ReasonCode::Success => self.reauth_state = ReAuthState::Inactive,
+                    ReasonCode::ContinueAuthentication => self.reauth_state = ReAuthState::DueAuth,
+                    _ | ReasonCode::ReAuthenticate => {
+                        error!("server sent invalid AUTH reason code");
+                        self.raw.prepare_disconnect(ReasonCode::ProtocolError);
+                        return Err(MqttError::Server);
+                    }
+                }
+
+                Event::Auth(Auth {
+                    reason_code: auth.reason_code,
+                    authentication_data: auth.authentication_data.map(Property::into_inner),
+                    reason_string: auth.reason_string.map(Property::into_inner),
+                    user_properties: auth
+                        .user_properties
+                        .into_iter()
+                        .map(Property::into_inner)
+                        .collect(),
+                })
             }
         };
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -3,7 +3,7 @@
 use core::{matches, num::NonZero};
 
 use crate::{
-    auth::{AuthMechanism, AuthOptions},
+    auth::{AuthMechanism, AuthOptions, ReAuthState},
     buffer::BufferProvider,
     bytes::Bytes,
     client::{
@@ -168,6 +168,7 @@ pub struct Client<
 
     manual_ack_when:
         &'c dyn Fn(&Publish<'_, MAX_SUBSCRIPTION_IDENTIFIERS, MAX_USER_PROPERTIES>) -> bool,
+    reauth_state: ReAuthState,
 }
 
 impl<
@@ -199,6 +200,7 @@ impl<
             .field("server_config", &self.server_config)
             .field("session", &self.session)
             .field("raw", &self.raw)
+            .field("reauth_state", &self.reauth_state)
             .finish_non_exhaustive()
     }
 }
@@ -229,12 +231,13 @@ impl<
     fn format(&self, fmt: defmt::Formatter) {
         defmt::write!(
             fmt,
-            "Client {{ client_config: {:?}, shared_config: {:?}, server_config: {:?}, session: {:?}, raw: {:?}, .. }}",
+            "Client {{ client_config: {:?}, shared_config: {:?}, server_config: {:?}, session: {:?}, raw: {:?}, reauth_state: {:?}, .. }}",
             self.client_config,
             self.shared_config,
             self.server_config,
             self.session,
             self.raw,
+            self.reauth_state,
         );
     }
 }
@@ -296,6 +299,7 @@ impl<
             raw: Raw::new_disconnected(buffer),
 
             manual_ack_when: &|_| false,
+            reauth_state: ReAuthState::Inactive,
         }
     }
 
@@ -388,6 +392,8 @@ impl<
                 MAX_USER_PROPERTIES
             );
         }
+
+        self.reauth_state = ReAuthState::Inactive;
 
         // Set client session expiry interval because it is relevant to determine
         // which session expiry interval can be sent in DISCONNECT packet.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -3,10 +3,11 @@
 use core::{matches, num::NonZero};
 
 use crate::{
+    auth::{AuthMechanism, AuthOptions},
     buffer::BufferProvider,
     bytes::Bytes,
     client::{
-        event::{Connected, Event, Puback, Publish, Pubrej, Suback},
+        event::{Auth, Connected, Event, Puback, Publish, Pubrej, Suback},
         options::{
             AckMode, AckOptions, ConnectOptions, DisconnectOptions, PublicationOptions,
             SubscriptionOptions, TopicReference, UnsubscriptionOptions,
@@ -25,9 +26,9 @@ use crate::{
     },
     v5::{
         packet::{
-            ConnackPacket, ConnectPacket, DisconnectPacket, PingreqPacket, PingrespPacket,
-            PubackPacket, PubcompPacket, PublishPacket, PubrecPacket, PubrelPacket, SubackPacket,
-            SubscribePacket, UnsubackPacket, UnsubscribePacket,
+            AuthPacket, ConnackPacket, ConnectPacket, DisconnectPacket, PingreqPacket,
+            PingrespPacket, PubackPacket, PubcompPacket, PublishPacket, PubrecPacket, PubrelPacket,
+            SubackPacket, SubscribePacket, UnsubackPacket, UnsubscribePacket,
         },
         property::Property,
     },
@@ -368,11 +369,282 @@ impl<
         self.raw.buffer_mut()
     }
 
+    async fn start_connect<E>(
+        &mut self,
+        options: &ConnectOptions<'_>,
+        client_identifier: Option<MqttString<'_>>,
+    ) -> Result<(), MqttError<'c, 0, E>> {
+        assert!(
+            options.user_properties.len() <= MAX_USER_PROPERTIES,
+            "attempted to send CONNECT with {} > {} (MAX_USER_PROPERTIES) properties",
+            options.user_properties.len(),
+            MAX_USER_PROPERTIES
+        );
+        if let Some(ref will) = options.will {
+            assert!(
+                will.user_properties.len() <= MAX_USER_PROPERTIES,
+                "attempted to send Will with {} > {} (MAX_USER_PROPERTIES) properties",
+                will.user_properties.len(),
+                MAX_USER_PROPERTIES
+            );
+        }
+
+        // Set client session expiry interval because it is relevant to determine
+        // which session expiry interval can be sent in DISCONNECT packet.
+        self.client_config.session_expiry_interval = options.session_expiry_interval;
+
+        // Set request problem information because it is required to detect protocol
+        // errors when server sends a reason string or user properties in any packet
+        // other than PUBLISH, CONNACK, or DISCONNECT
+        self.client_config.request_problem_information = options.request_problem_information;
+
+        // Empirical maximum packet size mapping
+        // -------------------------------------------------------------------------------------------------------
+        //         remaining length              | fixed header length |              max packet size
+        //                               0..=127 |                   2 |                                   2..=129
+        //                          128..=16_383 |                   3 |                              131..=16_386
+        //                    16_384..=2_097_151 |                   4 |                        16_388..=2_097_155
+        // 2_097_152..=VarByteInt::MAX_ENCODABLE |                   5 | 2_097_157..=(VarByteInt::MAX_ENCODABLE+5)
+
+        const MAX_POSSIBLE_PACKET_SIZE: u32 = VarByteInt::MAX_ENCODABLE + 5;
+
+        self.client_config.maximum_accepted_remaining_length = match options.maximum_packet_size {
+            MaximumPacketSize::Unlimited => u32::MAX,
+            MaximumPacketSize::Limit(l) => match l.get() {
+                0 => unreachable!("NonZero invariant"),
+                1 => panic!(
+                    "every MQTT packet is at least 2 bytes long, a smaller maximum packet size makes no sense"
+                ),
+                2..=129 => l.get() - 2,
+                130..=16_386 => l.get() - 3,
+                16_387..=2_097_155 => l.get() - 4,
+                2_097_156..MAX_POSSIBLE_PACKET_SIZE => l.get() - 5,
+                MAX_POSSIBLE_PACKET_SIZE.. => VarByteInt::MAX_ENCODABLE,
+            },
+        };
+
+        trace!(
+            "maximum accepted remaining length set to {:?}",
+            self.client_config.maximum_accepted_remaining_length
+        );
+
+        let packet_client_identifier = client_identifier
+            .as_ref()
+            .map(MqttString::as_borrowed)
+            .unwrap_or_default();
+
+        let mut packet = ConnectPacket::<MAX_USER_PROPERTIES>::new(
+            packet_client_identifier,
+            options.clean_start,
+            options.keep_alive,
+            options.maximum_packet_size,
+            options.session_expiry_interval,
+            // Safety: `Self::new` panics if `RECEIVE_MAXIMUM` is 0. Thus, this
+            // code is only reached when `RECEIVE_MAXIMUM` is greater than 0.
+            unsafe { NonZero::new_unchecked(RECEIVE_MAXIMUM as u16) },
+            options.request_response_information,
+            options.request_problem_information,
+            options
+                .user_properties
+                .iter()
+                .map(MqttStringPair::as_borrowed)
+                .map(Into::into)
+                .collect(),
+        );
+
+        if let Some(ref authentication_method) = self.client_config.authentication_method {
+            packet.add_authentication_method(authentication_method.as_borrowed().into());
+        }
+        if let Some(ref authentication_data) = options.authentication_data {
+            packet.add_authentication_data(authentication_data.as_borrowed().into());
+        }
+
+        if let Some(ref user_name) = options.user_name {
+            packet.add_user_name(user_name.as_borrowed());
+        }
+        if let Some(ref password) = options.password {
+            packet.add_password(password.as_borrowed());
+        }
+
+        if let Some(ref will) = options.will {
+            let will_qos = will.will_qos;
+            let will_retain = will.will_retain;
+
+            packet.add_will(will.as_borrowed_will(), will_qos, will_retain);
+        }
+
+        debug!("sending CONNECT packet");
+        self.raw.send(&packet).await?;
+        self.raw.flush().await?;
+
+        Ok(())
+    }
+
+    async fn complete_connect<'d, E>(
+        &mut self,
+        connack_header: FixedHeader,
+        options: &ConnectOptions<'_>,
+        client_identifier: Option<MqttString<'d>>,
+    ) -> Result<Connected<'d, MAX_USER_PROPERTIES>, MqttError<'c, MAX_USER_PROPERTIES, E>>
+    where
+        'c: 'd,
+    {
+        let ConnackPacket::<MAX_USER_PROPERTIES> {
+            session_present,
+            reason_code,
+            session_expiry_interval,
+            receive_maximum,
+            maximum_qos,
+            retain_available,
+            maximum_packet_size,
+            assigned_client_identifier,
+            topic_alias_maximum,
+            reason_string,
+            user_properties,
+            wildcard_subscription_available,
+            subscription_identifier_available,
+            shared_subscription_available,
+            server_keep_alive,
+            response_information,
+            server_reference,
+            authentication_method,
+            authentication_data,
+        } = self.raw.recv_body(&connack_header).await?;
+
+        if !options.request_response_information && response_information.is_some() {
+            error!("server sent response information when request response information was false");
+            self.raw.prepare_disconnect(ReasonCode::ProtocolError);
+            return Err(MqttError::Server);
+        }
+
+        if self.client_config.authentication_method.is_none() && authentication_method.is_some() {
+            error!("server sent an authentication method when CONNECT didn't contain one");
+            self.raw.prepare_disconnect(ReasonCode::ProtocolError);
+            return Err(MqttError::Server);
+        }
+
+        if reason_code.is_success() {
+            debug!("CONNACK packet indicates success");
+
+            let client_identifier = assigned_client_identifier
+                .map(Property::into_inner)
+                .or(client_identifier)
+                .ok_or_else(|| {
+                    error!("server did not assign a client identifier when it was required");
+                    self.raw.prepare_disconnect(ReasonCode::ProtocolError);
+                    MqttError::Server
+                })?;
+
+            if let Some(ref connect_authentication_method) =
+                self.client_config.authentication_method
+            {
+                let Some(connack_authentication_method) = authentication_method else {
+                    error!(
+                        "server didn't send an authentication method in successful CONNACK packet when it was required"
+                    );
+                    self.raw.prepare_disconnect(ReasonCode::ProtocolError);
+                    return Err(MqttError::Server);
+                };
+
+                if connect_authentication_method != &connack_authentication_method.into_inner() {
+                    error!(
+                        "server sent an authentication method different from the required value"
+                    );
+                    self.raw.prepare_disconnect(ReasonCode::ProtocolError);
+                    return Err(MqttError::Server);
+                }
+            }
+
+            if session_present {
+                if options.clean_start {
+                    error!("server set the session present flag when clean start was set");
+                    self.raw.prepare_disconnect(ReasonCode::ProtocolError);
+                    return Err(MqttError::Server);
+                } else {
+                    info!("continuing previous session");
+                    self.session.reconnect();
+                }
+            } else {
+                #[allow(clippy::if_same_then_else)]
+                if options.clean_start {
+                    info!("beginning new session");
+                } else {
+                    info!(
+                        "beginning new session because server does not have the requested session present"
+                    );
+                }
+                self.session.clear();
+            }
+
+            self.shared_config.session_expiry_interval =
+                session_expiry_interval.unwrap_or(options.session_expiry_interval);
+            self.shared_config.keep_alive =
+                server_keep_alive.map_or(options.keep_alive, Property::into_inner);
+
+            if let Some(r) = receive_maximum {
+                self.server_config.receive_maximum = r.into_inner();
+            }
+            if let Some(m) = maximum_qos {
+                self.server_config.maximum_qos = m.into_inner();
+            }
+            if let Some(r) = retain_available {
+                self.server_config.retain_supported = r.into_inner();
+            }
+            if let Some(m) = maximum_packet_size {
+                self.server_config.maximum_packet_size = m;
+            }
+            if let Some(t) = topic_alias_maximum {
+                self.server_config.topic_alias_maximum = t.into_inner();
+            }
+            if let Some(w) = wildcard_subscription_available {
+                self.server_config.wildcard_subscription_supported = w.into_inner();
+            }
+            if let Some(s) = subscription_identifier_available {
+                self.server_config.subscription_identifiers_supported = s.into_inner();
+            }
+            if let Some(s) = shared_subscription_available {
+                self.server_config.shared_subscription_supported = s.into_inner();
+            }
+
+            Ok(Connected {
+                session_present,
+                client_identifier,
+                user_properties: user_properties
+                    .into_iter()
+                    .map(Property::into_inner)
+                    .collect(),
+                response_information: response_information.map(Property::into_inner),
+                server_reference: server_reference.map(Property::into_inner),
+                authentication_data: authentication_data.map(Property::into_inner),
+            })
+        } else {
+            debug!("CONNACK packet indicates rejection");
+            info!("connection rejected by server (reason: {:?})", reason_code);
+
+            self.raw.prepare_close();
+
+            info!("disconnected from server");
+
+            Err(MqttError::Disconnect {
+                reason: reason_code,
+                reason_string: reason_string.map(Property::into_inner),
+                user_properties: user_properties
+                    .into_iter()
+                    .map(Property::into_inner)
+                    .collect(),
+                server_reference: server_reference.map(Property::into_inner),
+            })
+        }
+    }
+
     /// Establishes a connection to an MQTT server over the provided [`Transport`].
     ///
-    /// Sends a CONNECT packet and awaits the CONNACK response by the server. It initializes
-    /// the internal state of the client, including session information and negotiated server
-    /// capabilities.
+    /// Sends a CONNECT packet and awaits the CONNACK response by the server. Authentication
+    /// is only possible via the User Name and Password fields. For enhanced authentication,
+    /// use [`Client::connect_enhanced`].
+    ///
+    /// The internal state of the client, including session information and negotiated server
+    /// capabilities is initialized.
     ///
     /// This function must only be called if:
     /// - The client is newly constructed and has not yet been connected.
@@ -426,113 +698,28 @@ impl<
     where
         'c: 'd,
     {
-        assert!(
-            options.user_properties.len() <= MAX_USER_PROPERTIES,
-            "attempted to send CONNECT with {} > {} (MAX_USER_PROPERTIES) properties",
-            options.user_properties.len(),
-            MAX_USER_PROPERTIES
-        );
-        if let Some(ref will) = options.will {
-            assert!(
-                will.user_properties.len() <= MAX_USER_PROPERTIES,
-                "attempted to send Will with {} > {} (MAX_USER_PROPERTIES) properties",
-                will.user_properties.len(),
-                MAX_USER_PROPERTIES
-            );
-        }
-
         self.raw.set_net(net);
 
-        // Set client session expiry interval because it is relevant to determine
-        // which session expiry interval can be sent in DISCONNECT packet.
-        self.client_config.session_expiry_interval = options.session_expiry_interval;
+        // Reset authentication method so `Client::start_connect` sees that the connection
+        // attempt is not using enhanced authentication
+        self.client_config.authentication_method = None;
 
-        // Set request problem information because it is required to detect protocol
-        // errors when server sends a reason string or user properties in any packet
-        // other than PUBLISH, CONNACK, or DISCONNECT
-        self.client_config.request_problem_information = options.request_problem_information;
-
-        // Empirical maximum packet size mapping
-        // -------------------------------------------------------------------------------------------------------
-        //         remaining length              | fixed header length |              max packet size
-        //                               0..=127 |                   2 |                                   2..=129
-        //                          128..=16_383 |                   3 |                              131..=16_386
-        //                    16_384..=2_097_151 |                   4 |                        16_388..=2_097_155
-        // 2_097_152..=VarByteInt::MAX_ENCODABLE |                   5 | 2_097_157..=(VarByteInt::MAX_ENCODABLE+5)
-
-        const MAX_POSSIBLE_PACKET_SIZE: u32 = VarByteInt::MAX_ENCODABLE + 5;
-
-        self.client_config.maximum_accepted_remaining_length = match options.maximum_packet_size {
-            MaximumPacketSize::Unlimited => u32::MAX,
-            MaximumPacketSize::Limit(l) => match l.get() {
-                0 => unreachable!("NonZero invariant"),
-                1 => panic!(
-                    "every MQTT packet is at least 2 bytes long, a smaller maximum packet size makes no sense"
-                ),
-                2..=129 => l.get() - 2,
-                130..=16_386 => l.get() - 3,
-                16_387..=2_097_155 => l.get() - 4,
-                2_097_156..MAX_POSSIBLE_PACKET_SIZE => l.get() - 5,
-                MAX_POSSIBLE_PACKET_SIZE.. => VarByteInt::MAX_ENCODABLE,
-            },
-        };
-
-        trace!(
-            "maximum accepted remaining length set to {:?}",
-            self.client_config.maximum_accepted_remaining_length
-        );
-
-        {
-            let packet_client_identifier = client_identifier
-                .as_ref()
-                .map(MqttString::as_borrowed)
-                .unwrap_or_default();
-
-            let mut packet = ConnectPacket::<MAX_USER_PROPERTIES>::new(
-                packet_client_identifier,
-                options.clean_start,
-                options.keep_alive,
-                options.maximum_packet_size,
-                options.session_expiry_interval,
-                // Safety: `Self::new` panics if `RECEIVE_MAXIMUM` is 0. Thus, this
-                // code is only reached when `RECEIVE_MAXIMUM` is greater than 0.
-                unsafe { NonZero::new_unchecked(RECEIVE_MAXIMUM as u16) },
-                options.request_response_information,
-                options.request_problem_information,
-                options
-                    .user_properties
-                    .iter()
-                    .map(MqttStringPair::as_borrowed)
-                    .map(Into::into)
-                    .collect(),
-            );
-
-            if let Some(ref user_name) = options.user_name {
-                packet.add_user_name(user_name.as_borrowed());
-            }
-            if let Some(ref password) = options.password {
-                packet.add_password(password.as_borrowed());
-            }
-
-            if let Some(ref will) = options.will {
-                let will_qos = will.will_qos;
-                let will_retain = will.will_retain;
-
-                packet.add_will(will.as_borrowed_will(), will_qos, will_retain);
-            }
-
-            debug!("sending CONNECT packet");
-            self.raw.send(&packet).await?;
-            self.raw.flush().await?;
-        }
+        self.start_connect(
+            options,
+            client_identifier.as_ref().map(MqttString::as_borrowed),
+        )
+        .await
+        .map_err(MqttError::inflate)?;
 
         let header = self.raw.recv_header().await?;
 
         match header.packet_type() {
-            Ok(ConnackPacket::<MAX_USER_PROPERTIES>::PACKET_TYPE) => debug!(
-                "received CONNACK packet header (remaining length: {})",
-                header.remaining_len.value()
-            ),
+            Ok(ConnackPacket::<MAX_USER_PROPERTIES>::PACKET_TYPE) => {
+                debug!(
+                    "received CONNACK packet header (remaining length: {})",
+                    header.remaining_len.value()
+                );
+            }
             Ok(t) => {
                 error!("received unexpected {:?} packet header", t);
 
@@ -546,123 +733,256 @@ impl<
             }
         }
 
-        let ConnackPacket::<MAX_USER_PROPERTIES> {
-            session_present,
-            reason_code,
-            session_expiry_interval,
-            receive_maximum,
-            maximum_qos,
-            retain_available,
-            maximum_packet_size,
-            assigned_client_identifier,
-            topic_alias_maximum,
-            reason_string,
-            user_properties,
-            wildcard_subscription_available,
-            subscription_identifier_available,
-            shared_subscription_available,
-            server_keep_alive,
-            response_information,
-            server_reference,
-        } = self.raw.recv_body(&header).await?;
+        let c = self
+            .complete_connect(header, options, client_identifier)
+            .await?;
 
-        if !options.request_response_information && response_information.is_some() {
-            error!("server sent response information when request response information was false");
-            self.raw.prepare_disconnect(ReasonCode::ProtocolError);
-            return Err(MqttError::Server);
-        }
+        info!("connected to server");
 
-        if reason_code.is_success() {
-            debug!("CONNACK packet indicates success");
+        Ok(c)
+    }
 
-            let client_identifier = assigned_client_identifier
-                .map(Property::into_inner)
-                .or(client_identifier)
-                .ok_or_else(|| {
-                    error!("server did not assign a client identifier when it was required.");
-                    self.raw.prepare_disconnect(ReasonCode::ProtocolError);
-                    MqttError::Server
-                })?;
+    /// Establishes a connection to an MQTT server over the provided [`Transport`] using
+    /// MQTTv5's enhanced authentication.
+    ///
+    /// Sends a CONNECT packet and executes an enhanced authentication exchange provided by
+    /// an [`AuthMechanism`] until a CONNACK response is sent by the server. For every AUTH
+    /// packet sent by the server, [`AuthMechanism::kontinue`] is called. For the final
+    /// CONNACK packet, [`AuthMechanism::success`] is called. The [`AuthMechanism`] may
+    /// detect an error in the authentication process or experience an internal error. In
+    /// this case, the exchange is interrupted, [`MqttError::EnhancedAuthFailed`] is returned
+    /// an optional DISCONNECT packet is scheduled to be sent with [`Client::abort`],
+    /// depending on the returned [`ReasonCode`] by the [`AuthMechanism`].
+    ///
+    /// The internal state of the client, including session information and negotiated server
+    /// capabilities is initialized.
+    ///
+    /// This function must only be called if:
+    /// - The client is newly constructed and has not yet been connected.
+    /// - A previous connection was closed gracefully via [`Client::disconnect`].
+    /// - An unrecoverable error occurred and the error handling was performed with
+    ///   [`Client::abort`].
+    ///
+    /// Configuration that was negotiated with the server is stored in the `client_config`,
+    /// `server_config`, `shared_config`, and `session` fields, which have getters
+    /// ([`Client::client_config`], [`Client::server_config`], [`Client::shared_config`],
+    /// [`Client::session`]).
+    ///
+    /// If the server indicates that no session is present (Session Present flag is 0), the
+    /// client's local session state is cleared. To persist state across connections,
+    /// call [`Client::session`] to clone the state before calling this method.
+    ///
+    /// # Returns
+    ///
+    /// - [`Ok(Connected)`]: Contains information from the CONNACK packet that is not persisted
+    ///   in the client's internal configuration fields.
+    /// - [`Err(MqttError)`]: If the connection attempt failed.
+    ///
+    /// # Errors
+    ///
+    /// * [`MqttError::Server`] if:
+    ///   * the server sends a malformed packet
+    ///   * the first received packet is something other than a CONNACK packet
+    ///   * `client_identifier` is [`None`] and the server did not assign a client identifier
+    ///   * the server causes a protocol error
+    ///   * the server sends Response Information despite `request_response_information` in [`ConnectOptions`]
+    ///     being 0
+    /// * [`MqttError::Disconnect`] if the CONNACK packet's reason code is not successful (>= 0x80)
+    /// * [`MqttError::Network`] if the underlying [`Transport`] returned an error
+    /// * [`MqttError::Alloc`] if the underlying [`BufferProvider`] returned an error
+    /// * [`MqttError::EnhancedAuthFailed`] if the [`AuthMechanism`] detected or experienced an
+    ///   error.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the length of the `user_properties` slice in the [`ConnectOptions`]
+    /// or the length of the `user_properties` slice in the [`WillOptions`] in [`ConnectOptions`]
+    /// is greater than `MAX_USER_PROPERTIES`.
+    ///
+    /// [`Ok(Connected)`]: crate::client::event::Connected
+    /// [`Err(MqttError)`]: crate::client::MqttError
+    /// [`WillOptions`]: crate::client::options::WillOptions
+    pub async fn connect_enhanced<'d, A>(
+        &mut self,
+        net: N,
+        options: &ConnectOptions<'_>,
+        client_identifier: Option<MqttString<'d>>,
+        authentication_method: MqttString<'a>,
+        mechanism: &mut A,
+    ) -> Result<Connected<'d, MAX_USER_PROPERTIES>, MqttError<'c, MAX_USER_PROPERTIES, A::Error>>
+    where
+        A: AuthMechanism<MAX_USER_PROPERTIES>,
+        'c: 'd,
+    {
+        self.raw.set_net(net);
 
-            if session_present {
-                if options.clean_start {
-                    error!("server set the session present flag when clean start was set");
+        // Set authentication method because it is required for future AUTH packets,
+        // and further checks for CONNACK and AUTH packets.
+        self.client_config.authentication_method = Some(authentication_method);
+
+        self.start_connect(
+            options,
+            client_identifier.as_ref().map(MqttString::as_borrowed),
+        )
+        .await
+        .map_err(MqttError::inflate)?;
+
+        let header = loop {
+            let header = self.raw.recv_header().await?;
+
+            match header.packet_type() {
+                Ok(ConnackPacket::<MAX_USER_PROPERTIES>::PACKET_TYPE) => {
+                    debug!(
+                        "received CONNACK packet header (remaining length: {})",
+                        header.remaining_len.value()
+                    );
+                    break header;
+                }
+                Ok(AuthPacket::<MAX_USER_PROPERTIES>::PACKET_TYPE) => debug!(
+                    "received AUTH packet header (remaining length: {})",
+                    header.remaining_len.value()
+                ),
+                Ok(t) => {
+                    error!("received unexpected {:?} packet header", t);
                     self.raw.prepare_disconnect(ReasonCode::ProtocolError);
                     return Err(MqttError::Server);
-                } else {
-                    info!("connected to server and reconnected to session");
-                    self.session.reconnect();
                 }
-            } else {
-                #[allow(clippy::if_same_then_else)]
-                if options.clean_start {
-                    info!("connected to server");
-                } else {
-                    info!(
-                        "connected to server but server does not have the requested session present"
-                    );
+                Err(_) => {
+                    error!("received invalid header {:?}", header);
+                    self.raw.prepare_disconnect(ReasonCode::MalformedPacket);
+                    return Err(MqttError::Server);
                 }
-                self.session.clear();
             }
 
-            self.shared_config.session_expiry_interval =
-                session_expiry_interval.unwrap_or(options.session_expiry_interval);
-            self.shared_config.keep_alive =
-                server_keep_alive.map_or(options.keep_alive, Property::into_inner);
+            let AuthPacket::<MAX_USER_PROPERTIES> {
+                reason_code,
+                authentication_method,
+                authentication_data,
+                reason_string,
+                user_properties,
+            } = self.raw.recv_body(&header).await?;
 
-            if let Some(r) = receive_maximum {
-                self.server_config.receive_maximum = r.into_inner();
-            }
-            if let Some(m) = maximum_qos {
-                self.server_config.maximum_qos = m.into_inner();
-            }
-            if let Some(r) = retain_available {
-                self.server_config.retain_supported = r.into_inner();
-            }
-            if let Some(m) = maximum_packet_size {
-                self.server_config.maximum_packet_size = m;
-            }
-            if let Some(t) = topic_alias_maximum {
-                self.server_config.topic_alias_maximum = t.into_inner();
-            }
-            if let Some(w) = wildcard_subscription_available {
-                self.server_config.wildcard_subscription_supported = w.into_inner();
-            }
-            if let Some(s) = subscription_identifier_available {
-                self.server_config.subscription_identifiers_supported = s.into_inner();
-            }
-            if let Some(s) = shared_subscription_available {
-                self.server_config.shared_subscription_supported = s.into_inner();
+            if reason_code != ReasonCode::ContinueAuthentication {
+                error!("server sent invalid AUTH reason code");
+                self.raw.prepare_disconnect(ReasonCode::ProtocolError);
+                return Err(MqttError::Server);
             }
 
-            Ok(Connected {
-                session_present,
-                client_identifier,
-                user_properties: user_properties
-                    .into_iter()
-                    .map(Property::into_inner)
-                    .collect(),
-                response_information: response_information.map(Property::into_inner),
-                server_reference: server_reference.map(Property::into_inner),
-            })
-        } else {
-            debug!("CONNACK packet indicates rejection");
-            info!("connection rejected by server (reason: {:?})", reason_code);
+            if !self.client_config.request_problem_information
+                && (reason_string.is_some() || !user_properties.is_empty())
+            {
+                error!(
+                    "server sent reason string or user properties when request problem information was false"
+                );
+                self.raw.prepare_disconnect(ReasonCode::ProtocolError);
+                return Err(MqttError::Server);
+            }
 
-            self.raw.prepare_close();
+            if &authentication_method.into_inner()
+                != self.client_config.authentication_method.as_ref().unwrap()
+            {
+                error!("server sent an authentication method different from the required value");
+                self.raw.prepare_disconnect(ReasonCode::ProtocolError);
+                return Err(MqttError::Server);
+            }
 
-            info!("disconnected from server");
-
-            Err(MqttError::Disconnect {
-                reason: reason_code,
+            let event = Auth::<MAX_USER_PROPERTIES> {
+                reason_code,
+                authentication_data: authentication_data.map(Property::into_inner),
                 reason_string: reason_string.map(Property::into_inner),
                 user_properties: user_properties
                     .into_iter()
                     .map(Property::into_inner)
                     .collect(),
-                server_reference: server_reference.map(Property::into_inner),
-            })
+            };
+
+            let AuthOptions::<MAX_USER_PROPERTIES> {
+                authentication_data,
+                reason_string,
+                user_properties,
+            } = match mechanism.kontinue(&event) {
+                Ok(a) => a,
+                Err((e, reason_code)) => {
+                    error!("authentication failed");
+
+                    match reason_code {
+                        Some(
+                            r @ (ReasonCode::Success
+                            | ReasonCode::DisconnectWithWillMessage
+                            | ReasonCode::UnspecifiedError
+                            | ReasonCode::MalformedPacket
+                            | ReasonCode::ProtocolError
+                            | ReasonCode::ImplementationSpecificError
+                            | ReasonCode::TopicNameInvalid
+                            | ReasonCode::ReceiveMaximumExceeded
+                            | ReasonCode::TopicAliasInvalid
+                            | ReasonCode::PacketTooLarge
+                            | ReasonCode::MessageRateTooHigh
+                            | ReasonCode::QuotaExceeded
+                            | ReasonCode::AdministrativeAction
+                            | ReasonCode::PayloadFormatInvalid),
+                        ) => {
+                            self.raw.prepare_disconnect(r);
+                        }
+                        Some(_) => {
+                            warn!("invalid DISCONNECT reason code returned by auth mechanism");
+
+                            self.raw.prepare_close();
+                        }
+                        None => self.raw.prepare_close(),
+                    }
+
+                    return Err(MqttError::EnhancedAuthFailed(e));
+                }
+            };
+
+            let packet = AuthPacket::<MAX_USER_PROPERTIES>::new(
+                ReasonCode::ContinueAuthentication,
+                self.client_config
+                    .authentication_method
+                    .as_ref()
+                    .unwrap()
+                    .as_borrowed()
+                    .into(),
+                authentication_data.map(Into::into),
+                reason_string.map(Into::into),
+                user_properties.into_iter().map(Into::into).collect(),
+            );
+
+            debug!("sending AUTH packet");
+
+            self.raw.send(&packet).await?;
+            self.raw.flush().await?;
+        };
+
+        let c = self
+            .complete_connect(header, options, client_identifier)
+            .await?;
+
+        if let Err((e, reason_code)) = mechanism.success(&Auth::<MAX_USER_PROPERTIES> {
+            reason_code: ReasonCode::Success,
+            authentication_data: c.authentication_data.as_ref().map(MqttBinary::as_borrowed),
+            reason_string: None,
+            user_properties: c
+                .user_properties
+                .iter()
+                .map(MqttStringPair::as_borrowed)
+                .collect(),
+        }) {
+            error!("authentication failed");
+
+            if let Some(reason_code) = reason_code {
+                self.raw.prepare_disconnect(reason_code);
+            } else {
+                self.raw.prepare_close();
+            }
+
+            return Err(MqttError::EnhancedAuthFailed(e));
         }
+
+        info!("connected to server");
+
+        Ok(c)
     }
 
     /// Start a ping handshake by sending a PINGRESP packet.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -218,7 +218,7 @@ impl<
 > defmt::Format
     for Client<
         '_,
-        '_,
+        'c,
         N,
         B,
         SUBSCRIBE_MAXIMUM,

--- a/src/client/options/auth.rs
+++ b/src/client/options/auth.rs
@@ -1,0 +1,63 @@
+use const_fn::const_fn;
+
+use crate::types::{MqttBinary, MqttString, MqttStringPair};
+
+/// Options for enhanced re-authentication for the AUTH packet.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Options<'a> {
+    /// The authentication data property of the AUTH packet.
+    pub authentication_data: Option<MqttBinary<'a>>,
+
+    /// The reason string property of the AUTH packet.
+    pub reason_string: Option<MqttString<'a>>,
+
+    /// Arbitrary key-value pairs of strings sent as the user property entries of the AUTH packet.
+    /// Note that this slice's length must be less than [`Client`]'s const generic parameter
+    /// `MAX_USER_PROPERTIES`.
+    ///
+    /// [`Client`]: crate::client::Client
+    pub user_properties: &'a [MqttStringPair<'a>],
+}
+
+impl Default for Options<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'a> Options<'a> {
+    /// Creates new authentication options without properties.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            authentication_data: None,
+            reason_string: None,
+            user_properties: &[],
+        }
+    }
+
+    /// Sets the authentication data property.
+    #[const_fn(cfg(not(feature = "alloc")))]
+    #[must_use]
+    pub const fn authentication_data(mut self, authentication_data: MqttBinary<'a>) -> Self {
+        self.authentication_data = Some(authentication_data);
+        self
+    }
+    /// Sets the reason string property.
+    #[const_fn(cfg(not(feature = "alloc")))]
+    #[must_use]
+    pub const fn reason_string(mut self, reason_string: MqttString<'a>) -> Self {
+        self.reason_string = Some(reason_string);
+        self
+    }
+    /// Sets the user properties. Note that this slice's length must be less than [`Client`]'s
+    /// const generic parameter `MAX_USER_PROPERTIES`.
+    ///
+    /// [`Client`]: crate::client::Client
+    #[must_use]
+    pub const fn user_properties(mut self, user_properties: &'a [MqttStringPair<'a>]) -> Self {
+        self.user_properties = user_properties;
+        self
+    }
+}

--- a/src/client/options/connect.rs
+++ b/src/client/options/connect.rs
@@ -47,6 +47,9 @@ pub struct Options<'c> {
     /// [`Client`]: crate::client::Client
     pub user_properties: &'c [MqttStringPair<'c>],
 
+    /// The authentication data property of the CONNECT packet.
+    pub authentication_data: Option<MqttBinary<'c>>,
+
     /// The user name the client wishes to authenticate with.
     pub user_name: Option<MqttString<'c>>,
     /// The password the client wishes to perform basic authentication with.
@@ -77,6 +80,7 @@ impl<'c> Options<'c> {
             request_response_information: false,
             request_problem_information: false,
             user_properties: &[],
+            authentication_data: None,
             user_name: None,
             password: None,
             will: None,
@@ -129,6 +133,13 @@ impl<'c> Options<'c> {
     #[must_use]
     pub const fn user_properties(mut self, user_properties: &'c [MqttStringPair<'c>]) -> Self {
         self.user_properties = user_properties;
+        self
+    }
+    /// Sets the authentication data property of the CONNECT packet.
+    #[const_fn(cfg(not(feature = "alloc")))]
+    #[must_use]
+    pub const fn authentication_data(mut self, authentication_data: MqttBinary<'c>) -> Self {
+        self.authentication_data = Some(authentication_data);
         self
     }
     /// Sets the user name.

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -1,6 +1,7 @@
 //! Contains user-facing option types for configuring client actions.
 
 mod ack;
+mod auth;
 mod connect;
 mod disconnect;
 mod publish;
@@ -9,6 +10,7 @@ mod unsubscribe;
 mod will;
 
 pub use ack::{Mode as AckMode, Options as AckOptions};
+pub use auth::Options as ReAuthOptions;
 pub use connect::Options as ConnectOptions;
 pub use disconnect::Options as DisconnectOptions;
 pub use publish::{Options as PublicationOptions, TopicReference};

--- a/src/config/client.rs
+++ b/src/config/client.rs
@@ -1,4 +1,7 @@
-use crate::{config::SessionExpiryInterval, types::VarByteInt};
+use crate::{
+    config::SessionExpiryInterval,
+    types::{MqttString, VarByteInt},
+};
 
 /// Configuration of the client which must be upheld by the server.
 /// These values are used by the client to enforce protocol correctness.
@@ -8,9 +11,9 @@ use crate::{config::SessionExpiryInterval, types::VarByteInt};
 ///   and is therefore not required as an in-memory value.
 /// * Client's topic alias maximum: incoming topic aliases are currently not supported,
 ///   this is configured into the protocol via a topic alias maximum value of 0.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Config {
+pub struct Config<'a> {
     /// The session expiry interval requested by the client. Note that this is NOT
     /// necessarily the actual session expiry interval value in force which is used by
     /// the server, as the server can overwrite this value in its CONNACK packet. The
@@ -53,14 +56,31 @@ pub struct Config {
     /// [`Client::connect`]: crate::client::Client::connect
     /// [`ConnectOptions`]: crate::client::options::ConnectOptions
     pub request_problem_information: bool,
+
+    /// The authentication method that was sent in the CONNECT packet.
+    ///
+    /// - If no authentication method was used ([`None`]):
+    ///   - neither server nor client must send AUTH packets -> re-authentication is not
+    ///     possible.
+    ///   - the server must not send an authentication method in its CONNACK packet.
+    /// - If an authentication method was used ([`Some`]):
+    ///   - any AUTH packets sent by either server or client must contain the same
+    ///     authentication method.
+    ///   - if the server rejects the connection attempt with an erroneous CONNACK packet,
+    ///     this CONNACK packet does not have to contain this authentication method value.
+    ///   - if the server accepts this connection attempt, the CONNACK packet must contain
+    ///     the same authentication method.
+    ///   - re-authentication at any time after receiving the CONNACK is possible.
+    pub authentication_method: Option<MqttString<'a>>,
 }
 
-impl Default for Config {
+impl Default for Config<'_> {
     fn default() -> Self {
         Self {
             session_expiry_interval: SessionExpiryInterval::default(),
             maximum_accepted_remaining_length: VarByteInt::MAX_ENCODABLE,
             request_problem_information: false,
+            authentication_method: None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ mod bytes;
 mod fmt;
 mod packet;
 
+pub mod auth;
 pub mod buffer;
 pub mod client;
 pub mod config;

--- a/src/v5/packet/auth.rs
+++ b/src/v5/packet/auth.rs
@@ -1,0 +1,427 @@
+use heapless::Vec;
+
+use crate::{
+    buffer::BufferProvider,
+    eio::{Read, Write},
+    fmt::{const_assert, trace, verbose},
+    header::{FixedHeader, PacketType},
+    io::{
+        read::{BodyReader, Readable},
+        write::{Writable, wlen},
+    },
+    packet::{Packet, RxError, RxPacket, TxError, TxPacket},
+    types::{ReasonCode, VarByteInt},
+    v5::property::{
+        AtMostOnceProperty, AuthenticationData, AuthenticationMethod, PropertyType, ReasonString,
+        UserProperty,
+    },
+};
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct AuthPacket<'p, const MAX_USER_PROPERTIES: usize> {
+    pub reason_code: ReasonCode,
+
+    pub authentication_method: AuthenticationMethod<'p>,
+    pub authentication_data: Option<AuthenticationData<'p>>,
+    pub reason_string: Option<ReasonString<'p>>,
+    pub user_properties: Vec<UserProperty<'p>, MAX_USER_PROPERTIES>,
+}
+
+impl<const MAX_USER_PROPERTIES: usize> Packet for AuthPacket<'_, MAX_USER_PROPERTIES> {
+    const PACKET_TYPE: PacketType = PacketType::Auth;
+}
+impl<'p, const MAX_USER_PROPERTIES: usize> RxPacket<'p> for AuthPacket<'p, MAX_USER_PROPERTIES> {
+    async fn receive<R: Read, B: BufferProvider<'p>>(
+        header: &FixedHeader,
+        mut reader: BodyReader<'_, 'p, R, B>,
+    ) -> Result<Self, RxError<R::Error, B::ProvisionError>> {
+        trace!("decoding AUTH packet");
+
+        if header.flags() != 0 {
+            trace!("invalid AUTH fixed header flags: {}", header.flags());
+            return Err(RxError::MalformedPacket);
+        }
+
+        let r = &mut reader;
+
+        let authenticate_reason_code = if header.remaining_len.size() == 0 {
+            verbose!("received minimal AUTH packet");
+            // Despite the specification allowing this, this is a protocol error because the authentication method
+            // must always be present and therefore some properties are always present and the abbreviation
+            // cannot be taken.
+            return Err(RxError::ProtocolError);
+        } else {
+            verbose!("reading reason code field");
+            ReasonCode::read(r).await?
+        };
+
+        if !matches!(
+            authenticate_reason_code,
+            ReasonCode::Success | ReasonCode::ContinueAuthentication | ReasonCode::ReAuthenticate
+        ) {
+            trace!("invalid AUTH reason code: {:?}", authenticate_reason_code);
+            return Err(RxError::ProtocolError);
+        }
+
+        verbose!("reading property length field");
+        let properties_length = VarByteInt::read(r).await?.size();
+
+        verbose!("property length: {} bytes", properties_length);
+
+        if r.remaining_len() != properties_length {
+            trace!("invalid AUTH property length for remaining packet length");
+            return Err(RxError::MalformedPacket);
+        }
+
+        let mut authentication_method = None;
+        let mut authentication_data = None;
+        let mut reason_string = None;
+        let mut user_properties = Vec::new();
+
+        while r.remaining_len() > 0 {
+            verbose!(
+                "reading property identifier (remaining length: {} bytes)",
+                r.remaining_len()
+            );
+            let property_type = PropertyType::read(r).await?;
+
+            verbose!(
+                "reading {:?} property body (remaining length: {} bytes)",
+                property_type,
+                r.remaining_len()
+            );
+            match property_type {
+                PropertyType::AuthenticationMethod => authentication_method.try_set(r).await?,
+                PropertyType::AuthenticationData => authentication_data.try_set(r).await?,
+                PropertyType::ReasonString => reason_string.try_set(r).await?,
+                PropertyType::UserProperty if !user_properties.is_full() => {
+                    let user_property = UserProperty::read(r).await?;
+
+                    // Safety: `!Vec::is_full` guarantees there is space
+                    unsafe { user_properties.push_unchecked(user_property) };
+                }
+                PropertyType::UserProperty => {
+                    UserProperty::skip(r).await?;
+                }
+                // Malformed packet according to <https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901029>
+                p => {
+                    trace!("invalid AUTH property: {:?}", p);
+                    return Err(RxError::MalformedPacket);
+                }
+            };
+        }
+
+        let Some(authentication_method) = authentication_method else {
+            trace!("authentication method property missing from AUTH packet");
+            return Err(RxError::ProtocolError);
+        };
+
+        Ok(Self {
+            reason_code: authenticate_reason_code,
+            authentication_method,
+            authentication_data,
+            reason_string,
+            user_properties,
+        })
+    }
+}
+impl<const MAX_USER_PROPERTIES: usize> TxPacket for AuthPacket<'_, MAX_USER_PROPERTIES> {
+    async fn send<W: Write>(&self, write: &mut W) -> Result<(), TxError<W::Error>> {
+        FixedHeader::new(Self::PACKET_TYPE, 0x00, self.remaining_len())
+            .write(write)
+            .await?;
+
+        self.reason_code.write(write).await?;
+
+        let properties_length = self.properties_length();
+        properties_length.write(write).await?;
+
+        self.authentication_method.write(write).await?;
+        self.authentication_data.write(write).await?;
+        self.reason_string.write(write).await?;
+
+        for user_property in &self.user_properties {
+            user_property.write(write).await?;
+        }
+
+        Ok(())
+    }
+
+    fn remaining_len(&self) -> VarByteInt {
+        let variable_header_length = wlen!(ReasonCode);
+
+        let properties_length = self.properties_length();
+        let total_properties_length = properties_length.size() + properties_length.written_len();
+
+        let total_length = variable_header_length + total_properties_length;
+
+        // max length = MAX_USER_PROPERTIES * 131077 + 196619
+        // Invariant: MAX_USER_PROPERTIES <= 2046 => max length <= VarByteInt::MAX_ENCODABLE
+        // variable header (reason_code): 1
+        // property length: 4
+        // properties: MAX_USER_PROPERTIES * 131077 + 196614
+        VarByteInt::new_unchecked(total_length as u32)
+    }
+}
+
+impl<'p, const MAX_USER_PROPERTIES: usize> AuthPacket<'p, MAX_USER_PROPERTIES> {
+    pub const fn new(
+        reason_code: ReasonCode,
+        authentication_method: AuthenticationMethod<'p>,
+        authentication_data: Option<AuthenticationData<'p>>,
+        reason_string: Option<ReasonString<'p>>,
+        user_properties: Vec<UserProperty<'p>, MAX_USER_PROPERTIES>,
+    ) -> Self {
+        const {
+            const_assert!(MAX_USER_PROPERTIES <= 2046);
+        }
+
+        Self {
+            reason_code,
+            authentication_method,
+            authentication_data,
+            reason_string,
+            user_properties,
+        }
+    }
+
+    fn properties_length(&self) -> VarByteInt {
+        let len = self.authentication_method.written_len()
+            + self.authentication_data.written_len()
+            + self.reason_string.written_len()
+            + self
+                .user_properties
+                .iter()
+                .map(Writable::written_len)
+                .sum::<usize>();
+
+        // max length = MAX_USER_PROPERTIES * 131077 + 196614
+        // Invariant: MAX_USER_PROPERTIES <= 2046 => max length <= VarByteInt::MAX_ENCODABLE
+        //
+        // authentication method: 65538
+        // authentication data: 65538
+        // reason string: 65538
+        // user properties: MAX_USER_PROPERTIES * 131077
+        VarByteInt::new_unchecked(len as u32)
+    }
+}
+
+#[cfg(test)]
+mod unit {
+    use heapless::Vec;
+
+    use crate::{
+        test::{rx::decode, tx::encode},
+        types::{MqttBinary, MqttString, MqttStringPair, ReasonCode},
+        v5::{packet::AuthPacket, property::UserProperty},
+    };
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn encode_simple() {
+        let packet = AuthPacket::<16>::new(
+            ReasonCode::ContinueAuthentication,
+            MqttString::from_str("").unwrap().into(),
+            None,
+            None,
+            Vec::new(),
+        );
+
+        #[rustfmt::skip]
+        encode!(packet, [
+            0xF0, //
+            0x05, // remaining length
+            0x18, // reason code
+
+            0x03, // property length
+
+            // Authentication Method
+            0x15, 0x00, 0x00,
+        ]);
+    }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn encode_properties() {
+        let packet = AuthPacket::<16>::new(
+            ReasonCode::ReAuthenticate,
+            MqttString::try_from("SCRAM-SHA-1").unwrap().into(),
+            Some(
+                MqttBinary::try_from("n,,n=user,r=fyko+d2lbbFgONRv9qkxdawL")
+                    .unwrap()
+                    .into(),
+            ),
+            Some(MqttString::try_from("LET ME IN").unwrap().into()),
+            [
+                UserProperty(MqttStringPair::new(
+                    MqttString::from_str("a").unwrap(),
+                    MqttString::from_str("b").unwrap(),
+                )),
+                UserProperty(MqttStringPair::new(
+                    MqttString::from_str("b").unwrap(),
+                    MqttString::from_str("c").unwrap(),
+                )),
+                UserProperty(MqttStringPair::new(
+                    MqttString::from_str("c").unwrap(),
+                    MqttString::from_str("a").unwrap(),
+                )),
+            ]
+            .into(),
+        );
+
+        #[rustfmt::skip]
+        encode!(packet, [
+                0xF0, //
+                0x58, // remaining length
+                0x19, // reason code
+                0x56, // property length
+
+                // Authentication Method
+                0x15, 0x00, 0x0B, b'S', b'C', b'R', b'A', b'M', b'-', b'S', b'H', b'A', b'-', b'1',
+
+                // Authentication Data
+                0x16, 0x00, 0x24, b'n', b',', b',', b'n', b'=', b'u', b's', b'e', b'r', b',', b'r', b'=', b'f', b'y', b'k', b'o', b'+',
+                b'd', b'2', b'l', b'b', b'b', b'F', b'g', b'O', b'N', b'R', b'v', b'9', b'q', b'k', b'x', b'd', b'a', b'w', b'L',
+
+                // Reason String
+                0x1F, 0x00, 0x09, b'L', b'E', b'T', b' ', b'M', b'E', b' ', b'I', b'N',
+
+                0x26,       // User property
+                0x00, 0x01, b'a',
+                0x00, 0x01, b'b',
+
+                0x26,       // User property
+                0x00, 0x01, b'b',
+                0x00, 0x01, b'c',
+
+                0x26,       // User property
+                0x00, 0x01, b'c',
+                0x00, 0x01, b'a',
+            ]
+        );
+    }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn decode_simple() {
+        let packet = decode!(
+            AuthPacket<16>,
+            5,
+            [0xF0, 0x05, 0x00, 0x03, 0x15, 0x00, 0x00]
+        );
+
+        assert_eq!(packet.reason_code, ReasonCode::Success);
+        assert_eq!(
+            packet.authentication_method,
+            MqttString::from_str("").unwrap().into()
+        );
+        assert!(packet.authentication_data.is_none());
+        assert!(packet.reason_string.is_none());
+        assert!(packet.user_properties.is_empty());
+    }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn decode_properties() {
+        #[rustfmt::skip]
+        let packet = decode!(AuthPacket<16>, 78, [
+            0xF0,
+            0x4E,
+            0x19, // Reason code
+            0x4C, // Property length
+
+            // User Property
+            0x26, 0x00, 0x03, b'l', b'e', b'd',
+                  0x00, 0x08, b'z', b'e', b'p', b'p', b'e', b'l', b'i', b'n',
+
+            // Reason String
+            0x1F, 0x00, 0x04, b'g', b'o', b'n', b'e',
+
+            // Authentication Data
+            0x16, 0x00, 0x03, b'1', b'.', b'4',
+
+            // User Property
+            0x26, 0x00, 0x02, b'A', b'C',
+                  0x00, 0x02, b'D', b'C',
+
+            // User Property
+            0x26, 0x00, 0x01, b'U',
+                  0x00, 0x01, b'2',
+
+            // Authentication Method
+            0x15, 0x00, 0x1C, b'b', b'e', b'a', b'r', b'd', b'_', b'l', b'e', b'n', b'g', b't', b'h', b'_',
+            b't', b'o', b'_', b'w', b'i', b's', b'd', b'o', b'm', b'_', b'r', b'a', b't', b'i', b'o',
+        ]);
+
+        assert_eq!(packet.reason_code, ReasonCode::ReAuthenticate);
+        assert_eq!(
+            packet.authentication_method,
+            MqttString::try_from("beard_length_to_wisdom_ratio")
+                .unwrap()
+                .into()
+        );
+        assert_eq!(
+            packet.authentication_data,
+            Some(MqttBinary::try_from("1.4".as_bytes()).unwrap().into())
+        );
+        assert_eq!(
+            packet.reason_string,
+            Some(MqttString::try_from("gone").unwrap().into())
+        );
+        assert_eq!(
+            packet.user_properties.as_slice(),
+            &[
+                UserProperty(MqttStringPair::new(
+                    MqttString::from_str("led").unwrap(),
+                    MqttString::from_str("zeppelin").unwrap()
+                )),
+                UserProperty(MqttStringPair::new(
+                    MqttString::from_str("AC").unwrap(),
+                    MqttString::from_str("DC").unwrap()
+                )),
+                UserProperty(MqttStringPair::new(
+                    MqttString::from_str("U").unwrap(),
+                    MqttString::from_str("2").unwrap()
+                ))
+            ]
+        );
+    }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn decode_incomplete_user_properties() {
+        #[rustfmt::skip]
+        let packet = decode!(AuthPacket<1>, 179, [
+            0xF0,
+            0xB3, 0x01,
+            0x00, // Reason code
+            0xB0, 0x01, // Property length
+
+            // User Property
+            0x26, 0x00, 0x22, b'S', b'h', b'a', b'k', b'e', b' ', b'V', b'e', b'l', b'o', b'c', b'i', b't', b'y', b' ', b'(',
+                  b'C', b'e', b'n', b't', b'r', b'i', b'f', b'u', b'g', b'a', b'l', b' ', b'F', b'o', b'r', b'c', b'e', b')',
+                  0x00, 0x31, b'4', b'.', b'3', b' ', b'G', b'-', b'F', b'o', b'r', b'c', b'e', b's', b' ', b'(', b'S', b'u', b'f', b'f', b'i', b'c', b'i', b'e', b'n', b't',
+                  b' ', b't', b'o', b' ', b'b', b'y', b'p', b'a', b's', b's', b' ', b'a', b'l', b'l', b' ', b'r', b'a', b'i', b'n', b'c', b'o', b'a', b't', b's', b')',
+
+            // User Property
+            0x26, 0x00, 0x13, b'F', b'l', b'o', b'o', b'f', b' ', b'D', b'e', b'c', b'o', b'm', b'p', b'r', b'e', b's', b's', b'i', b'o', b'n',
+                  0x00, 0x14, b'2', b'0', b'0', b'%', b' ', b'V', b'o', b'l', b'u', b'm', b'e', b' ', b'I', b'n', b'c', b'r', b'e', b'a', b's', b'e',
+
+            // Authentication Method
+            0x15, 0x00, 0x00,
+
+            // User Property
+            0x26, 0x00, 0x19, b'C', b'o', b'u', b'c', b'h', b' ', b'C', b'o', b'n', b't', b'a', b'm', b'i', b'n', b'a', b't', b'i', b'o', b'n', b' ', b'S', b'p', b'e', b'e', b'd',
+                  0x00, 0x0B, b'0', b'.', b'4', b' ', b'S', b'e', b'c', b'o', b'n', b'd', b's',
+        ]);
+
+        assert_eq!(
+            packet.user_properties.as_slice(),
+            &[UserProperty(MqttStringPair::new(
+                MqttString::from_str("Shake Velocity (Centrifugal Force)").unwrap(),
+                MqttString::from_str("4.3 G-Forces (Sufficient to bypass all raincoats)").unwrap()
+            ))]
+        );
+    }
+}

--- a/src/v5/packet/connack.rs
+++ b/src/v5/packet/connack.rs
@@ -10,10 +10,11 @@ use crate::{
     packet::{Packet, RxError, RxPacket},
     types::{ReasonCode, VarByteInt},
     v5::property::{
-        AssignedClientIdentifier, AtMostOnceProperty, MaximumQoS, PropertyType, ReasonString,
-        ReceiveMaximum, ResponseInformation, RetainAvailable, ServerKeepAlive, ServerReference,
-        SharedSubscriptionAvailable, SubscriptionIdentifierAvailable, TopicAliasMaximum,
-        UserProperty, WildcardSubscriptionAvailable,
+        AssignedClientIdentifier, AtMostOnceProperty, AuthenticationData, AuthenticationMethod,
+        MaximumQoS, PropertyType, ReasonString, ReceiveMaximum, ResponseInformation,
+        RetainAvailable, ServerKeepAlive, ServerReference, SharedSubscriptionAvailable,
+        SubscriptionIdentifierAvailable, TopicAliasMaximum, UserProperty,
+        WildcardSubscriptionAvailable,
     },
 };
 
@@ -39,10 +40,8 @@ pub struct ConnackPacket<'p, const MAX_USER_PROPERTIES: usize> {
     pub server_keep_alive: Option<ServerKeepAlive>,
     pub response_information: Option<ResponseInformation<'p>>,
     pub server_reference: Option<ServerReference<'p>>,
-    // authentication method is currently unused and does not have to be read into memory.
-    // pub authentication_method: Option<AuthenticationMethod<'p>>,
-    // authentication data is currently unused and does not have to be read into memory.
-    // pub authentication_data: Option<AuthenticationData<'p>>,
+    pub authentication_method: Option<AuthenticationMethod<'p>>,
+    pub authentication_data: Option<AuthenticationData<'p>>,
 }
 
 impl<const MAX_USER_PROPERTIES: usize> Packet for ConnackPacket<'_, MAX_USER_PROPERTIES> {
@@ -126,9 +125,8 @@ impl<'p, const MAX_USER_PROPERTIES: usize> RxPacket<'p> for ConnackPacket<'p, MA
         let mut server_keep_alive = None;
         let mut response_information = None;
         let mut server_reference = None;
-
-        let mut seen_authentication_method = false;
-        let mut seen_authentication_data = false;
+        let mut authentication_method = None;
+        let mut authentication_data = None;
 
         while r.remaining_len() > 0 {
             verbose!(
@@ -167,20 +165,8 @@ impl<'p, const MAX_USER_PROPERTIES: usize> RxPacket<'p> for ConnackPacket<'p, MA
                 PropertyType::ServerKeepAlive => server_keep_alive.try_set(r).await?,
                 PropertyType::ResponseInformation => response_information.try_set(r).await?,
                 PropertyType::ServerReference => server_reference.try_set(r).await?,
-                PropertyType::AuthenticationMethod if seen_authentication_method => return Err(RxError::ProtocolError),
-                PropertyType::AuthenticationMethod => {
-                    seen_authentication_method = true;
-                    let len = u16::read(r).await? as usize;
-                    verbose!("skipping authentication method ({} bytes)", len);
-                    r.skip(len).await?;
-                }
-                PropertyType::AuthenticationData if seen_authentication_data => return Err(RxError::ProtocolError),
-                PropertyType::AuthenticationData => {
-                    seen_authentication_data = true;
-                    let len = u16::read(r).await? as usize;
-                    verbose!("skipping authentication data ({} bytes)", len);
-                    r.skip(len).await?;
-                }
+                PropertyType::AuthenticationMethod => authentication_method.try_set(r).await?,
+                PropertyType::AuthenticationData => authentication_data.try_set(r).await?,
                 p => {
                     // Malformed packet according to <https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901029>
                     trace!("invalid CONNACK property: {:?}", p);
@@ -207,6 +193,8 @@ impl<'p, const MAX_USER_PROPERTIES: usize> RxPacket<'p> for ConnackPacket<'p, MA
             server_keep_alive,
             response_information,
             server_reference,
+            authentication_method,
+            authentication_data,
         })
     }
 }
@@ -218,14 +206,15 @@ mod unit {
     use crate::{
         config::{KeepAlive, MaximumPacketSize, SessionExpiryInterval},
         test::rx::decode,
-        types::{MqttString, MqttStringPair, QoS, ReasonCode},
+        types::{MqttBinary, MqttString, MqttStringPair, QoS, ReasonCode},
         v5::{
             packet::ConnackPacket,
             property::{
-                AssignedClientIdentifier, MaximumQoS, ReasonString, ReceiveMaximum,
-                ResponseInformation, RetainAvailable, ServerKeepAlive, ServerReference,
-                SharedSubscriptionAvailable, SubscriptionIdentifierAvailable, TopicAliasMaximum,
-                UserProperty, WildcardSubscriptionAvailable,
+                AssignedClientIdentifier, AuthenticationData, AuthenticationMethod, MaximumQoS,
+                ReasonString, ReceiveMaximum, ResponseInformation, RetainAvailable,
+                ServerKeepAlive, ServerReference, SharedSubscriptionAvailable,
+                SubscriptionIdentifierAvailable, TopicAliasMaximum, UserProperty,
+                WildcardSubscriptionAvailable,
             },
         },
     };
@@ -253,8 +242,8 @@ mod unit {
         assert!(packet.server_keep_alive.is_none());
         assert!(packet.response_information.is_none());
         assert!(packet.server_reference.is_none());
-        // assert!(packet.authentication_method.is_none());
-        // assert!(packet.authentication_data.is_none());
+        assert!(packet.authentication_method.is_none());
+        assert!(packet.authentication_data.is_none());
     }
 
     #[tokio::test]
@@ -393,18 +382,18 @@ mod unit {
                 MqttString::try_from("server.example.com").unwrap()
             ))
         );
-        // assert_eq!(
-        //     packet.authentication_method,
-        //     Some(AuthenticationMethod(
-        //         MqttString::try_from("SCRAM-SHA-256").unwrap()
-        //     ))
-        // );
-        // assert_eq!(
-        //     packet.authentication_data,
-        //     Some(AuthenticationData(
-        //         MqttBinary::try_from("auth_data".as_bytes()).unwrap()
-        //     ))
-        // );
+        assert_eq!(
+            packet.authentication_method,
+            Some(AuthenticationMethod(
+                MqttString::try_from("SCRAM-SHA-256").unwrap()
+            ))
+        );
+        assert_eq!(
+            packet.authentication_data,
+            Some(AuthenticationData(
+                MqttBinary::try_from("auth_data".as_bytes()).unwrap()
+            ))
+        );
     }
 
     #[tokio::test]

--- a/src/v5/packet/connect.rs
+++ b/src/v5/packet/connect.rs
@@ -206,6 +206,13 @@ impl<'p, const MAX_USER_PROPERTIES: usize> ConnectPacket<'p, MAX_USER_PROPERTIES
         VarByteInt::new_unchecked(len as u32)
     }
 
+    pub fn add_authentication_method(&mut self, authentication_method: AuthenticationMethod<'p>) {
+        self.authentication_method = Some(authentication_method);
+    }
+    pub fn add_authentication_data(&mut self, authentication_data: AuthenticationData<'p>) {
+        self.authentication_data = Some(authentication_data);
+    }
+
     pub fn add_user_name(&mut self, user_name: MqttString<'p>) {
         self.user_name = Some(user_name);
     }
@@ -283,7 +290,7 @@ mod unit {
     #[tokio::test]
     #[test_log::test]
     async fn encode_properties() {
-        let packet = ConnectPacket::<16>::new(
+        let mut packet = ConnectPacket::<16>::new(
             MqttString::try_from("a").unwrap(),
             false,
             KeepAlive::Infinite,
@@ -309,10 +316,22 @@ mod unit {
             .into(),
         );
 
+        packet.add_authentication_method(
+            MqttString::from_str("browser_tab_entropy_verification")
+                .unwrap()
+                .into(),
+        );
+        packet.add_authentication_data(
+            MqttBinary::from_slice("tabs=247;unknown_tab_playing_music=true".as_bytes())
+                .unwrap()
+                .into(),
+        );
+
         #[rustfmt::skip]
         encode!(packet, [
             0x10,       //
-            0x54,       // remaining length
+            0xA2,       // remaining length
+            0x01,       // remaining length
             0x00,       // ---
             0x04,       //
             b'M',       //
@@ -323,7 +342,8 @@ mod unit {
             0b00000000, // Connect flags
             0x00,       // Keep alive MSB
             0x00,       // Keep alive LSB
-            0x46,       // Property length
+            0x93,       // Property length
+            0x01,       // Property length
 
             0x11,       // Session expiry interval
             0x00, 0x7C, 0x26, 0xC7,
@@ -349,6 +369,14 @@ mod unit {
             0x26,       // User property
             0x00, 0x08, b't', b'r', b'i', b'p', b'l', b'e', b' ', b'3',
             0x00, 0x05, b't', b'r', b'a', b'c', b'k',
+
+            0x15,       // Authentication Method
+            0x00, 0x20, b'b', b'r', b'o', b'w', b's', b'e', b'r', b'_', b't', b'a', b'b', b'_', b'e', b'n', b't',
+            b'r', b'o', b'p', b'y', b'_', b'v', b'e', b'r', b'i', b'f', b'i', b'c', b'a', b't', b'i', b'o', b'n',
+
+            0x16,       // Authentication Data
+            0x00, 0x27, b't', b'a', b'b', b's', b'=', b'2', b'4', b'7', b';', b'u', b'n', b'k', b'n', b'o', b'w', b'n', b'_', b't', b'a',
+            b'b', b'_', b'p', b'l', b'a', b'y', b'i', b'n', b'g', b'_', b'm', b'u', b's', b'i', b'c', b'=', b't', b'r', b'u', b'e',
 
             0x00,       // Client identifier len MSB
             0x01,       // Client identifier len LSB

--- a/src/v5/packet/mod.rs
+++ b/src/v5/packet/mod.rs
@@ -1,4 +1,4 @@
-// mod auth;
+mod auth;
 mod connack;
 mod connect;
 mod disconnect;
@@ -9,7 +9,7 @@ mod subacks;
 mod subscribe;
 mod unsubscribe;
 
-// pub use auth::AuthPacket;
+pub use auth::AuthPacket;
 pub use connack::ConnackPacket;
 pub use connect::ConnectPacket;
 pub use disconnect::DisconnectPacket;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -19,7 +19,7 @@ pub mod failing;
 pub mod fmt;
 pub mod utils;
 
-type DefaultClient<'a, T> = Client<'a, T, AllocBuffer, 1, 1, 1, 1, 16>;
+type DefaultClient<'a, T> = Client<'static, 'a, T, AllocBuffer, 1, 1, 1, 1, 16>;
 
 pub type TestClient<'a> = DefaultClient<'a, FromTokio<TcpStream>>;
 pub type FailingClient<'a> = DefaultClient<'a, FromTokio<FailingTcp>>;
@@ -38,6 +38,7 @@ pub const NO_SESSION_CONNECT_OPTIONS: &ConnectOptions<'static> = &ConnectOptions
     request_response_information: false,
     request_problem_information: true,
     user_properties: &[],
+    authentication_data: None,
     user_name: Some(USERNAME),
     password: Some(PASSWORD),
     will: None,

--- a/tests/integration/ack_options.rs
+++ b/tests/integration/ack_options.rs
@@ -392,7 +392,7 @@ async fn pubrel_too_many_user_properties() {
 #[ignore = "mosquitto has no configurable PUBACK maximum packet size"]
 #[tokio::test]
 #[test_log::test]
-async fn server_maximum_packet_size_not_exceeded_by_puback_hive_only() {
+async fn server_maximum_packet_size_not_exceeded_by_puback_emqx_only_hive_only() {
     // fixed header, packet identifier, reason code, property length
     const OVERHEAD: u32 = 4 + 2 + 1 + 3;
 
@@ -468,7 +468,7 @@ async fn server_maximum_packet_size_not_exceeded_by_puback_hive_only() {
 #[ignore = "mosquitto has no configurable PUBACK maximum packet size"]
 #[tokio::test]
 #[test_log::test]
-async fn server_maximum_packet_size_exceeded_by_puback_hive_only() {
+async fn server_maximum_packet_size_exceeded_by_puback_emqx_only_hive_only() {
     // fixed header, packet identifier, reason code, property length
     const OVERHEAD: u32 = 4 + 2 + 1 + 3;
 
@@ -546,7 +546,7 @@ async fn server_maximum_packet_size_exceeded_by_puback_hive_only() {
 #[ignore = "mosquitto has no configurable PUBREC/PUBCOMP maximum packet size"]
 #[tokio::test]
 #[test_log::test]
-async fn server_maximum_packet_size_not_exceeded_by_pubrec_pubcomp_hive_only() {
+async fn server_maximum_packet_size_not_exceeded_by_pubrec_pubcomp_emqx_only_hive_only() {
     // fixed header, packet identifier, reason code, property length
     const OVERHEAD: u32 = 4 + 2 + 1 + 3;
 
@@ -636,7 +636,7 @@ async fn server_maximum_packet_size_not_exceeded_by_pubrec_pubcomp_hive_only() {
 #[ignore = "mosquitto has no configurable PUBREC maximum packet size"]
 #[tokio::test]
 #[test_log::test]
-async fn server_maximum_packet_size_exceeded_by_pubrec_hive_only() {
+async fn server_maximum_packet_size_exceeded_by_pubrec_emqx_only_hive_only() {
     // fixed header, packet identifier, reason code, property length
     const OVERHEAD: u32 = 4 + 2 + 1 + 3;
 
@@ -714,7 +714,7 @@ async fn server_maximum_packet_size_exceeded_by_pubrec_hive_only() {
 #[ignore = "mosquitto has no configurable PUBCOMP maximum packet size"]
 #[tokio::test]
 #[test_log::test]
-async fn server_maximum_packet_size_exceeded_by_pubcomp_hive_only() {
+async fn server_maximum_packet_size_exceeded_by_pubcomp_emqx_only_hive_only() {
     // fixed header, packet identifier, reason code, property length
     const OVERHEAD: u32 = 4 + 2 + 1 + 3;
 
@@ -800,7 +800,7 @@ async fn server_maximum_packet_size_exceeded_by_pubcomp_hive_only() {
 #[ignore = "mosquitto has no configurable PUBREL maximum packet size"]
 #[tokio::test]
 #[test_log::test]
-async fn server_maximum_packet_size_not_exceeded_by_pubrel_hive_only() {
+async fn server_maximum_packet_size_not_exceeded_by_pubrel_emqx_only_hive_only() {
     // fixed header, packet identifier, reason code, property length
     const OVERHEAD: u32 = 4 + 2 + 1 + 3;
 
@@ -858,7 +858,7 @@ async fn server_maximum_packet_size_not_exceeded_by_pubrel_hive_only() {
 #[ignore = "mosquitto has no configurable PUBREL maximum packet size"]
 #[tokio::test]
 #[test_log::test]
-async fn server_maximum_packet_size_exceeded_by_pubrel_hive_only() {
+async fn server_maximum_packet_size_exceeded_by_pubrel_emqx_only_hive_only() {
     // fixed header, packet identifier, reason code, property length
     const OVERHEAD: u32 = 4 + 2 + 1 + 3;
 

--- a/tests/integration/auth.rs
+++ b/tests/integration/auth.rs
@@ -1,0 +1,546 @@
+use std::{
+    assert_eq, matches,
+    net::SocketAddr,
+    panic,
+    str::from_utf8,
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
+
+use base64::{Engine, engine::general_purpose::STANDARD};
+use hmac::{Hmac, KeyInit, Mac};
+use log::{debug, error, warn};
+use pbkdf2::pbkdf2_hmac;
+use rand::{Rng, distributions::Alphanumeric};
+use rust_mqtt::{
+    auth::{AuthMechanism, AuthOptions},
+    client::{
+        Client, MqttError,
+        event::{Auth, Event},
+        options::{
+            ConnectOptions, PublicationOptions, ReAuthOptions, SubscriptionOptions, TopicReference,
+            UnsubscriptionOptions,
+        },
+    },
+    types::{MqttBinary, MqttString, ReasonCode},
+};
+use sha2::{Digest, Sha256};
+use tokio::{
+    join,
+    time::{sleep, timeout},
+};
+use tokio_test::assert_err;
+
+use crate::common::{
+    BROKER_ADDRESS, DEFAULT_DC_OPTIONS, NO_SESSION_CONNECT_OPTIONS, PASSWORD, TestClient, USERNAME,
+    assert::{assert_ok, assert_published, assert_subscribe},
+    fmt::warn_inspect,
+    utils::{ALLOC, connected_client, disconnect, tcp_connection, unique_topic},
+};
+
+const NO_CREDS_CONNECT_OPTIONS: ConnectOptions = ConnectOptions::new().clean_start();
+const SCRAM_METHOD: MqttString = MqttString::from_str_unchecked("SCRAM-SHA-256");
+
+fn scram() -> (ScramSha256, MqttBinary<'static>) {
+    ScramSha256::new(USERNAME.as_str(), from_utf8(PASSWORD.as_bytes()).unwrap())
+}
+
+async fn connected_enhanced_auth_client(
+    broker: SocketAddr,
+    client_identifier: Option<MqttString<'_>>,
+) -> Result<TestClient<'static>, MqttError<'static, 16, ScramError>> {
+    let mut client = Client::new(ALLOC.get());
+
+    let tcp = tcp_connection(broker)
+        .await
+        .map_err(MqttError::into_fallible)?;
+
+    let (mut scram, first) = scram();
+
+    warn_inspect!(
+        client
+            .connect_enhanced(
+                tcp,
+                &NO_CREDS_CONNECT_OPTIONS.authentication_data(first),
+                client_identifier,
+                SCRAM_METHOD,
+                &mut scram
+            )
+            .await,
+        "Client::connect() failed"
+    )
+    .map(|_| client)
+}
+
+#[ignore = "enhanced authentication is only supported out of the box by emqx"]
+#[tokio::test]
+#[test_log::test]
+async fn connect_enhanced_emqx_only() {
+    let mut c = Client::new(ALLOC.get());
+
+    let (mut scram, first) = scram();
+
+    let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
+
+    assert_ok!(
+        c.connect_enhanced(
+            tcp,
+            &NO_CREDS_CONNECT_OPTIONS.clone().authentication_data(first),
+            None,
+            SCRAM_METHOD,
+            &mut scram,
+        )
+        .await
+    );
+
+    disconnect(&mut c, DEFAULT_DC_OPTIONS).await;
+}
+
+#[ignore = "enhanced authentication is only supported out of the box by emqx"]
+#[tokio::test]
+#[test_log::test]
+async fn reauthenticate_emqx_only() {
+    let mut c = assert_ok!(connected_enhanced_auth_client(BROKER_ADDRESS, None).await);
+
+    let (mut scram, first) = scram();
+
+    assert_ok!(
+        timeout(Duration::from_secs(5), async {
+            assert_ok!(
+                c.reauthenticate(&ReAuthOptions::new().authentication_data(first))
+                    .await
+            );
+
+            loop {
+                match assert_ok!(c.poll().await) {
+                    Event::Auth(auth) if auth.reason_code == ReasonCode::Success => {
+                        assert_ok!(scram.success(&auth));
+                        break;
+                    }
+
+                    Event::Auth(auth) => {
+                        let options = assert_ok!(scram.kontinue(&auth));
+                        let options = ReAuthOptions {
+                            authentication_data: options.authentication_data,
+                            ..Default::default()
+                        };
+                        assert_ok!(c.reauthenticate(&options).await)
+                    }
+                    _ => warn!("received unexpected event"),
+                }
+            }
+        })
+        .await
+    );
+
+    disconnect(&mut c, DEFAULT_DC_OPTIONS).await;
+}
+
+#[ignore = "enhanced authentication is only supported out of the box by emqx"]
+#[tokio::test]
+#[test_log::test]
+async fn reauthenticate_with_publish_traffic_emqx_only() {
+    let mut rx = assert_ok!(connected_enhanced_auth_client(BROKER_ADDRESS, None).await);
+    let mut tx =
+        assert_ok!(connected_client(BROKER_ADDRESS, NO_SESSION_CONNECT_OPTIONS, None).await);
+
+    let (in_topic_name, in_topic_filter) = unique_topic();
+    let (out_topic_name, _) = unique_topic();
+
+    let reauthenticated = AtomicBool::new(false);
+
+    let msg = "Modern security: I prove I am me by unlocking a phone that proves I am me to approve a code that proves I am me.";
+
+    let publisher = async {
+        while !reauthenticated.load(Ordering::Relaxed) {
+            let pub_options =
+                PublicationOptions::new(TopicReference::Name(in_topic_name.as_borrowed())).retain();
+
+            sleep(Duration::from_millis(5)).await;
+            assert_published!(tx, pub_options, msg.into());
+        }
+
+        disconnect(&mut tx, DEFAULT_DC_OPTIONS).await;
+    };
+
+    let receiver = async {
+        assert_subscribe!(
+            rx,
+            &SubscriptionOptions::new().at_least_once(),
+            in_topic_filter
+        );
+
+        let (mut scram, first) = scram();
+
+        assert_ok!(
+            rx.reauthenticate(&ReAuthOptions::new().authentication_data(first))
+                .await
+        );
+
+        loop {
+            match rx
+                .publish(
+                    &PublicationOptions::new(TopicReference::Name(out_topic_name.as_borrowed()))
+                        .exactly_once(),
+                    msg.into(),
+                )
+                .await
+            {
+                Ok(_) => {}
+                Err(e) => assert_eq!(e, MqttError::SendQuotaExceeded),
+            }
+
+            match assert_ok!(rx.poll().await) {
+                Event::Auth(auth) if auth.reason_code == ReasonCode::Success => {
+                    sleep(Duration::from_millis(100)).await;
+                    assert_ok!(scram.success(&auth));
+                    break;
+                }
+                Event::Auth(auth) => {
+                    sleep(Duration::from_millis(100)).await;
+                    let options = assert_ok!(scram.kontinue(&auth));
+                    let options = ReAuthOptions {
+                        authentication_data: options.authentication_data,
+                        ..Default::default()
+                    };
+                    assert_ok!(rx.reauthenticate(&options).await)
+                }
+                Event::Publish(_) => {}
+                Event::PublishReceived(_) | Event::PublishComplete(_) => {}
+                e => warn!("received unexpected event: {:?}", e),
+            }
+        }
+
+        reauthenticated.store(true, Ordering::Relaxed);
+
+        disconnect(&mut rx, DEFAULT_DC_OPTIONS).await;
+    };
+
+    join!(receiver, publisher);
+}
+
+#[ignore = "enhanced authentication is only supported out of the box by emqx"]
+#[tokio::test]
+#[test_log::test]
+async fn reauthenticate_with_sub_unsub_traffic_emqx_only() {
+    let mut c = assert_ok!(connected_enhanced_auth_client(BROKER_ADDRESS, None).await);
+
+    let (mut scram, first) = scram();
+
+    assert_ok!(
+        c.reauthenticate(&ReAuthOptions::new().authentication_data(first))
+            .await
+    );
+
+    loop {
+        match c
+            .subscribe(unique_topic().1, &SubscriptionOptions::new())
+            .await
+        {
+            Ok(_) => {}
+            Err(e) => assert_eq!(e, MqttError::SessionBuffer),
+        }
+        match c
+            .unsubscribe(unique_topic().1, &UnsubscriptionOptions::new())
+            .await
+        {
+            Ok(_) => {}
+            Err(e) => assert_eq!(e, MqttError::SessionBuffer),
+        }
+
+        match assert_ok!(c.poll().await) {
+            Event::Auth(auth) if auth.reason_code == ReasonCode::Success => {
+                sleep(Duration::from_millis(100)).await;
+                assert_ok!(scram.success(&auth));
+                break;
+            }
+            Event::Auth(auth) => {
+                sleep(Duration::from_millis(100)).await;
+                let options = assert_ok!(scram.kontinue(&auth));
+                let options = ReAuthOptions {
+                    authentication_data: options.authentication_data,
+                    ..Default::default()
+                };
+                assert_ok!(c.reauthenticate(&options).await)
+            }
+            Event::Suback(_) | Event::Unsuback(_) => {}
+            e => warn!("received unexpected event: {:?}", e),
+        }
+    }
+
+    disconnect(&mut c, DEFAULT_DC_OPTIONS).await;
+}
+
+#[ignore = "enhanced authentication is only supported out of the box by emqx"]
+#[tokio::test]
+#[test_log::test]
+async fn reauthenticate_with_ping_traffic_emqx_only() {
+    let mut c = assert_ok!(connected_enhanced_auth_client(BROKER_ADDRESS, None).await);
+
+    let (mut scram, first) = scram();
+
+    assert_ok!(
+        c.reauthenticate(&ReAuthOptions::new().authentication_data(first))
+            .await
+    );
+
+    loop {
+        assert_ok!(c.ping().await);
+
+        match assert_ok!(c.poll().await) {
+            Event::Auth(auth) if auth.reason_code == ReasonCode::Success => {
+                sleep(Duration::from_millis(100)).await;
+                assert_ok!(scram.success(&auth));
+                break;
+            }
+            Event::Auth(auth) => {
+                sleep(Duration::from_millis(100)).await;
+                let options = assert_ok!(scram.kontinue(&auth));
+                let options = ReAuthOptions {
+                    authentication_data: options.authentication_data,
+                    ..Default::default()
+                };
+                assert_ok!(c.reauthenticate(&options).await)
+            }
+            Event::Pingresp => {}
+            e => warn!("received unexpected event: {:?}", e),
+        }
+    }
+
+    disconnect(&mut c, DEFAULT_DC_OPTIONS).await;
+}
+
+#[ignore = "enhanced authentication is only supported out of the box by emqx"]
+#[tokio::test]
+#[test_log::test]
+async fn authenticate_handshake_violation_emqx_only() {
+    let mut client: TestClient = Client::new(ALLOC.get());
+
+    let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
+
+    let (mut scram, first) = scram();
+
+    assert_err!(
+        client
+            .connect_enhanced(
+                tcp,
+                &NO_CREDS_CONNECT_OPTIONS.authentication_data(first),
+                None,
+                MqttString::from_str("SCRAM-SHA-512").unwrap(),
+                &mut scram
+            )
+            .await
+    );
+}
+
+#[ignore = "enhanced authentication is only supported out of the box by emqx"]
+#[tokio::test]
+#[test_log::test]
+async fn reauthenticate_handshake_violation_prevented_emqx_only() {
+    let mut c = assert_ok!(connected_enhanced_auth_client(BROKER_ADDRESS, None).await);
+
+    let (_, first) = scram();
+
+    assert_ok!(
+        c.reauthenticate(&ReAuthOptions::new().authentication_data(first))
+            .await
+    );
+
+    let e = assert_err!(c.reauthenticate(&ReAuthOptions::new()).await);
+    assert_eq!(e, MqttError::ReauthenticationHandshakeStateMismatched);
+
+    disconnect(&mut c, DEFAULT_DC_OPTIONS).await;
+}
+
+#[ignore = "enhanced authentication is only supported out of the box by emqx"]
+#[tokio::test]
+#[test_log::test]
+async fn reauthenticate_handshake_violation_emqx_only() {
+    let mut c = assert_ok!(connected_enhanced_auth_client(BROKER_ADDRESS, None).await);
+
+    assert_ok!(
+        c.reauthenticate(
+            &ReAuthOptions::new()
+                .authentication_data(MqttBinary::from_slice("gibberish".as_bytes()).unwrap())
+        )
+        .await
+    );
+
+    let e = assert_err!(c.poll().await);
+    assert!(matches!(e, MqttError::Disconnect { .. }));
+}
+
+#[derive(Debug)]
+struct ScramError;
+
+#[derive(Debug, Clone)]
+enum State {
+    AwaitServerFirst {
+        client_nonce: String,
+        client_first_bare: String,
+    },
+    AwaitServerFinal {
+        server_signature: Vec<u8>,
+    },
+    Complete,
+}
+
+#[derive(Debug, Clone)]
+struct ScramSha256 {
+    password: String,
+    state: State,
+}
+
+impl ScramSha256 {
+    pub fn new(username: &str, password: impl Into<String>) -> (Self, MqttBinary<'static>) {
+        let username = username.replace('=', "=2D").replace(',', "=2C"); // RFC 5802 escaping
+        let client_nonce = rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(24)
+            .map(char::from)
+            .collect();
+        let client_first_bare = format!("n={},r={}", username, client_nonce);
+        let client_first = format!("n,,{}", client_first_bare);
+
+        (
+            Self {
+                password: password.into(),
+                state: State::AwaitServerFirst {
+                    client_nonce,
+                    client_first_bare,
+                },
+            },
+            MqttBinary::try_from(client_first.into_bytes()).unwrap(),
+        )
+    }
+}
+
+impl<const MAX_USER_PROPERTIES: usize> AuthMechanism<MAX_USER_PROPERTIES> for ScramSha256 {
+    type Error = ScramError;
+
+    fn kontinue(
+        &mut self,
+        auth: &Auth<'_, MAX_USER_PROPERTIES>,
+    ) -> Result<AuthOptions<'_, MAX_USER_PROPERTIES>, (Self::Error, Option<ReasonCode>)> {
+        let State::AwaitServerFirst {
+            client_nonce,
+            client_first_bare,
+        } = &self.state
+        else {
+            return Err((ScramError, Some(ReasonCode::ProtocolError)));
+        };
+
+        let server_first = auth
+            .authentication_data
+            .as_ref()
+            .and_then(|d| from_utf8(d.as_bytes()).ok())
+            .ok_or((ScramError, Some(ReasonCode::ProtocolError)))?;
+
+        let full_nonce =
+            get_attr(server_first, "r=").map_err(|e| (e, Some(ReasonCode::ProtocolError)))?;
+        let salt = STANDARD
+            .decode(get_attr(server_first, "s=").map_err(|e| (e, Some(ReasonCode::ProtocolError)))?)
+            .map_err(|_| (ScramError, Some(ReasonCode::ProtocolError)))?;
+        let iter = get_attr(server_first, "i=")
+            .map_err(|e| (e, Some(ReasonCode::ProtocolError)))?
+            .parse::<u32>()
+            .map_err(|_| (ScramError, Some(ReasonCode::ProtocolError)))?;
+
+        debug!(
+            "full_nonce={}, salt={:?}, iterations={}",
+            full_nonce, salt, iter
+        );
+
+        if !full_nonce.starts_with(client_nonce) {
+            error!(
+                "server nonce (={}) does not start with client nonce (={})",
+                full_nonce, client_nonce
+            );
+
+            return Err((ScramError, Some(ReasonCode::ProtocolError)));
+        }
+
+        let mut salted_password = [0u8; 32];
+        pbkdf2_hmac::<Sha256>(self.password.as_bytes(), &salt, iter, &mut salted_password);
+
+        let client_key = hmac(&salted_password, b"Client Key");
+        let stored_key = Sha256::digest(client_key);
+        let server_key = hmac(&salted_password, b"Server Key");
+
+        let client_final_no_proof = format!("c=biws,r={}", full_nonce);
+        let auth_msg = format!(
+            "{},{},{}",
+            client_first_bare, server_first, client_final_no_proof
+        );
+
+        let client_sig = hmac(&stored_key, auth_msg.as_bytes());
+        let client_proof: Vec<u8> = client_key
+            .iter()
+            .zip(client_sig.iter())
+            .map(|(a, b)| a ^ b)
+            .collect();
+
+        self.state = State::AwaitServerFinal {
+            server_signature: hmac(&server_key, auth_msg.as_bytes()).to_vec(),
+        };
+
+        let response = format!(
+            "{},p={}",
+            client_final_no_proof,
+            STANDARD.encode(client_proof)
+        );
+
+        debug!("client_final={}", response);
+
+        Ok(AuthOptions {
+            authentication_data: Some(MqttBinary::try_from(response.into_bytes()).unwrap()),
+            ..Default::default()
+        })
+    }
+
+    fn success(
+        &mut self,
+        auth: &Auth<'_, MAX_USER_PROPERTIES>,
+    ) -> Result<(), (Self::Error, Option<ReasonCode>)> {
+        let State::AwaitServerFinal { server_signature } = &self.state else {
+            return Err((ScramError, Some(ReasonCode::ProtocolError)));
+        };
+
+        let data = auth
+            .authentication_data
+            .as_ref()
+            .ok_or((ScramError, Some(ReasonCode::ProtocolError)))?;
+        let server_final = from_utf8(data.as_bytes())
+            .map_err(|_| (ScramError, Some(ReasonCode::ProtocolError)))?;
+
+        debug!("server_final={}", server_final);
+
+        let verifier = server_final
+            .strip_prefix("v=")
+            .ok_or((ScramError, Some(ReasonCode::ProtocolError)))?;
+
+        if STANDARD
+            .decode(verifier)
+            .map_err(|_| (ScramError, Some(ReasonCode::ProtocolError)))?
+            == *server_signature
+        {
+            self.state = State::Complete;
+            Ok(())
+        } else {
+            Err((ScramError, Some(ReasonCode::ProtocolError)))
+        }
+    }
+}
+
+fn get_attr<'a>(input: &'a str, tag: &str) -> Result<&'a str, ScramError> {
+    input
+        .split(',')
+        .find_map(|s| s.strip_prefix(tag))
+        .ok_or(ScramError)
+}
+
+fn hmac(key: &[u8], data: &[u8]) -> [u8; 32] {
+    let mut h = Hmac::<Sha256>::new_from_slice(key).expect("HMAC size");
+    h.update(data);
+    h.finalize().into_bytes().into()
+}

--- a/tests/integration/connect_options.rs
+++ b/tests/integration/connect_options.rs
@@ -723,10 +723,10 @@ async fn keep_alive_not_kept_alive_will_timing() {
 #[test_log::test]
 async fn receive_maximum() {
     let (topic_name, topic_filter) = unique_topic();
-    let mut rx: Client<'_, _, _, 1, 2, 0, 0, 16> = Client::new(ALLOC.get());
+    let mut rx: Client<'_, '_, _, _, 1, 2, 0, 0, 16> = Client::new(ALLOC.get());
     // EMQX calculates its server receive maximum as min(client_receive_maximum, emqx_max_inflight),
     // so we need to go up to 10 on our RECEIVE_MAXIMUM
-    let mut tx: Client<'_, _, _, 1, 10, 10, 0, 16> = Client::new(ALLOC.get());
+    let mut tx: Client<'_, '_, _, _, 1, 10, 10, 0, 16> = Client::new(ALLOC.get());
 
     let tcp_rx = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
     let tcp_tx = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
@@ -793,7 +793,8 @@ async fn send_maximum_buffer_exceeded() {
 
     // EMQX calculates its server receive maximum as min(client_receive_maximum, emqx_max_inflight),
     // so we need to go up to 3 on our RECEIVE_MAXIMUM
-    let mut c: Client<'_, _, _, 1, 3, SEND_MAXIMUM_BUFFER_SIZE, 0, 16> = Client::new(ALLOC.get());
+    let mut c: Client<'_, '_, _, _, 1, 3, SEND_MAXIMUM_BUFFER_SIZE, 0, 16> =
+        Client::new(ALLOC.get());
 
     let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
 
@@ -830,7 +831,7 @@ async fn send_maximum_buffer_exceeded() {
 #[test_log::test]
 async fn server_receive_maximum_exceeded() {
     let topic_name = unique_topic().0;
-    let mut c: Client<'_, _, _, 1, 1, 256, 0, 16> = Client::new(ALLOC.get());
+    let mut c: Client<'_, '_, _, _, 1, 1, 256, 0, 16> = Client::new(ALLOC.get());
 
     let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
 

--- a/tests/integration/connect_options.rs
+++ b/tests/integration/connect_options.rs
@@ -23,9 +23,10 @@ use crate::common::{
     utils::{ALLOC, connected_client, disconnect, tcp_connection, unique_topic},
 };
 
+#[ignore = "enable this once emqx v6.3.0 is used, see https://github.com/emqx/emqx/issues/18425"]
 #[tokio::test]
 #[test_log::test]
-async fn maximum_packet_size_not_exceeded() {
+async fn maximum_packet_size_not_exceeded_hive_only_mosquitto_only() {
     // Has to be a reasonable value not too close to 0, otherwise broker might not reply or something similar
     const MAX_PACKET_SIZE: u32 = 100;
     const PACKET_SIZE: usize = MAX_PACKET_SIZE as usize;
@@ -74,7 +75,7 @@ async fn maximum_packet_size_not_exceeded() {
 #[ignore = "enable this once mosquitto v2.1.3 is used, see https://github.com/eclipse-mosquitto/mosquitto/issues/3503"]
 #[tokio::test]
 #[test_log::test]
-async fn maximum_packet_size_barely_exceeded_hive_only() {
+async fn maximum_packet_size_barely_exceeded_emqx_only_hive_only() {
     // Has to be a reasonable value not too close to 0, otherwise broker might not reply or something similar
     const MAX_PACKET_SIZE: u32 = 100;
     const PACKET_SIZE: usize = MAX_PACKET_SIZE as usize + 1;
@@ -643,7 +644,7 @@ async fn keep_alive_not_kept_alive_incoming_qos0() {
         assert_subscribe!(rx, DEFAULT_QOS0_SUB_OPTIONS, topic_filter);
 
         assert_ok!(
-            timeout(Duration::from_secs(4), async {
+            timeout(Duration::from_secs(5), async {
                 while !matches!(
                     rx.poll().await,
                     Err(MqttError::Disconnect {
@@ -723,7 +724,9 @@ async fn keep_alive_not_kept_alive_will_timing() {
 async fn receive_maximum() {
     let (topic_name, topic_filter) = unique_topic();
     let mut rx: Client<'_, _, _, 1, 2, 0, 0, 16> = Client::new(ALLOC.get());
-    let mut tx: Client<'_, _, _, 1, 1, 10, 0, 16> = Client::new(ALLOC.get());
+    // EMQX calculates its server receive maximum as min(client_receive_maximum, emqx_max_inflight),
+    // so we need to go up to 10 on our RECEIVE_MAXIMUM
+    let mut tx: Client<'_, _, _, 1, 10, 10, 0, 16> = Client::new(ALLOC.get());
 
     let tcp_rx = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
     let tcp_tx = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
@@ -788,7 +791,9 @@ async fn send_maximum_buffer_exceeded() {
     let topic = unique_topic().0;
     const SEND_MAXIMUM_BUFFER_SIZE: usize = 2;
 
-    let mut c: Client<'_, _, _, 1, 1, SEND_MAXIMUM_BUFFER_SIZE, 0, 16> = Client::new(ALLOC.get());
+    // EMQX calculates its server receive maximum as min(client_receive_maximum, emqx_max_inflight),
+    // so we need to go up to 3 on our RECEIVE_MAXIMUM
+    let mut c: Client<'_, _, _, 1, 3, SEND_MAXIMUM_BUFFER_SIZE, 0, 16> = Client::new(ALLOC.get());
 
     let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
 

--- a/tests/integration/disconnect_options.rs
+++ b/tests/integration/disconnect_options.rs
@@ -96,7 +96,7 @@ async fn too_many_user_properties() {
 #[ignore = "mosquitto has no configurable DISCONNECT maximum packet size"]
 #[tokio::test]
 #[test_log::test]
-async fn server_maximum_packet_size_not_exceeded_by_disconnect_hive_only() {
+async fn server_maximum_packet_size_not_exceeded_by_disconnect_emqx_only_hive_only() {
     // fixed header, reason code, property length
     const OVERHEAD: u32 = 4 + 1 + 3;
 
@@ -136,7 +136,7 @@ async fn server_maximum_packet_size_not_exceeded_by_disconnect_hive_only() {
 #[ignore = "mosquitto has no configurable DISCONNECT maximum packet size"]
 #[tokio::test]
 #[test_log::test]
-async fn server_maximum_packet_size_exceeded_by_disconnect_hive_only() {
+async fn server_maximum_packet_size_exceeded_by_disconnect_emqx_only_hive_only() {
     // fixed header, reason code, property length
     const OVERHEAD: u32 = 4 + 1 + 3;
 

--- a/tests/integration/message_retry.rs
+++ b/tests/integration/message_retry.rs
@@ -66,7 +66,8 @@ async fn outgoing_automatic_qos1_retry() {
         connect_options.clean_start = false;
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-        let mut tx: Client<'_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
+        let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+            Client::with_session(session, ALLOC.get());
         let info = assert_ok!(warn_inspect!(
             tx.connect(tcp, &connect_options, Some(tx_id.as_borrowed()))
                 .await,
@@ -156,7 +157,8 @@ async fn outgoing_automatic_qos2_retry_publish() {
         connect_options.clean_start = false;
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-        let mut tx: Client<'_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
+        let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+            Client::with_session(session, ALLOC.get());
         let info = assert_ok!(warn_inspect!(
             tx.connect(tcp, &connect_options, Some(tx_id.as_borrowed()))
                 .await,
@@ -243,7 +245,8 @@ async fn outgoing_manual_qos2_retry_publish() {
         connect_options.clean_start = false;
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-        let mut tx: Client<'_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
+        let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+            Client::with_session(session, ALLOC.get());
         let info = assert_ok!(warn_inspect!(
             tx.connect(tcp, &connect_options, Some(tx_id.as_borrowed()))
                 .await,
@@ -360,7 +363,8 @@ async fn outgoing_automatic_qos2_retry_pubrel() {
         connect_options.clean_start = false;
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-        let mut tx: Client<'_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
+        let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+            Client::with_session(session, ALLOC.get());
         let info = assert_ok!(warn_inspect!(
             tx.connect(tcp, &connect_options, Some(tx_id.as_borrowed()))
                 .await,
@@ -478,7 +482,8 @@ async fn outgoing_manual_qos2_retry_pubrel() {
         connect_options.clean_start = false;
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-        let mut tx: Client<'_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
+        let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+            Client::with_session(session, ALLOC.get());
         let info = assert_ok!(warn_inspect!(
             tx.connect(tcp, &connect_options, Some(tx_id.as_borrowed()))
                 .await,
@@ -589,7 +594,8 @@ async fn incoming_automatic_qos2_retry_pubcomp() {
         connect_options.clean_start = false;
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-        let mut rx: Client<'_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
+        let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+            Client::with_session(session, ALLOC.get());
         let info = assert_ok!(warn_inspect!(
             rx.connect(tcp, &connect_options, Some(rx_id.as_borrowed()))
                 .await,
@@ -687,7 +693,8 @@ async fn incoming_manual_qos2_retry_pubcomp() {
         connect_options.clean_start = false;
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-        let mut rx: Client<'_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
+        let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+            Client::with_session(session, ALLOC.get());
         let info = assert_ok!(warn_inspect!(
             rx.connect(tcp, &connect_options, Some(rx_id.as_borrowed()))
                 .await,
@@ -800,7 +807,7 @@ async fn outgoing_automatic_qos1_write_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut tx: Client<'_, _, _, 1, 1, 1, 1, 16> =
+                let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -928,7 +935,7 @@ async fn outgoing_automatic_qos1_read_fail_retry() {
 
                 let pid = session.outbound_publishes.first().unwrap().0;
 
-                let mut tx: Client<'_, _, _, 1, 1, 1, 1, 16> =
+                let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -1052,7 +1059,7 @@ async fn outgoing_automatic_qos2_write_fail_retry_hive_only_mosquitto_only() {
 
                 // Complete publish using infallible connection
 
-                let mut tx: Client<'_, _, _, 1, 1, 1, 1, 16> =
+                let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -1232,7 +1239,7 @@ async fn outgoing_manual_qos2_write_fail_retry_hive_only_mosquitto_only() {
 
                 // Complete publish using infallible connection
 
-                let mut tx: Client<'_, _, _, 1, 1, 1, 1, 16> =
+                let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -1417,7 +1424,7 @@ async fn outgoing_automatic_qos2_read_fail_retry_hive_only_mosquitto_only() {
 
                 // Complete publish using infallible connection
 
-                let mut tx: Client<'_, _, _, 1, 1, 1, 1, 16> =
+                let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -1605,7 +1612,7 @@ async fn outgoing_manual_qos2_read_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut tx: Client<'_, _, _, 1, 1, 1, 1, 16> =
+                let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -1820,7 +1827,7 @@ async fn incoming_automatic_qos1_write_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut rx: Client<'_, _, _, 1, 1, 1, 1, 16> =
+                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -1941,7 +1948,7 @@ async fn incoming_manual_qos1_write_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut rx: Client<'_, _, _, 1, 1, 1, 1, 16> =
+                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -2062,7 +2069,7 @@ async fn incoming_automatic_qos1_read_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut rx: Client<'_, _, _, 1, 1, 1, 1, 16> =
+                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -2182,7 +2189,7 @@ async fn incoming_manual_qos1_read_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut rx: Client<'_, _, _, 1, 1, 1, 1, 16> =
+                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -2317,7 +2324,7 @@ async fn incoming_automatic_qos2_write_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut rx: Client<'_, _, _, 1, 1, 1, 1, 16> =
+                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -2467,7 +2474,7 @@ async fn incoming_manual_qos2_write_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut rx: Client<'_, _, _, 1, 1, 1, 1, 16> =
+                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -2630,7 +2637,7 @@ async fn incoming_automatic_qos2_read_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut rx: Client<'_, _, _, 1, 1, 1, 1, 16> =
+                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -2804,7 +2811,7 @@ async fn incoming_manual_qos2_read_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut rx: Client<'_, _, _, 1, 1, 1, 1, 16> =
+                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(

--- a/tests/integration/message_retry.rs
+++ b/tests/integration/message_retry.rs
@@ -3,7 +3,7 @@ use std::{num::NonZero, time::Duration};
 use rust_mqtt::{
     client::{
         Client,
-        event::{Event, Puback, Publish, Suback},
+        event::{Event, Puback, Publish, Pubrej, Suback},
         options::{AckMode, AckOptions, PublicationOptions, TopicReference},
     },
     config::SessionExpiryInterval,
@@ -101,7 +101,7 @@ async fn outgoing_automatic_qos1_retry() {
         let sub_options = DEFAULT_QOS0_SUB_OPTIONS.at_least_once();
         assert_subscribe!(rx, &sub_options, topic_filter.clone());
         let p = assert_ok!(assert_ok!(
-            timeout(Duration::from_secs(5), receive_publish(&mut rx)).await
+            timeout(Duration::from_secs(5), receive_and_complete(&mut rx)).await
         ));
         assert_eq!(p.topic, topic_name.as_borrowed());
         assert_eq!(p.message, msg.into());
@@ -191,7 +191,7 @@ async fn outgoing_automatic_qos2_retry_publish() {
         let sub_options = DEFAULT_QOS0_SUB_OPTIONS.exactly_once();
         assert_subscribe!(rx, &sub_options, topic_filter.clone());
         let p = assert_ok!(assert_ok!(
-            timeout(Duration::from_secs(5), receive_publish(&mut rx)).await
+            timeout(Duration::from_secs(5), receive_and_complete(&mut rx)).await
         ));
         assert_eq!(p.topic, topic_name.as_borrowed());
         assert_eq!(p.message, msg.into());
@@ -290,7 +290,7 @@ async fn outgoing_manual_qos2_retry_publish() {
         let sub_options = DEFAULT_QOS0_SUB_OPTIONS.exactly_once();
         assert_subscribe!(rx, &sub_options, topic_filter.clone());
         let p = assert_ok!(assert_ok!(
-            timeout(Duration::from_secs(5), receive_publish(&mut rx)).await
+            timeout(Duration::from_secs(5), receive_and_complete(&mut rx)).await
         ));
         assert_eq!(p.topic, topic_name.as_borrowed());
         assert_eq!(p.message, msg.into());
@@ -381,6 +381,12 @@ async fn outgoing_automatic_qos2_retry_pubrel() {
                             reason_string: _,
                             user_properties: _,
                         }) if packet_identifier == pid => break,
+                        Event::PublishRejected(Pubrej {
+                            packet_identifier,
+                            reason_code: _,
+                            reason_string: _,
+                            user_properties: _,
+                        }) if packet_identifier == pid => break,
                         _ => {}
                     }
                 }
@@ -395,7 +401,7 @@ async fn outgoing_automatic_qos2_retry_pubrel() {
         let sub_options = DEFAULT_QOS0_SUB_OPTIONS.exactly_once();
         assert_subscribe!(rx, &sub_options, topic_filter.clone());
         let p = assert_ok!(assert_ok!(
-            timeout(Duration::from_secs(5), receive_publish(&mut rx)).await
+            timeout(Duration::from_secs(5), receive_and_complete(&mut rx)).await
         ));
         assert_eq!(p.topic, topic_name.as_borrowed());
         assert_eq!(p.message, msg.into());
@@ -493,6 +499,12 @@ async fn outgoing_manual_qos2_retry_pubrel() {
                             reason_string: _,
                             user_properties: _,
                         }) if packet_identifier == pid => break,
+                        Event::PublishRejected(Pubrej {
+                            packet_identifier,
+                            reason_code: _,
+                            reason_string: _,
+                            user_properties: _,
+                        }) if packet_identifier == pid => break,
                         _ => {}
                     }
                 }
@@ -507,7 +519,7 @@ async fn outgoing_manual_qos2_retry_pubrel() {
         let sub_options = DEFAULT_QOS0_SUB_OPTIONS.exactly_once();
         assert_subscribe!(rx, &sub_options, topic_filter.clone());
         let p = assert_ok!(assert_ok!(
-            timeout(Duration::from_secs(5), receive_publish(&mut rx)).await
+            timeout(Duration::from_secs(5), receive_and_complete(&mut rx)).await
         ));
         assert_eq!(p.topic, topic_name.as_borrowed());
         assert_eq!(p.message, msg.into());
@@ -949,9 +961,10 @@ async fn outgoing_automatic_qos1_read_fail_retry() {
     join!(rx, tx);
 }
 
+#[ignore = "enable this once emqx v6.2.4 is used, see https://github.com/emqx/emqx/issues/18441"]
 #[tokio::test]
 #[test_log::test]
-async fn outgoing_automatic_qos2_write_fail_retry() {
+async fn outgoing_automatic_qos2_write_fail_retry_hive_only_mosquitto_only() {
     let tx_id = MqttString::from_str("RETRY_OUTGOING_AUTOMATIC_QOS2_WRITE_FAIL_CLIENT").unwrap();
 
     let (rx_subscribed, subscribed) = oneshot::channel();
@@ -1126,9 +1139,10 @@ async fn outgoing_automatic_qos2_write_fail_retry() {
     join!(rx, tx);
 }
 
+#[ignore = "enable this once emqx v6.2.4 is used, see https://github.com/emqx/emqx/issues/18441"]
 #[tokio::test]
 #[test_log::test]
-async fn outgoing_manual_qos2_write_fail_retry() {
+async fn outgoing_manual_qos2_write_fail_retry_hive_only_mosquitto_only() {
     let tx_id = MqttString::from_str("RETRY_OUTGOING_MANUAL_QOS2_WRITE_FAIL_CLIENT").unwrap();
 
     let (rx_subscribed, subscribed) = oneshot::channel();
@@ -1313,9 +1327,10 @@ async fn outgoing_manual_qos2_write_fail_retry() {
     join!(rx, tx);
 }
 
+#[ignore = "enable this once emqx v6.2.4 is used, see https://github.com/emqx/emqx/issues/18441"]
 #[tokio::test]
 #[test_log::test]
-async fn outgoing_automatic_qos2_read_fail_retry() {
+async fn outgoing_automatic_qos2_read_fail_retry_hive_only_mosquitto_only() {
     let tx_id = MqttString::from_str("RETRY_OUTGOING_AUTOMATIC_QOS2_READ_FAIL_CLIENT").unwrap();
 
     let (rx_subscribed, subscribed) = oneshot::channel();
@@ -1472,6 +1487,12 @@ async fn outgoing_automatic_qos2_read_fail_retry() {
                 match assert_ok!(tx.poll().await) {
                     Event::PublishComplete(Puback {
                         ack_mode: _,
+                        packet_identifier,
+                        reason_code: _,
+                        reason_string: _,
+                        user_properties: _,
+                    }) if pid == packet_identifier => {}
+                    Event::PublishRejected(Pubrej {
                         packet_identifier,
                         reason_code: _,
                         reason_string: _,
@@ -1662,6 +1683,12 @@ async fn outgoing_manual_qos2_read_fail_retry() {
                 match assert_ok!(tx.poll().await) {
                     Event::PublishComplete(Puback {
                         ack_mode: _,
+                        packet_identifier,
+                        reason_code: _,
+                        reason_string: _,
+                        user_properties: _,
+                    }) if pid == packet_identifier => {}
+                    Event::PublishRejected(Pubrej {
                         packet_identifier,
                         reason_code: _,
                         reason_string: _,

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,4 +1,5 @@
 mod ack_options;
+mod auth;
 mod connect_options;
 mod creds;
 mod disconnect_options;

--- a/tests/integration/pub_properties.rs
+++ b/tests/integration/pub_properties.rs
@@ -62,7 +62,7 @@ async fn message_expiry_interval_basic() {
 #[ignore = "enable this test once https://github.com/hivemq/hivemq-community-edition/issues/616 is fixed"]
 #[tokio::test]
 #[test_log::test]
-async fn message_expiry_interval_partially_expired_mosquitto_only() {
+async fn message_expiry_interval_partially_expired_emqx_only_mosquitto_only() {
     let (topic_name, topic_filter) = unique_topic();
     let msg = "It's not a bug, it's an undocumented feature!";
 

--- a/tests/integration/session.rs
+++ b/tests/integration/session.rs
@@ -90,7 +90,7 @@ async fn session_continue_connection_dropped() {
     connect_options.clean_start = false;
 
     let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-    let mut c: Client<'_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
+    let mut c: Client<'_, '_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
     let info = assert_ok!(warn_inspect!(
         c.connect(tcp, &connect_options, Some(id.as_borrowed()))
             .await,
@@ -147,7 +147,7 @@ async fn session_discontinued_clean_start() {
     drop(c);
 
     let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-    let mut c: Client<'_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
+    let mut c: Client<'_, '_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
     let info = assert_ok!(warn_inspect!(
         c.connect(tcp, &connect_options, Some(id.as_borrowed()))
             .await,
@@ -195,7 +195,7 @@ async fn session_expired() {
     sleep(Duration::from_secs(5)).await;
 
     let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-    let mut c: Client<'_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
+    let mut c: Client<'_, '_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
     let info = assert_ok!(warn_inspect!(
         c.connect(tcp, &connect_options, Some(id.as_borrowed()))
             .await,

--- a/tests/integration/sub_options.rs
+++ b/tests/integration/sub_options.rs
@@ -297,7 +297,7 @@ async fn subscription_identifier() {
     let mut tx =
         assert_ok!(connected_client(BROKER_ADDRESS, NO_SESSION_CONNECT_OPTIONS, None).await);
 
-    let mut rx: Client<'_, _, _, 1, 1, 1, 1, 16> = {
+    let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> = {
         let mut client = Client::new(ALLOC.get());
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);

--- a/tests/integration/will.rs
+++ b/tests/integration/will.rs
@@ -658,7 +658,7 @@ async fn will_delay_interval_basic() {
 #[ignore = "enable this test once the fix of https://github.com/eclipse-mosquitto/mosquitto/issues/3505 (mosquitto v2.1.3) is available"]
 #[tokio::test]
 #[test_log::test]
-async fn session_expires_right_after_disconnect_hive_only() {
+async fn session_expires_right_after_disconnect_emqx_only_hive_only() {
     let (will_topic_name, will_topic_filter) = unique_topic();
     let will_msg = "Death may be the greatest of all human blessings";
 
@@ -789,7 +789,7 @@ async fn will_delay_interval_completely_expired() {
 #[ignore = "enable this test once mosquitto v2.1.3 is used"]
 #[tokio::test]
 #[test_log::test]
-async fn clean_start_override_before_will_scheduled_hive_only() {
+async fn clean_start_override_before_will_scheduled_emqx_only_hive_only() {
     let id = MqttString::from_str("WILL_CLEAN_START_BEFORE_WILL_SCHEDULED").unwrap();
 
     let (will_topic_name, will_topic_filter) = unique_topic();
@@ -917,7 +917,8 @@ async fn will_existing_session_taken_over_with_session_expiry() {
     join!(receiver, publisher, publisher_takeover);
 }
 
-// fails with mosquitto v2.1.2
+#[expect(unused_attributes)]
+#[ignore = "enable this test once emqx v6.2.4 is used, see https://github.com/emqx/emqx/issues/18565"]
 #[ignore = "enable this test once mosquitto v2.1.3 is used"]
 #[tokio::test]
 #[test_log::test]
@@ -988,7 +989,7 @@ async fn will_existing_session_taken_over_with_will_delay_hive_only() {
 #[ignore = "enable this test once mosquitto v2.1.3 is used"]
 #[tokio::test]
 #[test_log::test]
-async fn will_existing_session_taken_over_with_clean_start_hive_only() {
+async fn will_existing_session_taken_over_with_clean_start_emqx_only_hive_only() {
     let id = MqttString::from_str("WILL_EXISTING_SESSION_TAKEN_OVER_WITH_CLEAN_START").unwrap();
 
     let (will_topic_name, will_topic_filter) = unique_topic();


### PR DESCRIPTION
Adds MQTTv5's enhanced/extended authentication including re-authentication. The old connection API remains unchanged. There is some, but rather minimal overhead added for tracking re-authentication state, even when enhanced authentication is not used.

- Refactors `Client::connect` into CONNECT transmission and client configuration and CONNACK processing
- Adds `Client::connect_enhanced` and `Client::reauthenticate`
- Adds EMQX to the test suite to test enhanced authentication with SCRAM-SHA-256
- Adds a second generic parameter to `MqttError`, defaulting to `Infallible` for errors occurring in the enhanced authentication provider.
- Fix unreachable panic in client on erroneous PUBCOMP packet
- Handle ignored event from state machine on inbound PUBLISH with unreachable panic

Closes #88 