### PR TITLE
Incoming topic alias & topic alias checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Return the `Transport` network handle after a successful disconnection / abortion
 - Add enhanced authentication with `Client::connect_enhanced` and re-authentication with `Client::reauthenticate`
 - Add generic paramater to `MqttError` defaulting to `Infallible` for errors during enhanced authentication
+- Add const generic parameter `MAX_INCOMING_TOPIC_ALIASES` indicating the number of topic aliases that are supported in inbound direction respectively
+- Add const generic parameter `MAX_OUTGOING_TOPIC_ALIASES` indicating the number of topic aliases that are supported in outbound direction respectively
+- Pass through the complete `TopicReference` instead of only the `TopicName` in incoming publications
+- Prevent publications by the client without a topic name to topic aliases that have not been mapped before
 
 ## 0.5.1 - 2026-04-10
 

--- a/README.md
+++ b/README.md
@@ -31,17 +31,16 @@ The design goal is a strict yet flexible and explicit API that leverages Rust's 
 - Subscription identifiers
 - Shared & wildcard subscriptions
 - Message expiry interval
-- Topic alias in outgoing publications
+- Topic alias
 - Request/Response
 - Request Problem Information
 - Reason String
 - User Property
 - Enhanced/Extended authentication and re-authentication
 
-### Currently unsupported MQTT features & limitations
+### Current limitation
 
-- Subscribing to multiple topics in a single packet
-- Topic alias in incoming publications
+- Subscribing to multiple topics in a single packet is not supported
 
 ### Extension plans (more or less by priority)
 

--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -30,7 +30,7 @@ async fn main() {
 
     let mut buffer = AllocBuffer;
 
-    let mut client = Client::<'_, '_, _, _, 1, 1, 1, 1, 16>::new(&mut buffer);
+    let mut client = Client::<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0>::new(&mut buffer);
 
     let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1883);
     let connection = TcpStream::connect(addr).await.unwrap();

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -33,7 +33,7 @@ async fn main() {
     #[cfg(feature = "bump")]
     let mut buffer = BumpBuffer::new(&mut buffer);
 
-    let mut client = Client::<'_, '_, _, _, 1, 1, 1, 1, 16>::new(&mut buffer);
+    let mut client = Client::<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 1>::new(&mut buffer);
 
     let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1883);
     let connection = TcpStream::connect(addr).await.unwrap();
@@ -269,7 +269,8 @@ async fn main() {
     let mut buffer = BumpBuffer::new(&mut buffer);
 
     // Continue the previous session
-    let mut client = Client::<'_, '_, _, _, 1, 1, 1, 1, 16>::with_session(session, &mut buffer);
+    let mut client =
+        Client::<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 1>::with_session(session, &mut buffer);
 
     let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1883);
     let connection = TcpStream::connect(addr).await.unwrap();

--- a/examples/manual_ack.rs
+++ b/examples/manual_ack.rs
@@ -45,7 +45,7 @@ async fn main() {
     #[cfg(feature = "bump")]
     let mut buffer = BumpBuffer::new(&mut buffer);
 
-    let mut client = Client::<'_, '_, _, _, 1, 3, 3, 0, 16>::new(&mut buffer);
+    let mut client = Client::<'_, '_, _, _, 1, 3, 3, 0, 16, 0, 0>::new(&mut buffer);
 
     // Acknowledge all packets manually which have a payload format indicator property with a value of
     // true (claiming that the payload is UTF-8). We intentionally leave the check for actual UTF-8

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -68,7 +68,7 @@ async fn main() {
     #[cfg(feature = "bump")]
     let mut buffer = BumpBuffer::new(&mut buffer);
 
-    let mut client = Client::<'_, '_, _, _, 1, 1, 1, 0, 1>::new(&mut buffer);
+    let mut client = Client::<'_, '_, _, _, 1, 1, 1, 0, 1, 0, 0>::new(&mut buffer);
 
     let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8883);
     let connection = TcpStream::connect(addr).await.unwrap();

--- a/src/client/err.rs
+++ b/src/client/err.rs
@@ -207,6 +207,14 @@ pub enum Error<'e, const MAX_USER_PROPERTIES: usize, A = Infallible> {
     /// [`Event::PublishComplete`]: crate::client::event::Event::PublishComplete
     SendQuotaExceeded,
 
+    /// A publish without a topic name was attempted to a topic alias that has not been mapped previously.
+    /// This can only occur when [`TopicReference::Alias`] is used.
+    ///
+    /// Recoverable error. No action has been taken by the client.
+    ///
+    /// [`TopicReference::Alias`]: crate::client::options::TopicReference::Alias
+    TopicAliasNotMapped,
+
     /// An operation was attempted which the server stated it does not support. If the requested operation
     /// were executed as is, a protocol error would be caused.
     ///
@@ -289,6 +297,7 @@ impl<const MAX_USER_PROPERTIES: usize, A> Error<'_, MAX_USER_PROPERTIES, A> {
                 | Self::ServerMaximumPacketSizeExceeded
                 | Self::SessionBuffer
                 | Self::SendQuotaExceeded
+                | Self::TopicAliasNotMapped
                 | Self::UnsupportedByServer
                 | Self::IllegalNoLocalSharedSubscription
                 | Self::NoEnhancedAuthentication
@@ -332,6 +341,7 @@ impl<'e, A> Error<'e, 0, A> {
             Self::ServerMaximumPacketSizeExceeded => Error::ServerMaximumPacketSizeExceeded,
             Self::SessionBuffer => Error::SessionBuffer,
             Self::SendQuotaExceeded => Error::SendQuotaExceeded,
+            Self::TopicAliasNotMapped => Error::TopicAliasNotMapped,
             Self::UnsupportedByServer => Error::UnsupportedByServer,
             Self::IllegalNoLocalSharedSubscription => Error::IllegalNoLocalSharedSubscription,
             Self::NoEnhancedAuthentication => Error::NoEnhancedAuthentication,
@@ -376,6 +386,7 @@ impl<'e, const MAX_USER_PROPERTIES: usize> Error<'e, MAX_USER_PROPERTIES> {
             Self::ServerMaximumPacketSizeExceeded => Error::ServerMaximumPacketSizeExceeded,
             Self::SessionBuffer => Error::SessionBuffer,
             Self::SendQuotaExceeded => Error::SendQuotaExceeded,
+            Self::TopicAliasNotMapped => Error::TopicAliasNotMapped,
             Self::UnsupportedByServer => Error::UnsupportedByServer,
             Self::IllegalNoLocalSharedSubscription => Error::IllegalNoLocalSharedSubscription,
             Self::NoEnhancedAuthentication => Error::NoEnhancedAuthentication,

--- a/src/client/event.rs
+++ b/src/client/event.rs
@@ -4,7 +4,7 @@ use heapless::Vec;
 
 use crate::{
     bytes::Bytes,
-    client::AckMode,
+    client::{AckMode, options::TopicReference},
     types::{
         IdentifiedQoS, MqttBinary, MqttString, MqttStringPair, PacketIdentifier, ReasonCode,
         TopicName, VarByteInt,
@@ -255,8 +255,11 @@ pub struct Publish<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER
     /// the retain as published flag of the matching subscription.
     pub retain: bool,
 
-    /// The exact topic of this publication.
-    pub topic: TopicName<'p>,
+    /// The topic of this publication. In the case of [`TopicReference::Mapping`], a new topic alias
+    /// mapping is created or an existing mapping is overwritten. In the case of
+    /// [`TopicReference::Alias`], an existing mapping is used and the mapped topic name is the referred
+    /// topic.
+    pub topic: TopicReference<'p>,
 
     /// If present, indicates whether the payload is UTF-8. This value is set by the publisher and is
     /// NOT verified by the client library.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -10,7 +10,7 @@ use crate::{
         event::{Auth, Connected, Event, Puback, Publish, Pubrej, Suback},
         options::{
             AckMode, AckOptions, ConnectOptions, DisconnectOptions, PublicationOptions,
-            ReAuthOptions, SubscriptionOptions, UnsubscriptionOptions,
+            ReAuthOptions, SubscriptionOptions, TopicReference, UnsubscriptionOptions,
         },
         raw::Raw,
     },
@@ -61,6 +61,13 @@ pub use raw::AbortError;
 ///   - It is recommended (but not strictly required) to use a value >= 1, because if the value is 0, the client does not
 ///     guarantee to detect the protocol error and disconnect from the server when the request problem information property in
 ///     CONNECT is 0 and the server sends user properties in a packet other than CONNACK, DISCONNECT or PUBLISH.
+/// - `MAX_INCOMING_TOPIC_ALIASES´: The maximum number of topic aliases the client supports in inbound direction This is the
+///   same value as the client topic alias maximum and no topic aliases greater than this value can be used in PUBLISH packets
+///   sent by the server. If this value is greater than the MQTT default of 0, the client will ínclude this value in its topic
+///   alias maximum value in the CONNECT packet. Must not be greater than 65535.
+/// - `MAX_OUTGOING_TOPIC_ALIASES`: The maximum number of topic aliases the client supports in outbound direction. The server
+///   may limit the client to a lower number of topic aliases in PUBLISH packets sent by the client by setting its topic alias
+///   maximum in the CONNACK packet to a lower value. Must not be greater than 65535.
 ///
 /// The client has two modes of how the acknowledgements within handshakes of [`QoS::AtLeastOnce`] and [`QoS::ExactlyOnce`]
 /// publications are handled. These modes are the default [`AckMode::Automatic`] and the proactively configurable
@@ -158,11 +165,17 @@ pub struct Client<
     const SEND_MAXIMUM: usize,
     const MAX_SUBSCRIPTION_IDENTIFIERS: usize,
     const MAX_USER_PROPERTIES: usize,
+    const MAX_INCOMING_TOPIC_ALIASES: usize,
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,
 > {
     client_config: ClientConfig<'a>,
     shared_config: SharedConfig,
     server_config: ServerConfig,
-    session: Session<SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>,
+    session: Session<
+        SUBSCRIBE_MAXIMUM,
+        RECEIVE_MAXIMUM,
+        SEND_MAXIMUM,
+        MAX_INCOMING_TOPIC_ALIASES, MAX_OUTGOING_TOPIC_ALIASES>,
 
     raw: Raw<'c, N, B>,
 
@@ -180,7 +193,8 @@ impl<
     const SEND_MAXIMUM: usize,
     const MAX_SUBSCRIPTION_IDENTIFIERS: usize,
     const MAX_USER_PROPERTIES: usize,
-> core::fmt::Debug
+    const MAX_INCOMING_TOPIC_ALIASES: usize,
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,> core::fmt::Debug
     for Client<
         '_,
         'c,
@@ -191,7 +205,8 @@ impl<
         SEND_MAXIMUM,
         MAX_SUBSCRIPTION_IDENTIFIERS,
         MAX_USER_PROPERTIES,
-    >
+        MAX_INCOMING_TOPIC_ALIASES,
+                MAX_OUTGOING_TOPIC_ALIASES,    >
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Client")
@@ -215,7 +230,8 @@ impl<
     const SEND_MAXIMUM: usize,
     const MAX_SUBSCRIPTION_IDENTIFIERS: usize,
     const MAX_USER_PROPERTIES: usize,
-> defmt::Format
+    const MAX_INCOMING_TOPIC_ALIASES: usize,
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,> defmt::Format
     for Client<
         '_,
         'c,
@@ -226,7 +242,8 @@ impl<
         SEND_MAXIMUM,
         MAX_SUBSCRIPTION_IDENTIFIERS,
         MAX_USER_PROPERTIES,
-    >
+        MAX_INCOMING_TOPIC_ALIASES,
+                MAX_OUTGOING_TOPIC_ALIASES,    >
 {
     fn format(&self, fmt: defmt::Formatter) {
         defmt::write!(
@@ -252,6 +269,8 @@ impl<
     const SEND_MAXIMUM: usize,
     const MAX_SUBSCRIPTION_IDENTIFIERS: usize,
     const MAX_USER_PROPERTIES: usize,
+    const MAX_INCOMING_TOPIC_ALIASES: usize,
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,
 >
     Client<
         'a,
@@ -263,6 +282,8 @@ impl<
         SEND_MAXIMUM,
         MAX_SUBSCRIPTION_IDENTIFIERS,
         MAX_USER_PROPERTIES,
+        MAX_INCOMING_TOPIC_ALIASES,
+        MAX_OUTGOING_TOPIC_ALIASES,
     >
 {
     /// Creates a new, disconnected MQTT client using a buffer provider to store
@@ -289,6 +310,14 @@ impl<
                 MAX_USER_PROPERTIES <= 1021,
                 "MAX_USER_PROPERTIES must be less than or equal to 1021"
             );
+            const_assert!(
+                MAX_INCOMING_TOPIC_ALIASES <= 65535,
+                "MAX_INCOMING_TOPIC_ALIASES must be less than or equal to 65535"
+            );
+            const_assert!(
+                MAX_OUTGOING_TOPIC_ALIASES <= 65535,
+                "MAX_OUTGOING_TOPIC_ALIASES must be less than or equal to 65535"
+            );
         }
 
         Self {
@@ -306,7 +335,8 @@ impl<
     /// Creates a new, disconnected MQTT client using a buffer provider to store
     /// dynamically sized fields of received packets.
     pub fn with_session(
-        session: Session<SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>,
+        session: Session<SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM, MAX_INCOMING_TOPIC_ALIASES,
+                MAX_OUTGOING_TOPIC_ALIASES,>,
         buffer: &'c mut B,
     ) -> Self {
         let mut s = Self::new(buffer);
@@ -355,7 +385,10 @@ impl<
 
     /// Returns session related configuration and tracking information.
     #[inline]
-    pub fn session(&self) -> &Session<SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM> {
+    pub fn session(
+        &self,
+    ) -> &Session<SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM, MAX_INCOMING_TOPIC_ALIASES,
+            MAX_OUTGOING_TOPIC_ALIASES,> {
         &self.session
     }
 
@@ -457,6 +490,10 @@ impl<
                 .map(Into::into)
                 .collect(),
         );
+
+        if MAX_INCOMING_TOPIC_ALIASES > 0 {
+            packet.add_topic_alias_maximum((MAX_INCOMING_TOPIC_ALIASES as u16).into());
+        }
 
         if let Some(ref authentication_method) = self.client_config.authentication_method {
             packet.add_authentication_method(authentication_method.as_borrowed().into());
@@ -1189,6 +1226,8 @@ impl<
     /// * The [`QoS`] should be less than or equal to the server's maximum [`QoS`].
     /// * The retain flag should only be set if the server supports retain.
     /// * A topic alias must be less than or equal to the server's maximum topic alias.
+    /// * A topic alias must have an existing mapping in the current network connection.
+    /// * A topic alias must not be greater than `MAX_OUTGOING_TOPIC_ALIASES`.
     ///
     /// The server support of these requirements can be checked via [`Client::server_config`].
     /// If a violation occurs, the client will not publish but prevent the protocol error
@@ -1221,11 +1260,14 @@ impl<
     ///   of outgoing publications, SUBSCRIBEs and UNSUBSCRIBEs
     /// * [`MqttError::ManualAckNotAllowed`] if the [`QoS`] is [`QoS::AtMostOnce`] or
     ///   [`QoS::AtLeastOnce`] and [`PublicationOptions::ack_mode`] is [`AckMode::Manual`]
+    /// * [`MqttError::TopicAliasNotMapped`] if the topic is the [`TopicReference::Alias`] variant and
+    ///   its value has not been mapped previously in the network connection.
     ///
     /// # Panics
     ///
     /// This function panics if the length of the `user_properties` slice in the [`PublicationOptions`]
     /// is greater than `MAX_USER_PROPERTIES`.
+    /// This function panics if a topic alias is used and it's greater than `MAX_OUTGOING_TOPIC_ALIASES`.
     pub async fn publish(
         &mut self,
         options: &PublicationOptions<'_>,
@@ -1238,10 +1280,23 @@ impl<
             MAX_USER_PROPERTIES
         );
 
+        if let Some(alias) = options.topic.alias() {
+            assert!(
+                usize::from(alias.get()) <= MAX_OUTGOING_TOPIC_ALIASES,
+                "attempted to publish to a topic alias greater than the client's maximum"
+            );
+        }
+
         if (matches!(options.qos, QoS::AtMostOnce | QoS::AtLeastOnce)
             && options.ack_mode == AckMode::Manual)
         {
             return Err(MqttError::ManualAckNotAllowed);
+        }
+
+        if let TopicReference::Alias(alias) = options.topic
+            && !self.session.is_mapped_outbound_alias(alias)
+        {
+            return Err(MqttError::TopicAliasNotMapped);
         }
 
         if options.qos > self.server_config.maximum_qos {
@@ -1329,6 +1384,12 @@ impl<
                 })?;
         }
 
+        if let TopicReference::Mapping(_, alias) = options.topic {
+            trace!("(re-)mapping outgoing topic alias {}", alias);
+
+            self.session.map_outbound_alias(alias);
+        }
+
         match identified_qos.packet_identifier() {
             Some(pid) => debug!("sending PUBLISH packet with packet identifier {}", pid),
             None => debug!("sending PUBLISH packet"),
@@ -1351,6 +1412,7 @@ impl<
     ///   * The [`QoS`] should be less than or equal to the server's maximum [`QoS`].
     ///   * The retain flag should only be set if the server supports retain.
     ///   * A topic alias must be less than or equal to the server's maximum topic alias.
+    ///   * A topic alias must have an existing mapping in the current network connection.
     /// * Client-side preconditions:
     ///   * The [`QoS`] must be [`QoS::AtLeastOnce`] or [`QoS::ExactlyOnce`] and must be the same as
     ///     that of the original publication.
@@ -1360,6 +1422,7 @@ impl<
     ///     the PUBCOMP packet.
     ///   * The previous PUBLISH packet must have been sent in a different, previous network
     ///     connection.
+    ///   * A topic alias must not be greater than `MAX_OUTGOING_TOPIC_ALIASES`.
     ///
     /// If a violation occurs, the client will not publish but prevent the protocol error
     /// and return an error. The server support of these requirements can be checked via
@@ -1388,12 +1451,15 @@ impl<
     ///     the retain flag set to true is attempted
     ///   * if a topic alias is used and its value is greater than the maximum value specified in the
     ///     server's CONNACK packet
+    /// * [`MqttError::TopicAliasNotMapped`] if the topic is the [`TopicReference::Alias`] variant and
+    ///   its value has not been mapped previously in the network connection.
     ///
     /// # Panics
     ///
     /// This function may panic if the [`QoS`] in the `options` is [`QoS::AtMostOnce`].
     /// This function panics if the length of the `user_properties` slice in the [`PublicationOptions`]
     /// is greater than `MAX_USER_PROPERTIES`.
+    /// This function panics if a topic alias is used and it's greater than `MAX_OUTGOING_TOPIC_ALIASES`.
     pub async fn republish(
         &mut self,
         packet_identifier: PacketIdentifier,
@@ -1412,6 +1478,19 @@ impl<
             QoS::AtMostOnce,
             "QoS 0 packets cannot be republished"
         );
+
+        if let Some(alias) = options.topic.alias() {
+            assert!(
+                usize::from(alias.get()) < MAX_OUTGOING_TOPIC_ALIASES,
+                "attempted to publish to a topic alias greater than the client's maximum"
+            );
+        }
+
+        if let TopicReference::Alias(alias) = options.topic
+            && !self.session.is_mapped_outbound_alias(alias)
+        {
+            return Err(MqttError::TopicAliasNotMapped);
+        }
 
         if options.qos > self.server_config.maximum_qos {
             return Err(MqttError::UnsupportedByServer);
@@ -1476,6 +1555,12 @@ impl<
                 SmError::QoSMismatched => MqttError::QoSMismatched,
                 SmError::HandshakeStateMismatched => MqttError::HandshakeStateMismatched,
             })?;
+
+        if let TopicReference::Mapping(_, alias) = options.topic {
+            trace!("(re-)mapping outgoing topic alias {}", alias);
+
+            self.session.map_outbound_alias(alias);
+        }
 
         debug!(
             "resending PUBLISH packet with packet identifier {}",
@@ -2337,13 +2422,24 @@ impl<
                     )
                     .await?;
 
-                // Our topic alias maximum is always 0, the moment we receive a topic alias, this is an error.
-                // TODO check topic alias allowance
-                // let TopicReference::Name(topic) = publish.topic else {
-                //     error!("received disallowed topic alias");
-                //     self.raw.prepare_disconnect(ReasonCode::TopicAliasInvalid);
-                //     return Err(MqttError::Server);
-                // };
+                if let Some(alias) = publish.topic.alias()
+                    && usize::from(alias.get()) > MAX_INCOMING_TOPIC_ALIASES                {
+                    error!("received disallowed topic alias {}", alias);
+                    self.raw.prepare_disconnect(ReasonCode::TopicAliasInvalid);
+                    return Err(MqttError::Server);
+                }
+                if let TopicReference::Alias(alias) = publish.topic
+                    && !self.session.is_mapped_inbound_alias(alias)
+                {
+                    error!("received publish to unmapped topic alias {}", alias);
+                    self.raw.prepare_disconnect(ReasonCode::ProtocolError);
+                    return Err(MqttError::Server);
+                }
+                if let TopicReference::Mapping(_, alias) = publish.topic {
+                    trace!("(re-)mapping incoming topic alias {}", alias);
+
+                    self.session.map_inbound_alias(alias);
+                }
 
                 let publish = Publish {
                     ack_mode: AckMode::default(),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -15,7 +15,7 @@ use crate::{
         raw::Raw,
     },
     config::{ClientConfig, MaximumPacketSize, ServerConfig, SessionExpiryInterval, SharedConfig},
-    fmt::{assert, const_assert, debug, error, info, panic, trace, unreachable, warn},
+    fmt::{assert, assert_ne, const_assert, debug, error, info, panic, trace, unreachable, warn},
     header::{FixedHeader, PacketType},
     io::Transport,
     packet::{Packet, TxPacket},

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -175,7 +175,9 @@ pub struct Client<
         SUBSCRIBE_MAXIMUM,
         RECEIVE_MAXIMUM,
         SEND_MAXIMUM,
-        MAX_INCOMING_TOPIC_ALIASES, MAX_OUTGOING_TOPIC_ALIASES>,
+        MAX_INCOMING_TOPIC_ALIASES,
+        MAX_OUTGOING_TOPIC_ALIASES,
+    >,
 
     raw: Raw<'c, N, B>,
 
@@ -194,7 +196,8 @@ impl<
     const MAX_SUBSCRIPTION_IDENTIFIERS: usize,
     const MAX_USER_PROPERTIES: usize,
     const MAX_INCOMING_TOPIC_ALIASES: usize,
-    const MAX_OUTGOING_TOPIC_ALIASES: usize,> core::fmt::Debug
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,
+> core::fmt::Debug
     for Client<
         '_,
         'c,
@@ -206,7 +209,8 @@ impl<
         MAX_SUBSCRIPTION_IDENTIFIERS,
         MAX_USER_PROPERTIES,
         MAX_INCOMING_TOPIC_ALIASES,
-                MAX_OUTGOING_TOPIC_ALIASES,    >
+        MAX_OUTGOING_TOPIC_ALIASES,
+    >
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Client")
@@ -231,7 +235,8 @@ impl<
     const MAX_SUBSCRIPTION_IDENTIFIERS: usize,
     const MAX_USER_PROPERTIES: usize,
     const MAX_INCOMING_TOPIC_ALIASES: usize,
-    const MAX_OUTGOING_TOPIC_ALIASES: usize,> defmt::Format
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,
+> defmt::Format
     for Client<
         '_,
         'c,
@@ -243,7 +248,8 @@ impl<
         MAX_SUBSCRIPTION_IDENTIFIERS,
         MAX_USER_PROPERTIES,
         MAX_INCOMING_TOPIC_ALIASES,
-                MAX_OUTGOING_TOPIC_ALIASES,    >
+        MAX_OUTGOING_TOPIC_ALIASES,
+    >
 {
     fn format(&self, fmt: defmt::Formatter) {
         defmt::write!(
@@ -335,8 +341,13 @@ impl<
     /// Creates a new, disconnected MQTT client using a buffer provider to store
     /// dynamically sized fields of received packets.
     pub fn with_session(
-        session: Session<SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM, MAX_INCOMING_TOPIC_ALIASES,
-                MAX_OUTGOING_TOPIC_ALIASES,>,
+        session: Session<
+            SUBSCRIBE_MAXIMUM,
+            RECEIVE_MAXIMUM,
+            SEND_MAXIMUM,
+            MAX_INCOMING_TOPIC_ALIASES,
+            MAX_OUTGOING_TOPIC_ALIASES,
+        >,
         buffer: &'c mut B,
     ) -> Self {
         let mut s = Self::new(buffer);
@@ -387,8 +398,13 @@ impl<
     #[inline]
     pub fn session(
         &self,
-    ) -> &Session<SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM, MAX_INCOMING_TOPIC_ALIASES,
-            MAX_OUTGOING_TOPIC_ALIASES,> {
+    ) -> &Session<
+        SUBSCRIBE_MAXIMUM,
+        RECEIVE_MAXIMUM,
+        SEND_MAXIMUM,
+        MAX_INCOMING_TOPIC_ALIASES,
+        MAX_OUTGOING_TOPIC_ALIASES,
+    > {
         &self.session
     }
 
@@ -2423,7 +2439,8 @@ impl<
                     .await?;
 
                 if let Some(alias) = publish.topic.alias()
-                    && usize::from(alias.get()) > MAX_INCOMING_TOPIC_ALIASES                {
+                    && usize::from(alias.get()) > MAX_INCOMING_TOPIC_ALIASES
+                {
                     error!("received disallowed topic alias {}", alias);
                     self.raw.prepare_disconnect(ReasonCode::TopicAliasInvalid);
                     return Err(MqttError::Server);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -10,7 +10,7 @@ use crate::{
         event::{Auth, Connected, Event, Puback, Publish, Pubrej, Suback},
         options::{
             AckMode, AckOptions, ConnectOptions, DisconnectOptions, PublicationOptions,
-            ReAuthOptions, SubscriptionOptions, TopicReference, UnsubscriptionOptions,
+            ReAuthOptions, SubscriptionOptions, UnsubscriptionOptions,
         },
         raw::Raw,
     },
@@ -2338,18 +2338,19 @@ impl<
                     .await?;
 
                 // Our topic alias maximum is always 0, the moment we receive a topic alias, this is an error.
-                let TopicReference::Name(topic) = publish.topic else {
-                    error!("received disallowed topic alias");
-                    self.raw.prepare_disconnect(ReasonCode::TopicAliasInvalid);
-                    return Err(MqttError::Server);
-                };
+                // TODO check topic alias allowance
+                // let TopicReference::Name(topic) = publish.topic else {
+                //     error!("received disallowed topic alias");
+                //     self.raw.prepare_disconnect(ReasonCode::TopicAliasInvalid);
+                //     return Err(MqttError::Server);
+                // };
 
                 let publish = Publish {
                     ack_mode: AckMode::default(),
                     dup: publish.dup,
                     identified_qos: publish.identified_qos,
                     retain: publish.retain,
-                    topic,
+                    topic: publish.topic,
                     payload_format_indicator: publish
                         .payload_format_indicator
                         .map(Property::into_inner),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1309,10 +1309,10 @@ impl<
             return Err(MqttError::ManualAckNotAllowed);
         }
 
-        if let TopicReference::Alias(alias) = options.topic
-            && !self.session.is_mapped_outbound_alias(alias)
-        {
-            return Err(MqttError::TopicAliasNotMapped);
+        if let TopicReference::Alias(alias) = options.topic {
+            if !self.session.is_mapped_outbound_alias(alias) {
+                return Err(MqttError::TopicAliasNotMapped);
+            }
         }
 
         if options.qos > self.server_config.maximum_qos {
@@ -1502,10 +1502,10 @@ impl<
             );
         }
 
-        if let TopicReference::Alias(alias) = options.topic
-            && !self.session.is_mapped_outbound_alias(alias)
-        {
-            return Err(MqttError::TopicAliasNotMapped);
+        if let TopicReference::Alias(alias) = options.topic {
+            if !self.session.is_mapped_outbound_alias(alias) {
+                return Err(MqttError::TopicAliasNotMapped);
+            }
         }
 
         if options.qos > self.server_config.maximum_qos {
@@ -2438,19 +2438,19 @@ impl<
                     )
                     .await?;
 
-                if let Some(alias) = publish.topic.alias()
-                    && usize::from(alias.get()) > MAX_INCOMING_TOPIC_ALIASES
-                {
-                    error!("received disallowed topic alias {}", alias);
-                    self.raw.prepare_disconnect(ReasonCode::TopicAliasInvalid);
-                    return Err(MqttError::Server);
+                if let Some(alias) = publish.topic.alias() {
+                    if usize::from(alias.get()) > MAX_INCOMING_TOPIC_ALIASES {
+                        error!("received disallowed topic alias {}", alias);
+                        self.raw.prepare_disconnect(ReasonCode::TopicAliasInvalid);
+                        return Err(MqttError::Server);
+                    }
                 }
-                if let TopicReference::Alias(alias) = publish.topic
-                    && !self.session.is_mapped_inbound_alias(alias)
-                {
-                    error!("received publish to unmapped topic alias {}", alias);
-                    self.raw.prepare_disconnect(ReasonCode::ProtocolError);
-                    return Err(MqttError::Server);
+                if let TopicReference::Alias(alias) = publish.topic {
+                    if !self.session.is_mapped_inbound_alias(alias) {
+                        error!("received publish to unmapped topic alias {}", alias);
+                        self.raw.prepare_disconnect(ReasonCode::ProtocolError);
+                        return Err(MqttError::Server);
+                    }
                 }
                 if let TopicReference::Mapping(_, alias) = publish.topic {
                     trace!("(re-)mapping incoming topic alias {}", alias);

--- a/src/client/options/publish.rs
+++ b/src/client/options/publish.rs
@@ -205,14 +205,19 @@ pub enum TopicReference<'t> {
 }
 
 impl<'t> TopicReference<'t> {
-    pub(crate) fn alias(&self) -> Option<NonZero<u16>> {
+    /// If present in the variant, returns the topic alias value of the [`TopicReference`].
+    /// This is the case for [`TopicReference::Mapping`] and [`TopicReference::Alias`].
+    pub fn alias(&self) -> Option<NonZero<u16>> {
         match self {
             Self::Name(_) => None,
             Self::Alias(alias) => Some(*alias),
             Self::Mapping(_, alias) => Some(*alias),
         }
     }
-    pub(crate) fn topic_name(&self) -> Option<&TopicName<'t>> {
+
+    /// If present in the variant, returns the topic name value of the [`TopicReference`].
+    /// This is the case for [`TopicReference::Name`] and [`TopicReference::Mapping`].
+    pub fn name(&self) -> Option<&TopicName<'t>> {
         match self {
             Self::Name(topic_name) => Some(topic_name),
             Self::Alias(_) => None,

--- a/src/session/handle.rs
+++ b/src/session/handle.rs
@@ -10,13 +10,34 @@ pub struct FreeHandle<
     const SUBSCRIBE_MAXIMUM: usize,
     const RECEIVE_MAXIMUM: usize,
     const SEND_MAXIMUM: usize,
+    const MAX_INCOMING_TOPIC_ALIASES: usize,
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,
 > {
-    pub session: &'a mut Session<SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>,
+    pub session: &'a mut Session<
+        SUBSCRIBE_MAXIMUM,
+        RECEIVE_MAXIMUM,
+        SEND_MAXIMUM,
+        MAX_INCOMING_TOPIC_ALIASES,
+        MAX_OUTGOING_TOPIC_ALIASES,
+    >,
     pub packet_identifier: PacketIdentifier,
 }
 
-impl<const SUBSCRIBE_MAXIMUM: usize, const RECEIVE_MAXIMUM: usize, const SEND_MAXIMUM: usize>
-    FreeHandle<'_, SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>
+impl<
+    const SUBSCRIBE_MAXIMUM: usize,
+    const RECEIVE_MAXIMUM: usize,
+    const SEND_MAXIMUM: usize,
+    const MAX_INCOMING_TOPIC_ALIASES: usize,
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,
+>
+    FreeHandle<
+        '_,
+        SUBSCRIBE_MAXIMUM,
+        RECEIVE_MAXIMUM,
+        SEND_MAXIMUM,
+        MAX_INCOMING_TOPIC_ALIASES,
+        MAX_OUTGOING_TOPIC_ALIASES,
+    >
 {
     pub fn outbound_sub(self) -> Result<(), Error> {
         self.session
@@ -96,13 +117,34 @@ pub struct SubHandle<
     const SUBSCRIBE_MAXIMUM: usize,
     const RECEIVE_MAXIMUM: usize,
     const SEND_MAXIMUM: usize,
+    const MAX_INCOMING_TOPIC_ALIASES: usize,
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,
 > {
-    pub session: &'a mut Session<SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>,
+    pub session: &'a mut Session<
+        SUBSCRIBE_MAXIMUM,
+        RECEIVE_MAXIMUM,
+        SEND_MAXIMUM,
+        MAX_INCOMING_TOPIC_ALIASES,
+        MAX_OUTGOING_TOPIC_ALIASES,
+    >,
     pub i: usize,
 }
 
-impl<const SUBSCRIBE_MAXIMUM: usize, const RECEIVE_MAXIMUM: usize, const SEND_MAXIMUM: usize>
-    SubHandle<'_, SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>
+impl<
+    const SUBSCRIBE_MAXIMUM: usize,
+    const RECEIVE_MAXIMUM: usize,
+    const SEND_MAXIMUM: usize,
+    const MAX_INCOMING_TOPIC_ALIASES: usize,
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,
+>
+    SubHandle<
+        '_,
+        SUBSCRIBE_MAXIMUM,
+        RECEIVE_MAXIMUM,
+        SEND_MAXIMUM,
+        MAX_INCOMING_TOPIC_ALIASES,
+        MAX_OUTGOING_TOPIC_ALIASES,
+    >
 {
     pub(crate) fn remove(self) {
         trace!("#{}: AwaitSuback -> Untracked", self.packet_identifier());
@@ -119,13 +161,34 @@ pub struct UnsubHandle<
     const SUBSCRIBE_MAXIMUM: usize,
     const RECEIVE_MAXIMUM: usize,
     const SEND_MAXIMUM: usize,
+    const MAX_INCOMING_TOPIC_ALIASES: usize,
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,
 > {
-    pub session: &'a mut Session<SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>,
+    pub session: &'a mut Session<
+        SUBSCRIBE_MAXIMUM,
+        RECEIVE_MAXIMUM,
+        SEND_MAXIMUM,
+        MAX_INCOMING_TOPIC_ALIASES,
+        MAX_OUTGOING_TOPIC_ALIASES,
+    >,
     pub i: usize,
 }
 
-impl<const SUBSCRIBE_MAXIMUM: usize, const RECEIVE_MAXIMUM: usize, const SEND_MAXIMUM: usize>
-    UnsubHandle<'_, SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>
+impl<
+    const SUBSCRIBE_MAXIMUM: usize,
+    const RECEIVE_MAXIMUM: usize,
+    const SEND_MAXIMUM: usize,
+    const MAX_INCOMING_TOPIC_ALIASES: usize,
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,
+>
+    UnsubHandle<
+        '_,
+        SUBSCRIBE_MAXIMUM,
+        RECEIVE_MAXIMUM,
+        SEND_MAXIMUM,
+        MAX_INCOMING_TOPIC_ALIASES,
+        MAX_OUTGOING_TOPIC_ALIASES,
+    >
 {
     pub(crate) fn remove(self) {
         trace!("#{}: AwaitUnsuback -> Untracked", self.packet_identifier());
@@ -142,14 +205,35 @@ pub struct InboundHandle<
     const SUBSCRIBE_MAXIMUM: usize,
     const RECEIVE_MAXIMUM: usize,
     const SEND_MAXIMUM: usize,
+    const MAX_INCOMING_TOPIC_ALIASES: usize,
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,
 > {
-    pub session: &'a mut Session<SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>,
+    pub session: &'a mut Session<
+        SUBSCRIBE_MAXIMUM,
+        RECEIVE_MAXIMUM,
+        SEND_MAXIMUM,
+        MAX_INCOMING_TOPIC_ALIASES,
+        MAX_OUTGOING_TOPIC_ALIASES,
+    >,
     pub i: usize,
     pub state: PeerPublishState,
 }
 
-impl<const SUBSCRIBE_MAXIMUM: usize, const RECEIVE_MAXIMUM: usize, const SEND_MAXIMUM: usize>
-    InboundHandle<'_, SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>
+impl<
+    const SUBSCRIBE_MAXIMUM: usize,
+    const RECEIVE_MAXIMUM: usize,
+    const SEND_MAXIMUM: usize,
+    const MAX_INCOMING_TOPIC_ALIASES: usize,
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,
+>
+    InboundHandle<
+        '_,
+        SUBSCRIBE_MAXIMUM,
+        RECEIVE_MAXIMUM,
+        SEND_MAXIMUM,
+        MAX_INCOMING_TOPIC_ALIASES,
+        MAX_OUTGOING_TOPIC_ALIASES,
+    >
 {
     fn set(&mut self, state: PeerPublishState) {
         trace!(
@@ -655,14 +739,35 @@ pub struct OutboundHandle<
     const SUBSCRIBE_MAXIMUM: usize,
     const RECEIVE_MAXIMUM: usize,
     const SEND_MAXIMUM: usize,
+    const MAX_INCOMING_TOPIC_ALIASES: usize,
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,
 > {
-    pub session: &'a mut Session<SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>,
+    pub session: &'a mut Session<
+        SUBSCRIBE_MAXIMUM,
+        RECEIVE_MAXIMUM,
+        SEND_MAXIMUM,
+        MAX_INCOMING_TOPIC_ALIASES,
+        MAX_OUTGOING_TOPIC_ALIASES,
+    >,
     pub i: usize,
     pub state: LocalPublishState,
 }
 
-impl<const SUBSCRIBE_MAXIMUM: usize, const RECEIVE_MAXIMUM: usize, const SEND_MAXIMUM: usize>
-    OutboundHandle<'_, SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>
+impl<
+    const SUBSCRIBE_MAXIMUM: usize,
+    const RECEIVE_MAXIMUM: usize,
+    const SEND_MAXIMUM: usize,
+    const MAX_INCOMING_TOPIC_ALIASES: usize,
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,
+>
+    OutboundHandle<
+        '_,
+        SUBSCRIBE_MAXIMUM,
+        RECEIVE_MAXIMUM,
+        SEND_MAXIMUM,
+        MAX_INCOMING_TOPIC_ALIASES,
+        MAX_OUTGOING_TOPIC_ALIASES,
+    >
 {
     fn set(&mut self, state: LocalPublishState) {
         trace!(

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,6 +1,6 @@
 //! Contains utilities for session management.
 
-use core::cmp::min;
+use core::{cmp::min, num::NonZero};
 use heapless::Vec;
 
 use crate::{
@@ -184,16 +184,23 @@ pub(crate) enum Event {
     ServerError,
 }
 
-/// Session-associated information
+/// Session- and connection-associated information
 ///
 /// Client identifier is not stored here as it would lead to inconsistencies with the underyling allocation system.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Session<
     const SUBSCRIBE_MAXIMUM: usize,
     const RECEIVE_MAXIMUM: usize,
     const SEND_MAXIMUM: usize,
+    const MAX_INCOMING_TOPIC_ALIASES: usize,
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,
 > {
+    /// The mapped topic aliases in incoming publications.
+    pub inbound_topic_aliases: [bool; MAX_INCOMING_TOPIC_ALIASES],
+    /// The mapped topic aliases in outgoing publications.
+    pub outbound_topic_aliases: [bool; MAX_OUTGOING_TOPIC_ALIASES],
+
     /// The currently in-flight subscriptions.
     pub subs: Vec<PacketIdentifier, SUBSCRIBE_MAXIMUM>,
     /// The currently in-flight unsubscriptions.
@@ -205,8 +212,47 @@ pub struct Session<
     pub outbound_publishes: Vec<(PacketIdentifier, LocalPublishState), SEND_MAXIMUM>,
 }
 
-impl<const SUBSCRIBE_MAXIMUM: usize, const RECEIVE_MAXIMUM: usize, const SEND_MAXIMUM: usize>
-    Session<SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>
+impl<
+    const SUBSCRIBE_MAXIMUM: usize,
+    const RECEIVE_MAXIMUM: usize,
+    const SEND_MAXIMUM: usize,
+    const MAX_INCOMING_TOPIC_ALIASES: usize,
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,
+> Default
+    for Session<
+        SUBSCRIBE_MAXIMUM,
+        RECEIVE_MAXIMUM,
+        SEND_MAXIMUM,
+        MAX_INCOMING_TOPIC_ALIASES,
+        MAX_OUTGOING_TOPIC_ALIASES,
+    >
+{
+    fn default() -> Self {
+        Self {
+            inbound_topic_aliases: [Default::default(); _],
+            outbound_topic_aliases: [Default::default(); _],
+            subs: Default::default(),
+            unsubs: Default::default(),
+            inbound_publishes: Default::default(),
+            outbound_publishes: Default::default(),
+        }
+    }
+}
+
+impl<
+    const SUBSCRIBE_MAXIMUM: usize,
+    const RECEIVE_MAXIMUM: usize,
+    const SEND_MAXIMUM: usize,
+    const MAX_INCOMING_TOPIC_ALIASES: usize,
+    const MAX_OUTGOING_TOPIC_ALIASES: usize,
+>
+    Session<
+        SUBSCRIBE_MAXIMUM,
+        RECEIVE_MAXIMUM,
+        SEND_MAXIMUM,
+        MAX_INCOMING_TOPIC_ALIASES,
+        MAX_OUTGOING_TOPIC_ALIASES,
+    >
 {
     /// Creates a handle to an unused packet identifier for usage in a new SUBSCRIBE, UNSUBSCRIBE
     /// or PUBLISH packet. Whether the specific type of category actually has free buffer space
@@ -214,7 +260,16 @@ impl<const SUBSCRIBE_MAXIMUM: usize, const RECEIVE_MAXIMUM: usize, const SEND_MA
     /// block other packet types from being sent.
     pub(crate) fn free_handle(
         &mut self,
-    ) -> Option<FreeHandle<'_, SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>> {
+    ) -> Option<
+        FreeHandle<
+            '_,
+            SUBSCRIBE_MAXIMUM,
+            RECEIVE_MAXIMUM,
+            SEND_MAXIMUM,
+            MAX_INCOMING_TOPIC_ALIASES,
+            MAX_OUTGOING_TOPIC_ALIASES,
+        >,
+    > {
         // TODO this can be a better search with a stack bitset / larger window of PIDs
 
         let mut packet_identifier = PacketIdentifier::ONE;
@@ -242,7 +297,16 @@ impl<const SUBSCRIBE_MAXIMUM: usize, const RECEIVE_MAXIMUM: usize, const SEND_MA
     pub(crate) fn sub_handle(
         &mut self,
         packet_identifier: PacketIdentifier,
-    ) -> Option<SubHandle<'_, SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>> {
+    ) -> Option<
+        SubHandle<
+            '_,
+            SUBSCRIBE_MAXIMUM,
+            RECEIVE_MAXIMUM,
+            SEND_MAXIMUM,
+            MAX_INCOMING_TOPIC_ALIASES,
+            MAX_OUTGOING_TOPIC_ALIASES,
+        >,
+    > {
         self.subs
             .iter()
             .position(|&p| p == packet_identifier)
@@ -253,7 +317,16 @@ impl<const SUBSCRIBE_MAXIMUM: usize, const RECEIVE_MAXIMUM: usize, const SEND_MA
     pub(crate) fn unsub_handle(
         &mut self,
         packet_identifier: PacketIdentifier,
-    ) -> Option<UnsubHandle<'_, SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>> {
+    ) -> Option<
+        UnsubHandle<
+            '_,
+            SUBSCRIBE_MAXIMUM,
+            RECEIVE_MAXIMUM,
+            SEND_MAXIMUM,
+            MAX_INCOMING_TOPIC_ALIASES,
+            MAX_OUTGOING_TOPIC_ALIASES,
+        >,
+    > {
         self.unsubs
             .iter()
             .position(|&p| p == packet_identifier)
@@ -264,7 +337,16 @@ impl<const SUBSCRIBE_MAXIMUM: usize, const RECEIVE_MAXIMUM: usize, const SEND_MA
     fn inbound_handle(
         &mut self,
         packet_identifier: PacketIdentifier,
-    ) -> Option<InboundHandle<'_, SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>> {
+    ) -> Option<
+        InboundHandle<
+            '_,
+            SUBSCRIBE_MAXIMUM,
+            RECEIVE_MAXIMUM,
+            SEND_MAXIMUM,
+            MAX_INCOMING_TOPIC_ALIASES,
+            MAX_OUTGOING_TOPIC_ALIASES,
+        >,
+    > {
         self.inbound_publishes
             .iter()
             .copied()
@@ -281,7 +363,16 @@ impl<const SUBSCRIBE_MAXIMUM: usize, const RECEIVE_MAXIMUM: usize, const SEND_MA
     fn outbound_handle(
         &mut self,
         packet_identifier: PacketIdentifier,
-    ) -> Option<OutboundHandle<'_, SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>> {
+    ) -> Option<
+        OutboundHandle<
+            '_,
+            SUBSCRIBE_MAXIMUM,
+            RECEIVE_MAXIMUM,
+            SEND_MAXIMUM,
+            MAX_INCOMING_TOPIC_ALIASES,
+            MAX_OUTGOING_TOPIC_ALIASES,
+        >,
+    > {
         self.outbound_publishes
             .iter()
             .copied()
@@ -300,7 +391,16 @@ impl<const SUBSCRIBE_MAXIMUM: usize, const RECEIVE_MAXIMUM: usize, const SEND_MA
     /// currently in-flight PUBLISH packet / handshake.
     pub(crate) fn outbound_iter(
         &mut self,
-    ) -> Option<OutboundHandle<'_, SUBSCRIBE_MAXIMUM, RECEIVE_MAXIMUM, SEND_MAXIMUM>> {
+    ) -> Option<
+        OutboundHandle<
+            '_,
+            SUBSCRIBE_MAXIMUM,
+            RECEIVE_MAXIMUM,
+            SEND_MAXIMUM,
+            MAX_INCOMING_TOPIC_ALIASES,
+            MAX_OUTGOING_TOPIC_ALIASES,
+        >,
+    > {
         self.outbound_publishes
             .first()
             .map(|(p, s)| (*p, *s))
@@ -371,9 +471,29 @@ impl<const SUBSCRIBE_MAXIMUM: usize, const RECEIVE_MAXIMUM: usize, const SEND_MA
         trace!("#{}: Untracked -> {:?}", packet_identifier, state);
     }
 
+    fn alias_index(alias: NonZero<u16>) -> usize {
+        let i = alias.get() - 1;
+
+        usize::from(i)
+    }
+    pub(crate) fn is_mapped_inbound_alias(&self, alias: NonZero<u16>) -> bool {
+        self.inbound_topic_aliases[Self::alias_index(alias)]
+    }
+    pub(crate) fn is_mapped_outbound_alias(&self, alias: NonZero<u16>) -> bool {
+        self.outbound_topic_aliases[Self::alias_index(alias)]
+    }
+    pub(crate) fn map_inbound_alias(&mut self, alias: NonZero<u16>) {
+        self.inbound_topic_aliases[Self::alias_index(alias)] = true;
+    }
+    pub(crate) fn map_outbound_alias(&mut self, alias: NonZero<u16>) {
+        self.outbound_topic_aliases[Self::alias_index(alias)] = true;
+    }
+
     pub(crate) fn clear(&mut self) {
         trace!("resetting session completely by clearing all entries");
 
+        self.inbound_topic_aliases = [Default::default(); _];
+        self.outbound_topic_aliases = [Default::default(); _];
         self.subs.clear();
         self.unsubs.clear();
         self.inbound_publishes.clear();
@@ -381,6 +501,9 @@ impl<const SUBSCRIBE_MAXIMUM: usize, const RECEIVE_MAXIMUM: usize, const SEND_MA
     }
 
     pub(crate) fn reconnect(&mut self) {
+        self.inbound_topic_aliases = [Default::default(); _];
+        self.outbound_topic_aliases = [Default::default(); _];
+
         trace!("reconnection resets:");
 
         for pid in &self.subs {
@@ -686,6 +809,7 @@ fn trace_nop(packet_identifier: PacketIdentifier) {
 
 #[cfg(test)]
 mod unit {
+    use core::num::NonZero;
     use std::vec::Vec;
 
     use crate::{
@@ -701,7 +825,7 @@ mod unit {
         ) => {
             #[test_log::test]
             fn $test_name() {
-                let mut sm = crate::session::Session::<10, 10, 10>::default();
+                let mut sm = crate::session::Session::<10, 10, 10, 10, 10>::default();
                 let pid = crate::types::PacketIdentifier::ONE;
 
                 sm_test!(@munch, 1, sm, pid, $($steps)*);
@@ -2072,7 +2196,7 @@ mod unit {
         #[test_log::test]
         #[test]
         fn no_sub_buffer_exceedance() {
-            let mut no_sub = Session::<0, 1, 1>::default();
+            let mut no_sub = Session::<0, 1, 1, 0, 0>::default();
             assert_err!(no_sub.free_handle().unwrap().outbound_sub());
             assert_err!(no_sub.free_handle().unwrap().outbound_unsub());
             assert_eq!(
@@ -2090,7 +2214,7 @@ mod unit {
             );
 
             const SOME: usize = 5;
-            let mut some_sub = Session::<SOME, 1, 1>::default();
+            let mut some_sub = Session::<SOME, 1, 1, 0, 0>::default();
             for _ in 0..SOME {
                 assert_ok!(some_sub.free_handle().unwrap().outbound_sub());
                 assert_ok!(some_sub.free_handle().unwrap().outbound_unsub());
@@ -2102,7 +2226,7 @@ mod unit {
         #[test_log::test]
         #[test]
         fn no_out_pub_buffer_exceedance() {
-            let mut no_out_pub = Session::<1, 1, 0>::default();
+            let mut no_out_pub = Session::<1, 1, 0, 0, 0>::default();
             let h = no_out_pub.free_handle().unwrap();
             let pid = h.packet_identifier;
             assert_ok!(h.outbound_sub());
@@ -2126,7 +2250,7 @@ mod unit {
             );
 
             const SOME: usize = 5;
-            let mut some_sub = Session::<1, 1, SOME>::default();
+            let mut some_sub = Session::<1, 1, SOME, 0, 0>::default();
             for _ in 0..SOME {
                 assert_ok!(
                     some_sub
@@ -2644,7 +2768,7 @@ mod unit {
         #[test_log::test]
         #[test]
         fn no_in_pub_buffer_exceedance() {
-            let mut no_in_pub = Session::<1, 0, 1>::default();
+            let mut no_in_pub = Session::<1, 0, 1, 0, 0>::default();
             let h = no_in_pub.free_handle().unwrap();
             let pid = h.packet_identifier;
             assert_ok!(h.outbound_sub());
@@ -2671,7 +2795,7 @@ mod unit {
             );
 
             const SOME: usize = 5;
-            let mut some_in_pub = Session::<1, SOME, 1>::default();
+            let mut some_in_pub = Session::<1, SOME, 1, 0, 0>::default();
             let mut pid = PacketIdentifier::ONE;
             for _ in 0..SOME {
                 assert_eq!(
@@ -2994,7 +3118,7 @@ mod unit {
     #[test_log::test]
     #[test]
     fn inbound_qos1() {
-        let mut sm = Session::<10, 10, 10>::default();
+        let mut sm = Session::<10, 10, 10, 0, 0>::default();
 
         let mut pid = PacketIdentifier::ONE;
         let mut pids = Vec::new();
@@ -3073,7 +3197,7 @@ mod unit {
     #[test_log::test]
     #[test]
     fn inbound_qos2_auto() {
-        let mut sm = Session::<10, 10, 10>::default();
+        let mut sm = Session::<10, 10, 10, 0, 0>::default();
 
         let mut pid = PacketIdentifier::ONE;
         let mut pids = Vec::new();
@@ -3147,7 +3271,7 @@ mod unit {
     #[test_log::test]
     #[test]
     fn inbound_qos2_manual() {
-        let mut sm = Session::<10, 10, 10>::default();
+        let mut sm = Session::<10, 10, 10, 0, 0>::default();
 
         let mut pid = PacketIdentifier::ONE;
         let mut pids = Vec::new();
@@ -3248,7 +3372,7 @@ mod unit {
     #[test_log::test]
     #[test]
     fn outbound_qos1() {
-        let mut sm = Session::<10, 10, 10>::default();
+        let mut sm = Session::<10, 10, 10, 0, 0>::default();
 
         let mut pids = Vec::new();
 
@@ -3291,7 +3415,7 @@ mod unit {
     #[test_log::test]
     #[test]
     fn outbound_qos2_auto() {
-        let mut sm = Session::<10, 10, 10>::default();
+        let mut sm = Session::<10, 10, 10, 0, 0>::default();
 
         let mut pids = Vec::new();
 
@@ -3354,7 +3478,7 @@ mod unit {
     #[test_log::test]
     #[test]
     fn outbound_qos2_manual() {
-        let mut sm = Session::<10, 10, 10>::default();
+        let mut sm = Session::<10, 10, 10, 0, 0>::default();
 
         let mut pids = Vec::new();
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -3556,4 +3556,80 @@ mod unit {
 
         assert!(sm.outbound_publishes.is_empty());
     }
+
+    #[test_log::test]
+    #[test]
+    fn inbound_topic_aliases() {
+        const ONE: NonZero<u16> = NonZero::new(1).unwrap();
+        const TWO: NonZero<u16> = NonZero::new(2).unwrap();
+
+        let mut session = Session::default();
+
+        fn cases(s: &mut Session<0, 0, 0, 2, 0>) {
+            assert!(!s.is_mapped_inbound_alias(ONE));
+            assert!(!s.is_mapped_inbound_alias(TWO));
+
+            // Only the correct alias is mapped
+            s.map_inbound_alias(ONE);
+            assert!(s.is_mapped_inbound_alias(ONE));
+            assert!(!s.is_mapped_inbound_alias(TWO));
+
+            // Remapping doesn't change anything
+            s.map_inbound_alias(ONE);
+            assert!(s.is_mapped_inbound_alias(ONE));
+            assert!(!s.is_mapped_inbound_alias(TWO));
+
+            s.map_inbound_alias(TWO);
+            assert!(s.is_mapped_inbound_alias(ONE));
+            assert!(s.is_mapped_inbound_alias(TWO));
+        }
+
+        cases(&mut session);
+
+        // Clearing the session should clear all mappings
+        session.clear();
+        cases(&mut session);
+
+        // Reconnecting the session should clear all mappings
+        session.reconnect();
+        cases(&mut session);
+    }
+
+    #[test_log::test]
+    #[test]
+    fn outbound_topic_aliases() {
+        const ONE: NonZero<u16> = NonZero::new(1).unwrap();
+        const TWO: NonZero<u16> = NonZero::new(2).unwrap();
+
+        let mut session = Session::default();
+
+        fn cases(s: &mut Session<0, 0, 0, 0, 2>) {
+            assert!(!s.is_mapped_outbound_alias(ONE));
+            assert!(!s.is_mapped_outbound_alias(TWO));
+
+            // Only the correct alias is mapped
+            s.map_outbound_alias(ONE);
+            assert!(s.is_mapped_outbound_alias(ONE));
+            assert!(!s.is_mapped_outbound_alias(TWO));
+
+            // Remapping doesn't change anything
+            s.map_outbound_alias(ONE);
+            assert!(s.is_mapped_outbound_alias(ONE));
+            assert!(!s.is_mapped_outbound_alias(TWO));
+
+            s.map_outbound_alias(TWO);
+            assert!(s.is_mapped_outbound_alias(ONE));
+            assert!(s.is_mapped_outbound_alias(TWO));
+        }
+
+        cases(&mut session);
+
+        // Clearing the session should clear all mappings
+        session.clear();
+        cases(&mut session);
+
+        // Reconnecting the session should clear all mappings
+        session.reconnect();
+        cases(&mut session);
+    }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -229,8 +229,8 @@ impl<
 {
     fn default() -> Self {
         Self {
-            inbound_topic_aliases: [Default::default(); _],
-            outbound_topic_aliases: [Default::default(); _],
+            inbound_topic_aliases: [Default::default(); MAX_INCOMING_TOPIC_ALIASES],
+            outbound_topic_aliases: [Default::default(); MAX_OUTGOING_TOPIC_ALIASES],
             subs: Default::default(),
             unsubs: Default::default(),
             inbound_publishes: Default::default(),
@@ -492,8 +492,8 @@ impl<
     pub(crate) fn clear(&mut self) {
         trace!("resetting session completely by clearing all entries");
 
-        self.inbound_topic_aliases = [Default::default(); _];
-        self.outbound_topic_aliases = [Default::default(); _];
+        self.inbound_topic_aliases = [Default::default(); MAX_INCOMING_TOPIC_ALIASES];
+        self.outbound_topic_aliases = [Default::default(); MAX_OUTGOING_TOPIC_ALIASES];
         self.subs.clear();
         self.unsubs.clear();
         self.inbound_publishes.clear();
@@ -501,8 +501,8 @@ impl<
     }
 
     pub(crate) fn reconnect(&mut self) {
-        self.inbound_topic_aliases = [Default::default(); _];
-        self.outbound_topic_aliases = [Default::default(); _];
+        self.inbound_topic_aliases = [Default::default(); MAX_INCOMING_TOPIC_ALIASES];
+        self.outbound_topic_aliases = [Default::default(); MAX_OUTGOING_TOPIC_ALIASES];
 
         trace!("reconnection resets:");
 

--- a/src/v5/packet/connect.rs
+++ b/src/v5/packet/connect.rs
@@ -206,6 +206,10 @@ impl<'p, const MAX_USER_PROPERTIES: usize> ConnectPacket<'p, MAX_USER_PROPERTIES
         VarByteInt::new_unchecked(len as u32)
     }
 
+    pub fn add_topic_alias_maximum(&mut self, topic_alias_maximum: TopicAliasMaximum) {
+        self.topic_alias_maximum = Some(topic_alias_maximum)
+    }
+
     pub fn add_authentication_method(&mut self, authentication_method: AuthenticationMethod<'p>) {
         self.authentication_method = Some(authentication_method);
     }

--- a/src/v5/packet/publish.rs
+++ b/src/v5/packet/publish.rs
@@ -238,7 +238,7 @@ impl<const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER_PROPERTIES: usize
             .await?;
 
         self.topic
-            .topic_name()
+            .name()
             .map(TopicName::as_borrowed)
             .map_or(Self::EMPTY_TOPIC, Into::into)
             .write(write)
@@ -310,7 +310,7 @@ impl<'p, const MAX_SUBSCRIPTION_IDENTIFIERS: usize, const MAX_USER_PROPERTIES: u
     fn remaining_len_raw(&self) -> Result<VarByteInt, TooLargeToEncode> {
         let topic_name_length = self
             .topic
-            .topic_name()
+            .name()
             .map(TopicName::as_borrowed)
             .map_or(Self::EMPTY_TOPIC, Into::into)
             .written_len();
@@ -493,8 +493,8 @@ mod unit {
 
             0x08, // Response Topic
             0x00, 0x17,
-            b'u', b'n', b'o', b',', b' ', b'd', b'o', b's', b',', b' ', b't', b'r', b'e', b's', b',', b' ', b'c', b'a', b't', b'o', b'r', b'c', b'e', 
-            
+            b'u', b'n', b'o', b',', b' ', b'd', b'o', b's', b',', b' ', b't', b'r', b'e', b's', b',', b' ', b'c', b'a', b't', b'o', b'r', b'c', b'e',
+
             0x09, // Correlation Data
             0x00, 0x08,
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -505,11 +505,11 @@ mod unit {
 
             0x26, // User property
             0x00, 0x04, b'G', b'y', b'r', b'o',
-            0x00, 0x09, b'G', b'e', b'a', b'r', b'l', b'o', b'o', b's', b'e', 
+            0x00, 0x09, b'G', b'e', b'a', b'r', b'l', b'o', b'o', b's', b'e',
 
             0x03, // Content type
             0x00, 0x16,
-            b'a', b'p', b'p', b'l', b'i', b'c', b'a', b't', b'i', b'o', b'n', b'/', b'j', b'a', b'v', b'a', b's', b'c', b'r', b'i', b'p', b't', 
+            b'a', b'p', b'p', b'l', b'i', b'c', b'a', b't', b'i', b'o', b'n', b'/', b'j', b'a', b'v', b'a', b's', b'c', b'r', b'i', b'p', b't',
 
             b'h', // Payload
             b'e', //

--- a/tests/common/assert.rs
+++ b/tests/common/assert.rs
@@ -45,8 +45,11 @@ macro_rules! assert_recv {
 macro_rules! assert_recv_excl {
     ($client:expr, $topic:expr) => {{
         let p = assert_ok!(crate::common::utils::receive_and_complete(&mut $client).await);
+
+        let topic = p.topic.name().expect("expected topic name only");
+
         assert_eq!(
-            &$topic, &p.topic,
+            &$topic, topic,
             "expected topic (left) != received topic (right)"
         );
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -19,7 +19,7 @@ pub mod failing;
 pub mod fmt;
 pub mod utils;
 
-type DefaultClient<'a, T> = Client<'static, 'a, T, AllocBuffer, 1, 1, 1, 1, 16>;
+type DefaultClient<'a, T> = Client<'static, 'a, T, AllocBuffer, 1, 1, 1, 1, 16, 0, 0>;
 
 pub type TestClient<'a> = DefaultClient<'a, FromTokio<TcpStream>>;
 pub type FailingClient<'a> = DefaultClient<'a, FromTokio<FailingTcp>>;

--- a/tests/integration/connect_options.rs
+++ b/tests/integration/connect_options.rs
@@ -723,10 +723,10 @@ async fn keep_alive_not_kept_alive_will_timing() {
 #[test_log::test]
 async fn receive_maximum() {
     let (topic_name, topic_filter) = unique_topic();
-    let mut rx: Client<'_, '_, _, _, 1, 2, 0, 0, 16> = Client::new(ALLOC.get());
+    let mut rx: Client<'_, '_, _, _, 1, 2, 0, 0, 16, 0, 0> = Client::new(ALLOC.get());
     // EMQX calculates its server receive maximum as min(client_receive_maximum, emqx_max_inflight),
     // so we need to go up to 10 on our RECEIVE_MAXIMUM
-    let mut tx: Client<'_, '_, _, _, 1, 10, 10, 0, 16> = Client::new(ALLOC.get());
+    let mut tx: Client<'_, '_, _, _, 1, 10, 10, 0, 16, 0, 0> = Client::new(ALLOC.get());
 
     let tcp_rx = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
     let tcp_tx = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
@@ -793,7 +793,7 @@ async fn send_maximum_buffer_exceeded() {
 
     // EMQX calculates its server receive maximum as min(client_receive_maximum, emqx_max_inflight),
     // so we need to go up to 3 on our RECEIVE_MAXIMUM
-    let mut c: Client<'_, '_, _, _, 1, 3, SEND_MAXIMUM_BUFFER_SIZE, 0, 16> =
+    let mut c: Client<'_, '_, _, _, 1, 3, SEND_MAXIMUM_BUFFER_SIZE, 0, 16, 0, 0> =
         Client::new(ALLOC.get());
 
     let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
@@ -831,7 +831,7 @@ async fn send_maximum_buffer_exceeded() {
 #[test_log::test]
 async fn server_receive_maximum_exceeded() {
     let topic_name = unique_topic().0;
-    let mut c: Client<'_, '_, _, _, 1, 1, 256, 0, 16> = Client::new(ALLOC.get());
+    let mut c: Client<'_, '_, _, _, 1, 1, 256, 0, 16, 0, 0> = Client::new(ALLOC.get());
 
     let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
 

--- a/tests/integration/message_retry.rs
+++ b/tests/integration/message_retry.rs
@@ -66,7 +66,7 @@ async fn outgoing_automatic_qos1_retry() {
         connect_options.clean_start = false;
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-        let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+        let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
             Client::with_session(session, ALLOC.get());
         let info = assert_ok!(warn_inspect!(
             tx.connect(tcp, &connect_options, Some(tx_id.as_borrowed()))
@@ -157,7 +157,7 @@ async fn outgoing_automatic_qos2_retry_publish() {
         connect_options.clean_start = false;
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-        let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+        let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
             Client::with_session(session, ALLOC.get());
         let info = assert_ok!(warn_inspect!(
             tx.connect(tcp, &connect_options, Some(tx_id.as_borrowed()))
@@ -245,7 +245,7 @@ async fn outgoing_manual_qos2_retry_publish() {
         connect_options.clean_start = false;
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-        let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+        let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
             Client::with_session(session, ALLOC.get());
         let info = assert_ok!(warn_inspect!(
             tx.connect(tcp, &connect_options, Some(tx_id.as_borrowed()))
@@ -363,7 +363,7 @@ async fn outgoing_automatic_qos2_retry_pubrel() {
         connect_options.clean_start = false;
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-        let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+        let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
             Client::with_session(session, ALLOC.get());
         let info = assert_ok!(warn_inspect!(
             tx.connect(tcp, &connect_options, Some(tx_id.as_borrowed()))
@@ -482,7 +482,7 @@ async fn outgoing_manual_qos2_retry_pubrel() {
         connect_options.clean_start = false;
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-        let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+        let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
             Client::with_session(session, ALLOC.get());
         let info = assert_ok!(warn_inspect!(
             tx.connect(tcp, &connect_options, Some(tx_id.as_borrowed()))
@@ -594,7 +594,7 @@ async fn incoming_automatic_qos2_retry_pubcomp() {
         connect_options.clean_start = false;
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-        let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+        let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
             Client::with_session(session, ALLOC.get());
         let info = assert_ok!(warn_inspect!(
             rx.connect(tcp, &connect_options, Some(rx_id.as_borrowed()))
@@ -693,7 +693,7 @@ async fn incoming_manual_qos2_retry_pubcomp() {
         connect_options.clean_start = false;
 
         let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-        let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+        let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
             Client::with_session(session, ALLOC.get());
         let info = assert_ok!(warn_inspect!(
             rx.connect(tcp, &connect_options, Some(rx_id.as_borrowed()))
@@ -807,7 +807,7 @@ async fn outgoing_automatic_qos1_write_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+                let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -935,7 +935,7 @@ async fn outgoing_automatic_qos1_read_fail_retry() {
 
                 let pid = session.outbound_publishes.first().unwrap().0;
 
-                let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+                let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -1059,7 +1059,7 @@ async fn outgoing_automatic_qos2_write_fail_retry_hive_only_mosquitto_only() {
 
                 // Complete publish using infallible connection
 
-                let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+                let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -1239,7 +1239,7 @@ async fn outgoing_manual_qos2_write_fail_retry_hive_only_mosquitto_only() {
 
                 // Complete publish using infallible connection
 
-                let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+                let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -1424,7 +1424,7 @@ async fn outgoing_automatic_qos2_read_fail_retry_hive_only_mosquitto_only() {
 
                 // Complete publish using infallible connection
 
-                let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+                let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -1612,7 +1612,7 @@ async fn outgoing_manual_qos2_read_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+                let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -1827,7 +1827,7 @@ async fn incoming_automatic_qos1_write_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -1948,7 +1948,7 @@ async fn incoming_manual_qos1_write_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -2069,7 +2069,7 @@ async fn incoming_automatic_qos1_read_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -2189,7 +2189,7 @@ async fn incoming_manual_qos1_read_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -2324,7 +2324,7 @@ async fn incoming_automatic_qos2_write_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -2474,7 +2474,7 @@ async fn incoming_manual_qos2_write_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -2637,7 +2637,7 @@ async fn incoming_automatic_qos2_read_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(
@@ -2811,7 +2811,7 @@ async fn incoming_manual_qos2_read_fail_retry() {
 
                 // Complete publish using infallible connection
 
-                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> =
+                let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
                     Client::with_session(session, ALLOC.get());
                 let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
                 assert_ok!(

--- a/tests/integration/message_retry.rs
+++ b/tests/integration/message_retry.rs
@@ -104,13 +104,13 @@ async fn outgoing_automatic_qos1_retry() {
         let p = assert_ok!(assert_ok!(
             timeout(Duration::from_secs(5), receive_and_complete(&mut rx)).await
         ));
-        assert_eq!(p.topic, topic_name.as_borrowed());
+        assert_eq!(p.topic.name().unwrap(), &topic_name);
         assert_eq!(p.message, msg.into());
 
         let p = assert_ok!(assert_ok!(
             timeout(Duration::from_secs(5), receive_publish(&mut rx)).await
         ));
-        assert_eq!(p.topic, topic_name.as_borrowed());
+        assert_eq!(p.topic.name().unwrap(), &topic_name);
         assert_eq!(p.message, msg.into());
 
         disconnect(&mut rx, DEFAULT_DC_OPTIONS).await;
@@ -195,7 +195,7 @@ async fn outgoing_automatic_qos2_retry_publish() {
         let p = assert_ok!(assert_ok!(
             timeout(Duration::from_secs(5), receive_and_complete(&mut rx)).await
         ));
-        assert_eq!(p.topic, topic_name.as_borrowed());
+        assert_eq!(p.topic.name().unwrap(), &topic_name);
         assert_eq!(p.message, msg.into());
 
         assert_err!(timeout(Duration::from_secs(5), receive_publish(&mut rx)).await);
@@ -295,7 +295,7 @@ async fn outgoing_manual_qos2_retry_publish() {
         let p = assert_ok!(assert_ok!(
             timeout(Duration::from_secs(5), receive_and_complete(&mut rx)).await
         ));
-        assert_eq!(p.topic, topic_name.as_borrowed());
+        assert_eq!(p.topic.name().unwrap(), &topic_name);
         assert_eq!(p.message, msg.into());
 
         assert_err!(timeout(Duration::from_secs(5), receive_publish(&mut rx)).await);
@@ -407,7 +407,7 @@ async fn outgoing_automatic_qos2_retry_pubrel() {
         let p = assert_ok!(assert_ok!(
             timeout(Duration::from_secs(5), receive_and_complete(&mut rx)).await
         ));
-        assert_eq!(p.topic, topic_name.as_borrowed());
+        assert_eq!(p.topic.name().unwrap(), &topic_name);
         assert_eq!(p.message, msg.into());
 
         assert_err!(timeout(Duration::from_secs(5), receive_publish(&mut rx)).await);
@@ -526,7 +526,7 @@ async fn outgoing_manual_qos2_retry_pubrel() {
         let p = assert_ok!(assert_ok!(
             timeout(Duration::from_secs(5), receive_and_complete(&mut rx)).await
         ));
-        assert_eq!(p.topic, topic_name.as_borrowed());
+        assert_eq!(p.topic.name().unwrap(), &topic_name);
         assert_eq!(p.message, msg.into());
 
         assert_err!(timeout(Duration::from_secs(5), receive_publish(&mut rx)).await);
@@ -582,7 +582,7 @@ async fn incoming_automatic_qos2_retry_pubcomp() {
         );
         assert!(publish.identified_qos.packet_identifier().is_some());
         let pid = publish.identified_qos.packet_identifier().unwrap();
-        assert_eq!(publish.topic, topic_name.as_borrowed());
+        assert_eq!(publish.topic.name().unwrap(), &topic_name);
         assert_eq!(publish.message, msg.into());
 
         let session = rx.session().clone();
@@ -676,7 +676,7 @@ async fn incoming_manual_qos2_retry_pubcomp() {
         );
         assert!(publish.identified_qos.packet_identifier().is_some());
         let pid = publish.identified_qos.packet_identifier().unwrap();
-        assert_eq!(publish.topic, topic_name.as_borrowed());
+        assert_eq!(publish.topic.name().unwrap(), &topic_name);
         assert_eq!(publish.message, msg.into());
 
         assert_ok!(

--- a/tests/integration/pub_properties.rs
+++ b/tests/integration/pub_properties.rs
@@ -1,4 +1,4 @@
-use std::{assert_eq, num::NonZero, panic, time::Duration};
+use std::{assert_eq, assert_ne, num::NonZero, panic, time::Duration};
 
 use rust_mqtt::{
     client::{
@@ -278,7 +278,7 @@ async fn outgoing_topic_alias_remap() {
 #[test_log::test]
 async fn incoming_topic_alias_basic() {
     let (topic_name, topic_filter) = unique_topic();
-    let msg = "There are two ways to write error-free programs. Only the third one works.";
+    let msg = "Always code as if the person who ends up maintaining your code is a violent psychopath who knows where you live.";
 
     let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 16, 0> = Client::new(ALLOC.get());
     let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
@@ -327,6 +327,94 @@ async fn incoming_topic_alias_basic() {
             panic!();
         };
         assert_eq!(topic, TopicReference::Alias(alias));
+
+        assert_ok!(rx.disconnect(DEFAULT_DC_OPTIONS).await);
+    };
+
+    join!(receiver, publisher);
+}
+
+#[tokio::test]
+#[test_log::test]
+async fn topic_alias_maximum_not_exceeded() {
+    let (topic_name_1, topic_filter_1) = unique_topic();
+    let (topic_name_2, topic_filter_2) = unique_topic();
+    let (topic_name_3, topic_filter_3) = unique_topic();
+    let msg = "There are only two hard things in computer science: cache invalidation, naming things, and off-by-one errors.";
+
+    let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 2, 0> = Client::new(ALLOC.get());
+    let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
+    assert_ok!(rx.connect(tcp, NO_SESSION_CONNECT_OPTIONS, None).await);
+
+    let mut tx =
+        assert_ok!(connected_client(BROKER_ADDRESS, NO_SESSION_CONNECT_OPTIONS, None).await);
+
+    let publisher = async {
+        sleep(Duration::from_secs(1)).await;
+
+        let pub_options =
+            PublicationOptions::new(TopicReference::Name(topic_name_1.clone())).at_least_once();
+
+        assert_published!(tx, pub_options.clone(), msg.into());
+
+        let pub_options =
+            PublicationOptions::new(TopicReference::Name(topic_name_2.clone())).at_least_once();
+
+        assert_published!(tx, pub_options.clone(), msg.into());
+
+        let pub_options =
+            PublicationOptions::new(TopicReference::Name(topic_name_3.clone())).at_least_once();
+
+        assert_published!(tx, pub_options.clone(), msg.into());
+
+        disconnect(&mut tx, DEFAULT_DC_OPTIONS).await;
+    };
+
+    let receiver = async {
+        let options = DEFAULT_QOS0_SUB_OPTIONS.at_least_once();
+
+        assert_ok!(rx.subscribe(topic_filter_1, &options).await);
+        let e = assert_ok!(rx.poll().await);
+        let Event::Suback(Suback { reason_code, .. }) = e else {
+            panic!();
+        };
+        assert_eq!(reason_code, ReasonCode::GrantedQoS1);
+
+        assert_ok!(rx.subscribe(topic_filter_2, &options).await);
+        let e = assert_ok!(rx.poll().await);
+        let Event::Suback(Suback { reason_code, .. }) = e else {
+            panic!();
+        };
+        assert_eq!(reason_code, ReasonCode::GrantedQoS1);
+
+        assert_ok!(rx.subscribe(topic_filter_3, &options).await);
+        let e = assert_ok!(rx.poll().await);
+        let Event::Suback(Suback { reason_code, .. }) = e else {
+            panic!();
+        };
+        assert_eq!(reason_code, ReasonCode::GrantedQoS1);
+
+        let e = assert_ok!(rx.poll().await);
+        let Event::Publish(Publish { topic, .. }) = e else {
+            panic!();
+        };
+        assert_eq!(topic.name().unwrap(), &topic_name_1);
+        let alias_1 = topic.alias().unwrap();
+
+        let e = assert_ok!(rx.poll().await);
+        let Event::Publish(Publish { topic, .. }) = e else {
+            panic!();
+        };
+        assert_eq!(topic.name().unwrap(), &topic_name_2);
+        let alias_2 = topic.alias().unwrap();
+
+        assert_ne!(alias_1, alias_2);
+
+        let e = assert_ok!(rx.poll().await);
+        let Event::Publish(Publish { topic, .. }) = e else {
+            panic!();
+        };
+        assert_eq!(topic, TopicReference::Name(topic_name_3.clone()));
 
         assert_ok!(rx.disconnect(DEFAULT_DC_OPTIONS).await);
     };

--- a/tests/integration/pub_properties.rs
+++ b/tests/integration/pub_properties.rs
@@ -3,10 +3,10 @@ use std::{assert_eq, num::NonZero, panic, time::Duration};
 use rust_mqtt::{
     client::{
         Client,
-        event::{Event, Publish},
+        event::{Event, Publish, Suback},
         options::{PublicationOptions, TopicReference},
     },
-    types::{MqttString, MqttStringPair},
+    types::{MqttString, MqttStringPair, ReasonCode},
 };
 use tokio::{
     join,
@@ -272,6 +272,66 @@ async fn outgoing_topic_alias_remap() {
     };
 
     join!(receiver1, receiver2, publisher);
+}
+
+#[tokio::test]
+#[test_log::test]
+async fn incoming_topic_alias_basic() {
+    let (topic_name, topic_filter) = unique_topic();
+    let msg = "There are two ways to write error-free programs. Only the third one works.";
+
+    let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 16, 0> = Client::new(ALLOC.get());
+    let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
+    assert_ok!(rx.connect(tcp, NO_SESSION_CONNECT_OPTIONS, None).await);
+
+    let mut tx =
+        assert_ok!(connected_client(BROKER_ADDRESS, NO_SESSION_CONNECT_OPTIONS, None).await);
+
+    let publisher = async {
+        sleep(Duration::from_secs(1)).await;
+
+        let pub_options = PublicationOptions::new(TopicReference::Name(topic_name.clone()))
+            .retain()
+            .at_least_once();
+
+        assert_published!(tx, pub_options.clone(), msg.into());
+
+        let pub_options = PublicationOptions::new(TopicReference::Name(topic_name.clone()))
+            .retain()
+            .at_least_once();
+
+        assert_published!(tx, pub_options.clone(), msg.into());
+
+        disconnect(&mut tx, DEFAULT_DC_OPTIONS).await;
+    };
+
+    let receiver = async {
+        let options = DEFAULT_QOS0_SUB_OPTIONS.at_least_once();
+
+        assert_ok!(rx.subscribe(topic_filter, &options).await);
+        let e = assert_ok!(rx.poll().await);
+        let Event::Suback(Suback { reason_code, .. }) = e else {
+            panic!();
+        };
+        assert_eq!(reason_code, ReasonCode::GrantedQoS1);
+
+        let e = assert_ok!(rx.poll().await);
+        let Event::Publish(Publish { topic, .. }) = e else {
+            panic!();
+        };
+        assert_eq!(topic.name().unwrap(), &topic_name);
+        let alias = topic.alias().unwrap();
+
+        let e = assert_ok!(rx.poll().await);
+        let Event::Publish(Publish { topic, .. }) = e else {
+            panic!();
+        };
+        assert_eq!(topic, TopicReference::Alias(alias));
+
+        assert_ok!(rx.disconnect(DEFAULT_DC_OPTIONS).await);
+    };
+
+    join!(receiver, publisher);
 }
 
 #[tokio::test]

--- a/tests/integration/pub_properties.rs
+++ b/tests/integration/pub_properties.rs
@@ -274,9 +274,10 @@ async fn outgoing_topic_alias_remap() {
     join!(receiver1, receiver2, publisher);
 }
 
+#[ignore = "hivemq does not assign topic aliases"]
 #[tokio::test]
 #[test_log::test]
-async fn incoming_topic_alias_basic() {
+async fn incoming_topic_alias_basic_emqx_only_mosquitto_only() {
     let (topic_name, topic_filter) = unique_topic();
     let msg = "Always code as if the person who ends up maintaining your code is a violent psychopath who knows where you live.";
 
@@ -334,9 +335,10 @@ async fn incoming_topic_alias_basic() {
     join!(receiver, publisher);
 }
 
+#[ignore = "hivemq does not assign topic aliases"]
 #[tokio::test]
 #[test_log::test]
-async fn topic_alias_maximum_not_exceeded() {
+async fn incoming_topic_alias_maximum_not_exceeded_emqx_only_mosquitto_only() {
     let (topic_name_1, topic_filter_1) = unique_topic();
     let (topic_name_2, topic_filter_2) = unique_topic();
     let (topic_name_3, topic_filter_3) = unique_topic();

--- a/tests/integration/pub_properties.rs
+++ b/tests/integration/pub_properties.rs
@@ -1,8 +1,9 @@
-use std::{num::NonZero, time::Duration};
+use std::{assert_eq, num::NonZero, panic, time::Duration};
 
 use rust_mqtt::{
     client::{
-        event::Publish,
+        Client,
+        event::{Event, Publish},
         options::{PublicationOptions, TopicReference},
     },
     types::{MqttString, MqttStringPair},
@@ -16,7 +17,7 @@ use tokio_test::assert_err;
 use crate::common::{
     BROKER_ADDRESS, DEFAULT_DC_OPTIONS, DEFAULT_QOS0_SUB_OPTIONS, NO_SESSION_CONNECT_OPTIONS,
     assert::{assert_ok, assert_published, assert_recv, assert_recv_excl, assert_subscribe},
-    utils::{connected_client, disconnect, unique_topic},
+    utils::{ALLOC, connected_client, disconnect, tcp_connection, unique_topic},
 };
 
 #[tokio::test]
@@ -144,14 +145,16 @@ async fn message_expiry_interval_completely_expired() {
 
 #[tokio::test]
 #[test_log::test]
-async fn topic_alias_basic() {
+async fn outgoing_topic_alias_basic() {
     let (topic_name, topic_filter) = unique_topic();
     let msg = "There are two ways to write error-free programs. Only the third one works.";
 
     let mut rx =
         assert_ok!(connected_client(BROKER_ADDRESS, NO_SESSION_CONNECT_OPTIONS, None).await);
-    let mut tx =
-        assert_ok!(connected_client(BROKER_ADDRESS, NO_SESSION_CONNECT_OPTIONS, None).await);
+
+    let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 16> = Client::new(ALLOC.get());
+    let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
+    assert_ok!(tx.connect(tcp, NO_SESSION_CONNECT_OPTIONS, None).await);
 
     let publisher = async {
         sleep(Duration::from_secs(1)).await;
@@ -163,15 +166,19 @@ async fn topic_alias_basic() {
         .retain()
         .at_least_once();
 
-        assert_published!(tx, pub_options.clone(), msg.into());
+        assert_ok!(tx.publish(&pub_options, msg.into()).await);
+        let e = assert_ok!(tx.poll().await);
+        assert!(matches!(e, Event::PublishAcknowledged(_)));
 
         let pub_options = PublicationOptions::new(TopicReference::Alias(NonZero::new(1).unwrap()))
             .retain()
             .at_least_once();
 
-        assert_published!(tx, pub_options.clone(), msg.into());
+        assert_ok!(tx.publish(&pub_options, msg.into()).await);
+        let e = assert_ok!(tx.poll().await);
+        assert!(matches!(e, Event::PublishAcknowledged(_)));
 
-        disconnect(&mut tx, DEFAULT_DC_OPTIONS).await;
+        assert_ok!(tx.disconnect(DEFAULT_DC_OPTIONS).await);
     };
 
     let receiver = async {
@@ -189,7 +196,7 @@ async fn topic_alias_basic() {
 
 #[tokio::test]
 #[test_log::test]
-async fn topic_alias_remap() {
+async fn outgoing_topic_alias_remap() {
     let (topic_name1, topic_filter1) = unique_topic();
     let (topic_name2, topic_filter2) = unique_topic();
     let msg = "It's working as designed, will update the requirements accordingly.";
@@ -198,8 +205,9 @@ async fn topic_alias_remap() {
         assert_ok!(connected_client(BROKER_ADDRESS, NO_SESSION_CONNECT_OPTIONS, None).await);
     let mut rx2 =
         assert_ok!(connected_client(BROKER_ADDRESS, NO_SESSION_CONNECT_OPTIONS, None).await);
-    let mut tx =
-        assert_ok!(connected_client(BROKER_ADDRESS, NO_SESSION_CONNECT_OPTIONS, None).await);
+    let mut tx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 16> = Client::new(ALLOC.get());
+    let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
+    assert_ok!(tx.connect(tcp, NO_SESSION_CONNECT_OPTIONS, None).await);
 
     let publisher = async {
         sleep(Duration::from_secs(1)).await;
@@ -211,7 +219,9 @@ async fn topic_alias_remap() {
         .retain()
         .at_least_once();
 
-        assert_published!(tx, pub_options.clone(), msg.into());
+        assert_ok!(tx.publish(&pub_options, msg.into()).await);
+        let e = assert_ok!(tx.poll().await);
+        assert!(matches!(e, Event::PublishAcknowledged(_)));
 
         let pub_options = PublicationOptions::new(TopicReference::Mapping(
             topic_name2.clone(),
@@ -220,15 +230,19 @@ async fn topic_alias_remap() {
         .retain()
         .at_least_once();
 
-        assert_published!(tx, pub_options.clone(), msg.into());
+        assert_ok!(tx.publish(&pub_options, msg.into()).await);
+        let e = assert_ok!(tx.poll().await);
+        assert!(matches!(e, Event::PublishAcknowledged(_)));
 
         let pub_options = PublicationOptions::new(TopicReference::Alias(NonZero::new(1).unwrap()))
             .retain()
             .at_least_once();
 
-        assert_published!(tx, pub_options.clone(), msg.into());
+        assert_ok!(tx.publish(&pub_options, msg.into()).await);
+        let e = assert_ok!(tx.poll().await);
+        assert!(matches!(e, Event::PublishAcknowledged(_)));
 
-        disconnect(&mut tx, DEFAULT_DC_OPTIONS).await;
+        assert_ok!(tx.disconnect(DEFAULT_DC_OPTIONS).await);
     };
 
     let receiver1 = async {

--- a/tests/integration/pub_sub.rs
+++ b/tests/integration/pub_sub.rs
@@ -205,7 +205,7 @@ async fn publish_recv_multiple_qos0() {
                     messages
                         .iter()
                         .enumerate()
-                        .find(|(_, (t, m))| *t == p.topic && m == &msg)
+                        .find(|(_, (t, m))| t == p.topic.name().unwrap() && m == &msg)
                         .ok_or("Option is None")
                 );
 
@@ -274,7 +274,7 @@ async fn publish_recv_multiple_qos1() {
                     messages
                         .iter()
                         .enumerate()
-                        .find(|(_, (t, m))| *t == p.topic && m == &msg)
+                        .find(|(_, (t, m))| t == p.topic.name().unwrap() && m == &msg)
                         .ok_or("Option is None")
                 );
 
@@ -342,7 +342,7 @@ async fn publish_recv_multiple_qos2() {
                     messages
                         .iter()
                         .enumerate()
-                        .find(|(_, (t, m))| *t == p.topic && m == &msg)
+                        .find(|(_, (t, m))| t == p.topic.name().unwrap() && m == &msg)
                         .ok_or("Option is None")
                 );
 

--- a/tests/integration/request_response.rs
+++ b/tests/integration/request_response.rs
@@ -52,7 +52,7 @@ async fn simple_request_response() {
             timeout(Duration::from_secs(5), receive_and_complete(&mut requester)).await
         ));
 
-        assert_eq!(topic, response_topic_name);
+        assert_eq!(topic.name().unwrap(), &response_topic_name);
         assert_eq!(&*message, response_msg.as_bytes());
         assert!(response_topic.is_none());
         assert!(correlation_data.is_none());
@@ -71,7 +71,7 @@ async fn simple_request_response() {
             ..
         } = assert_recv_excl!(responder, topic_name);
 
-        assert_eq!(topic, topic_name);
+        assert_eq!(topic.name().unwrap(), &topic_name);
         assert_eq!(&*message, request_msg.as_bytes());
         assert!(response_topic.is_some());
         assert_eq!(response_topic.as_ref().unwrap(), &response_topic_name);
@@ -124,7 +124,7 @@ async fn simple_correlation_data() {
             timeout(Duration::from_secs(5), receive_and_complete(&mut requester)).await
         ));
 
-        assert_eq!(topic, response_topic_name);
+        assert_eq!(topic.name().unwrap(), &response_topic_name);
         assert_eq!(&*message, response_msg.as_bytes());
         assert!(response_topic.is_none());
         assert!(correlation_data.is_some());
@@ -144,7 +144,7 @@ async fn simple_correlation_data() {
             ..
         } = assert_recv_excl!(responder, topic_name);
 
-        assert_eq!(topic, topic_name);
+        assert_eq!(topic.name().unwrap(), &topic_name);
         assert_eq!(&*message, request_msg.as_bytes());
         assert!(response_topic.is_some());
         assert_eq!(response_topic.as_ref().unwrap(), &response_topic_name);
@@ -208,7 +208,7 @@ async fn multiple_correlation_data() {
                 timeout(Duration::from_secs(5), receive_and_complete(&mut requester)).await
             ));
 
-            assert_eq!(topic, response_topic_name);
+            assert_eq!(topic.name().unwrap(), &response_topic_name);
             assert!(response_topic.is_none());
 
             let correlation = correlation_data.expect("Expected correlation data");
@@ -235,7 +235,7 @@ async fn multiple_correlation_data() {
                 ..
             } = assert_recv_excl!(responder, topic_name);
 
-            assert_eq!(topic, topic_name);
+            assert_eq!(topic.name().unwrap(), &topic_name);
             assert!(response_topic.is_some());
             assert_eq!(response_topic.as_ref().unwrap(), &response_topic_name);
 

--- a/tests/integration/session.rs
+++ b/tests/integration/session.rs
@@ -90,7 +90,8 @@ async fn session_continue_connection_dropped() {
     connect_options.clean_start = false;
 
     let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-    let mut c: Client<'_, '_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
+    let mut c: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
+        Client::with_session(session, ALLOC.get());
     let info = assert_ok!(warn_inspect!(
         c.connect(tcp, &connect_options, Some(id.as_borrowed()))
             .await,
@@ -147,7 +148,8 @@ async fn session_discontinued_clean_start() {
     drop(c);
 
     let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-    let mut c: Client<'_, '_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
+    let mut c: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
+        Client::with_session(session, ALLOC.get());
     let info = assert_ok!(warn_inspect!(
         c.connect(tcp, &connect_options, Some(id.as_borrowed()))
             .await,
@@ -195,7 +197,8 @@ async fn session_expired() {
     sleep(Duration::from_secs(5)).await;
 
     let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-    let mut c: Client<'_, '_, _, _, 1, 1, 1, 1, 16> = Client::with_session(session, ALLOC.get());
+    let mut c: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
+        Client::with_session(session, ALLOC.get());
     let info = assert_ok!(warn_inspect!(
         c.connect(tcp, &connect_options, Some(id.as_borrowed()))
             .await,

--- a/tests/integration/sub_options.rs
+++ b/tests/integration/sub_options.rs
@@ -16,8 +16,7 @@ use tokio_test::assert_err;
 use crate::common::{
     BROKER_ADDRESS, DEFAULT_DC_OPTIONS, DEFAULT_QOS0_SUB_OPTIONS, NO_SESSION_CONNECT_OPTIONS,
     assert::{assert_ok, assert_published, assert_recv, assert_subscribe},
-    fmt::warn_inspect,
-    utils::{ALLOC, connected_client, disconnect, tcp_connection, unique_topic},
+    utils::{connected_client, disconnect, tcp_connection, unique_topic},
 };
 
 #[tokio::test]
@@ -297,19 +296,8 @@ async fn subscription_identifier() {
     let mut tx =
         assert_ok!(connected_client(BROKER_ADDRESS, NO_SESSION_CONNECT_OPTIONS, None).await);
 
-    let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16> = {
-        let mut client = Client::new(ALLOC.get());
-
-        let tcp = assert_ok!(tcp_connection(BROKER_ADDRESS).await);
-
-        assert_ok!(
-            warn_inspect!(
-                client.connect(tcp, NO_SESSION_CONNECT_OPTIONS, None).await,
-                "Client::connect() failed"
-            )
-            .map(|_| client)
-        )
-    };
+    let mut rx: Client<'_, '_, _, _, 1, 1, 1, 1, 16, 0, 0> =
+        assert_ok!(connected_client(BROKER_ADDRESS, NO_SESSION_CONNECT_OPTIONS, None).await);
 
     let options = DEFAULT_QOS0_SUB_OPTIONS
         .at_least_once()

--- a/tests/integration/will.rs
+++ b/tests/integration/will.rs
@@ -686,7 +686,7 @@ async fn session_expires_right_after_disconnect_emqx_only_hive_only() {
             timeout(Duration::from_secs(2), receive_and_complete(&mut rx)).await
         ));
 
-        assert_eq!(topic, will_topic_name);
+        assert_eq!(topic.name().unwrap(), &will_topic_name);
         assert_eq!(&*message, will_msg.as_bytes());
 
         disconnect(&mut rx, DEFAULT_DC_OPTIONS).await;
@@ -736,7 +736,7 @@ async fn session_expires_before_will_delay_interval() {
             timeout(Duration::from_secs(4), receive_and_complete(&mut rx)).await
         ));
 
-        assert_eq!(topic, will_topic_name);
+        assert_eq!(topic.name().unwrap(), &will_topic_name);
         assert_eq!(&*message, will_msg.as_bytes());
 
         disconnect(&mut rx, DEFAULT_DC_OPTIONS).await;
@@ -845,7 +845,7 @@ async fn clean_start_override_before_will_scheduled_emqx_only_hive_only() {
             timeout(Duration::from_secs(3), receive_and_complete(&mut rx)).await
         ));
 
-        assert_eq!(topic, will_topic_name);
+        assert_eq!(topic.name().unwrap(), &will_topic_name);
 
         disconnect(&mut rx, DEFAULT_DC_OPTIONS).await;
     };
@@ -909,7 +909,7 @@ async fn will_existing_session_taken_over_with_session_expiry() {
         let Publish { topic, .. } = assert_ok!(assert_ok!(
             timeout(Duration::from_secs(10), receive_and_complete(&mut rx)).await
         ));
-        assert_eq!(topic, will_topic_name);
+        assert_eq!(topic.name().unwrap(), &will_topic_name);
 
         disconnect(&mut rx, DEFAULT_DC_OPTIONS).await;
     };
@@ -977,7 +977,7 @@ async fn will_existing_session_taken_over_with_will_delay_hive_only() {
         let Publish { topic, .. } = assert_ok!(assert_ok!(
             timeout(Duration::from_secs(10), receive_and_complete(&mut rx)).await
         ));
-        assert_eq!(topic, will_topic_name);
+        assert_eq!(topic.name().unwrap(), &will_topic_name);
 
         disconnect(&mut rx, DEFAULT_DC_OPTIONS).await;
     };
@@ -1040,7 +1040,7 @@ async fn will_existing_session_taken_over_with_clean_start_emqx_only_hive_only()
         let Publish { topic, .. } = assert_ok!(assert_ok!(
             timeout(Duration::from_secs(10), receive_and_complete(&mut rx)).await
         ));
-        assert_eq!(topic, will_topic_name);
+        assert_eq!(topic.name().unwrap(), &will_topic_name);
 
         disconnect(&mut rx, DEFAULT_DC_OPTIONS).await;
     };


### PR DESCRIPTION
Adds support for incoming topic aliases and add tracking of mapped topic aliases in both directions, detecting the use of unmapped topic aliases in alias-only publications.